### PR TITLE
Updated fix for kube_config 

### DIFF
--- a/srearena/service/kubectl.py
+++ b/srearena/service/kubectl.py
@@ -16,7 +16,11 @@ from rich.console import Console
 class KubeCtl:
     def __init__(self):
         """Initialize the KubeCtl object and load the Kubernetes configuration."""
-        config.load_kube_config()
+        try:
+            config.load_kube_config()
+        except Exception as e:
+            print("Missing kubeconfig. Please set up a cluster.")
+            exit(1)
         self.core_v1_api = client.CoreV1Api()
         self.apps_v1_api = client.AppsV1Api()
 


### PR DESCRIPTION
Updated fix for the kube_config. Wrapped loading the tube_config in a try block, printing out the exception caught and prompting the user to set up a cluster 