### PR TITLE
Error message for missing configuration 

### DIFF
--- a/srearena/service/kubectl.py
+++ b/srearena/service/kubectl.py
@@ -4,7 +4,11 @@ import json
 import subprocess
 import time
 
-from kubernetes import client, config
+try:
+    from kubernetes import client, config
+except ModuleNotFoundError as e: 
+    print("Your Kubeconfig is missing. Please set up a cluster.")
+    exit(1) 
 from kubernetes.client.rest import ApiException
 from rich.console import Console
 


### PR DESCRIPTION
I caught the error that occurs when you do not have a cluster configured, printing out a message to prompt the user to configure a cluster.