### PR TITLE
removed duplicating packages line in .toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,4 +227,3 @@ packages = ["srearena", "clients", "provisioner"]
 
 [tool.uv.sources]
 geni-lib-xlab = { path = "scripts/geni-lib/mod/geni_lib_xlab-1.0.0.tar.gz" }
-packages = ["srearena", "clients"]


### PR DESCRIPTION
.toml project file had line 230 duplicating packages array which caused an error of the format with vm. 

error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 230, column 13
    |
230 | packages = ["srearena", "clients"]
    |             ^^^^^^^^^^
invalid type: string "srearena", expected struct CatchAll

after removing the line uv sync worked. 

