### PR TITLE
I75: Lower resources from astronomy shop load generator

### DIFF
--- a/srearena/service/apps/astronomy_shop.py
+++ b/srearena/service/apps/astronomy_shop.py
@@ -29,18 +29,17 @@ class AstronomyShop(Application):
             "open-telemetry",
             "https://open-telemetry.github.io/opentelemetry-helm-charts",
         )
-        
+
         helm_configs = self.helm_configs.copy()
-        helm_configs["extra_args"] = self._get_load_generator_env_overrides()
-        
+        helm_configs["extra_args"] = [
+            "--set-string",
+            "components.load-generator.envOverrides[0].name=LOCUST_BROWSER_TRAFFIC_ENABLED",
+            "--set-string",
+            "components.load-generator.envOverrides[0].value=false",
+        ]
+
         Helm.install(**helm_configs)
         Helm.assert_if_deployed(self.helm_configs["namespace"])
-
-    def _get_load_generator_env_overrides(self):
-        return [
-            "--set-string", "components.load-generator.envOverrides[0].name=LOCUST_BROWSER_TRAFFIC_ENABLED",
-            "--set-string", "components.load-generator.envOverrides[0].value=false"
-        ]
 
     def delete(self):
         """Delete the Helm configurations."""


### PR DESCRIPTION
# Lower resources from astronomy shop load generator
Resolves #75

## What works

Setting `LOCUST_BROWSER_TRAFFIC_ENABLED=false` successfully disables browser traffic.

## What doesn't work

`LOCUST_HEADLESS=true` completely disables the locust web interface along with the web server, breaking the `locust-fetcher` which needs API access that comes from the web server running on port 8089.

According to [locust/main.py](https://github.com/locustio/locust/blob/master/locust/main.py) lines 447-481:

```python
  # start Web UI
  if not options.headless and not options.worker:
      protocol = "https" if options.tls_cert and options.tls_key else "http"

      if options.web_base_path and options.web_base_path[0] != "/":
          logger.error(
              f"Invalid format for --web-base-path argument ({options.web_base_path}): the url path must start with a slash."
          )
          sys.exit(1)
      if options.web_host == "*":
          # special check for "*" so that we're consistent with --master-bind-host
          web_host = ""
      else:
          web_host = options.web_host
      if web_host:
          url = f"{protocol}://{web_host}:{options.web_port}{options.web_base_path}"
      elif options.web_host_display_name:
          url = f"{options.web_host_display_name}"
      else:
          url = f"{protocol}://{'localhost' if os.name == 'nt' else '0.0.0.0'}:{options.web_port}{options.web_base_path}"
      logger.info(f"Starting web interface at {url}, press enter to open your default browser.")

      web_ui = environment.create_web_ui(
          host=web_host,
          port=options.web_port,
          web_base_path=options.web_base_path,
          web_login=options.web_login,
          tls_cert=options.tls_cert,
          tls_key=options.tls_key,
          stats_csv_writer=stats_csv_writer,
          delayed_start=True,
          userclass_picker_is_active=options.class_picker,
          build_path=options.build_path,
      )
  else:
      web_ui = None
```

The web server is only started when `options.headless` is FALSE. Otherwise, `create_web_ui` is not called.

```python
def create_web_ui(
        self,
        host="",
        port=8089,
        web_base_path: str | None = None,
        web_login: bool = False,
        tls_cert: str | None = None,
        tls_key: str | None = None,
        stats_csv_writer: StatsCSV | None = None,
        delayed_start=False,
        userclass_picker_is_active=False,
        build_path: str | None = None,
    ) -> WebUI:
        """
        Creates a :class:`WebUI <locust.web.WebUI>` instance for this Environment and start running the web server

        :param host: Host/interface that the web server should accept connections to. Defaults to ""
                     which means all interfaces
        :param port: Port that the web server should listen to
        :param web_login: If provided, an authentication page will protect the app
        :param tls_cert: An optional path (str) to a TLS cert. If this is provided the web UI will be
                         served over HTTPS
        :param tls_key: An optional path (str) to a TLS private key. If this is provided the web UI will be
                        served over HTTPS
        :param stats_csv_writer: `StatsCSV <stats_csv.StatsCSV>` instance.
        :param delayed_start: Whether or not to delay starting web UI until `start()` is called. Delaying web UI start
                              allows for adding Flask routes or Blueprints before accepting requests, avoiding errors.
```
---
That's why only managed to disable browser traffic and not the locust web interface.