### PR TITLE
Add ingress_misroute fault scenario and mitigation oracle

### DIFF
--- a/srearena/conductor/oracles/ingress_misroute_oracle.py
+++ b/srearena/conductor/oracles/ingress_misroute_oracle.py
@@ -1,0 +1,31 @@
+import logging
+from kubernetes import client
+from srearena.conductor.oracles.base import Oracle
+
+class IngressMisrouteMitigationOracle(Oracle):
+    def __init__(self, problem):
+        super().__init__(problem=problem)
+        self.networking_v1 = client.NetworkingV1Api()
+        self.logger = logging.getLogger(__name__)
+
+    def evaluate(self) -> bool:
+        results = {}
+        try:
+            ingress = self.networking_v1.read_namespaced_ingress(name=self.problem.ingress_name, namespace=self.problem.namespace)
+            for rule in ingress.spec.rules:
+                for path in rule.http.paths:
+                    if path.path == self.problem.path:
+                        if path.backend.service.name == self.problem.correct_service:
+                            self.logger.info(f"Ingress path '{self.problem.path}' correctly routed to '{self.problem.correct_service}'.")
+                            results["success"] = True
+                            return results
+                        else:
+                            self.logger.info(f"Ingress path '{self.problem.path}' still routed to '{path.backend.service.name}', mitigation incomplete.")
+                            results["success"] = False
+                            return results
+            self.logger.error("Path not found in ingress, mitigation incomplete.")
+            results["success"] = False
+        except client.exceptions.ApiException as e:
+            self.logger.error(f"Error checking ingress configuration: {e}")
+            results["success"] = False
+        return results

--- a/srearena/conductor/problems/ingress_misroute.py
+++ b/srearena/conductor/problems/ingress_misroute.py
@@ -1,0 +1,74 @@
+from kubernetes import client
+
+from srearena.conductor.problems.base import Problem
+from srearena.conductor.oracles.localization import LocalizationOracle
+from srearena.conductor.oracles.ingress_misroute_oracle import IngressMisrouteMitigationOracle
+from srearena.service.apps.hotelres import HotelReservation
+from srearena.service.kubectl import KubeCtl
+from srearena.utils.decorators import mark_fault_injected
+
+class IngressMisroute(Problem):
+    def __init__(self, path="/api", correct_service="frontend-service", wrong_service="recommendation-service"):
+        self.app = HotelReservation()
+        self.kubectl = KubeCtl()
+        self.path = path
+        self.correct_service = correct_service
+        self.wrong_service = wrong_service
+        self.ingress_name = "hotel-reservation-ingress"
+        super().__init__(app=self.app, namespace=self.app.namespace)
+
+        self.networking_v1 = client.NetworkingV1Api()
+
+        self.localization_oracle = LocalizationOracle(problem=self, expected=[self.correct_service])
+        self.mitigation_oracle = IngressMisrouteMitigationOracle(problem=self)
+
+    @mark_fault_injected
+    def inject_fault(self):
+        """Misroute /api to wrong backend"""
+
+        try:
+            ingress = self.networking_v1.read_namespaced_ingress(name=self.ingress_name, namespace=self.namespace)
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                ingress_manifest = {
+                    "apiVersion": "networking.k8s.io/v1",
+                    "kind": "Ingress",
+                    "metadata": {"name": self.ingress_name, "namespace": self.namespace},
+                    "spec": {
+                        "rules": [{
+                            "http": {
+                                "paths": [{
+                                    "path": self.path,
+                                    "pathType": "Prefix",
+                                    "backend": {
+                                        "service": {
+                                            "name": self.correct_service,
+                                            "port": {"number": 80}
+                                        }
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                }
+                self.networking_v1.create_namespaced_ingress(namespace=self.namespace, body=ingress_manifest)
+                ingress = self.networking_v1.read_namespaced_ingress(name=self.ingress_name, namespace=self.namespace)
+            else:
+                raise
+
+        # Modify the rule for /api to wrong_service
+        for rule in ingress.spec.rules:
+            for path in rule.http.paths:
+                if path.path == self.path:
+                    path.backend.service.name = self.wrong_service
+        self.networking_v1.replace_namespaced_ingress(name=self.ingress_name, namespace=self.namespace, body=ingress)
+
+    @mark_fault_injected
+    def recover_fault(self):
+        """Revert misroute to correct backend"""
+        ingress = self.networking_v1.read_namespaced_ingress(name=self.ingress_name, namespace=self.namespace)
+        for rule in ingress.spec.rules:
+            for path in rule.http.paths:
+                if path.path == self.path:
+                    path.backend.service.name = self.correct_service
+        self.networking_v1.replace_namespaced_ingress(name=self.ingress_name, namespace=self.namespace, body=ingress)

--- a/srearena/conductor/problems/registry.py
+++ b/srearena/conductor/problems/registry.py
@@ -41,6 +41,7 @@ from srearena.conductor.problems.wrong_service_selector import WrongServiceSelec
 from srearena.conductor.problems.network_policy_block import NetworkPolicyBlock
 from srearena.conductor.problems.taint_no_toleration import TaintNoToleration
 from srearena.conductor.problems.rolling_update_misconfigured import RollingUpdateMisconfigured
+from srearena.conductor.problems.ingress_misroute import IngressMisroute
 
 
 
@@ -173,6 +174,11 @@ class ProblemRegistry:
                 app_name="social_network"),
             "rolling_update_misconfigured_hotel_reservation": lambda: RollingUpdateMisconfigured(
                 app_name="hotel_reservation"),
+            "ingress_misroute": lambda: IngressMisroute(
+                path="/api",
+                correct_service="frontend-service",
+                wrong_service="recommendation-service"),
+
             # "missing_service_astronomy_shop": lambda: MissingService(app_name="astronomy_shop", faulty_service="ad"),
             # K8S operator misoperation -> Refactor later, not sure if they're working
             # They will also need to be updated to the new problem format.


### PR DESCRIPTION
https://github.com/xlab-uiuc/SREArena/issues/54

Adds ingress_misroute fault with detection, localization, and mitigation. Tested using `python cli.py`

```
start ingress_misroute
submit("No")
submit("Yes")
submit("frontend-service")
submit()
```

Output
`{'NOOP Detection': {'accuracy': 100.0, 'success': True}, 'Detection': {'accuracy': 100.0, 'success': True}, 'TTD': 85.50005292892456, 'Localization': {'accuracy': 100.0, 'success': True, 'is_subset': True}, 'TTL': 90.29235410690308, 'Mitigation': {'success': False}, 'TTM': 94.30941319465637}`


