### PR TITLE
I151: Don't stop after detection

### DIFF
--- a/srearena/conductor/conductor.py
+++ b/srearena/conductor/conductor.py
@@ -34,7 +34,9 @@ class Conductor:
         self.submission_stage = None  # "noop", "detection", "localization", "mitigation", "done"
         self.results = {}
 
-        self.strict_detection_mode = False
+        self.strict_detection_mode = False  # With strict detection as True, if the agent doesn't
+        # get the anomaly detection correct, it cannot advance to
+        # later stages.
 
     def dependency_check(self, binaries: list[str]):
         for binary in binaries:


### PR DESCRIPTION
Resolves #151

1. The agent can now proceed to the next stage even if it fails the detection.
2. We can use the flag `strict_detection_mode` to easily switch the behavior in the future if needed.

---
```bash
[NO OP Evaluation] System is healthy. Agent should detect no issue.
SREArena> submit("No")
== Detection Evaluation (expected: No) ==
✅ Detection: No
NO OP Detection Result: ✅
[Injecting fault now...]
== Fault Injection ==
Added shadowing environment variables to container frontend-proxy: ['FRONTEND_HOST']
Delete result for frontend-proxy: deployment.apps "frontend-proxy" deleted

Apply result for frontend-proxy: deployment.apps/frontend-proxy created

Injected environment variable shadowing fault for service: frontend-proxy
Service: frontend-proxy | Namespace: astronomy-shop
SREArena> submit("No")
== Detection Evaluation (expected: Yes) ==
❌ Detection: No
SREArena> submit("frontend-proxy")
== Localization Evaluation ==
✅ Exact match: ['frontend-proxy']
```