### PR TITLE
[#120] Letting SocialNetwork cleanup function remove the namespace

### DIFF
--- a/srearena/service/apps/astronomy_shop.py
+++ b/srearena/service/apps/astronomy_shop.py
@@ -36,7 +36,7 @@ class AstronomyShop(Application):
         """Delete the Helm configurations."""
         Helm.uninstall(**self.helm_configs)
         self.kubectl.delete_namespace(self.helm_configs["namespace"])
-        time.sleep(30)
+        self.kubectl.wait_for_namespace_deletion(self.namespace)
 
     def cleanup(self):
         Helm.uninstall(**self.helm_configs)

--- a/srearena/service/apps/hotelres.py
+++ b/srearena/service/apps/hotelres.py
@@ -89,7 +89,7 @@ class HotelReservation(Application):
     def cleanup(self):
         """Delete the entire namespace for the hotel reservation application."""
         self.kubectl.delete_namespace(self.namespace)
-        time.sleep(10)
+        self.kubectl.wait_for_namespace_deletion(self.namespace)
         pvs = self.kubectl.exec_command(
             "kubectl get pv --no-headers | grep 'test-hotel-reservation' | awk '{print $1}'"
         ).splitlines()

--- a/srearena/service/apps/socialnet.py
+++ b/srearena/service/apps/socialnet.py
@@ -71,7 +71,7 @@ class SocialNetwork(Application):
         if hasattr(self, "wrk"):
             self.wrk.stop()
         self.kubectl.delete_namespace(self.namespace)
-        time.sleep(10)
+        self.kubectl.wait_for_namespace_deletion(self.namespace)
 
     def create_workload(self):
         self.wrk = Wrk2WorkloadManager(

--- a/srearena/service/apps/train_ticket.py
+++ b/srearena/service/apps/train_ticket.py
@@ -31,7 +31,7 @@ class TrainTicket(Application):
         """Delete the Helm configurations."""
         # Helm.uninstall(**self.helm_configs) # Don't helm uninstall until cleanup job is fixed on train-ticket
         self.kubectl.delete_namespace(self.namespace)
-        time.sleep(30)
+        self.kubectl.wait_for_namespace_deletion(self.namespace)
 
     def cleanup(self):
         # Helm.uninstall(**self.helm_configs)


### PR DESCRIPTION
SocialNetwork namespace removal was commented out previously so I added it back in for consistency.

https://github.com/xlab-uiuc/SREArena/issues/120