### PR TITLE
[#64] Fixing cleanup function duplicated while in detection stage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -118,7 +118,8 @@ class HumanAgent:
 
                     return input
             except (SystemExit, KeyboardInterrupt, EOFError):
-                atexit.register(exit_cleanup_fault, conductor=self.conductor)
+                if self.conductor.submission_stage != "detection":
+                    atexit.register(exit_cleanup_fault, conductor=self.conductor)
                 raise SystemExit from None
 
     def _filter_dict(self, dictionary, filter_func):


### PR DESCRIPTION
Exiting in 'detection' stage will result in the cleanup function being run twice. This PR skips the cleanup in that scenario in `cli.py`. 