### PR TITLE
Fix double cleanup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -190,7 +190,7 @@ class HumanAgent:
 
                     return input
             except (SystemExit, KeyboardInterrupt, EOFError):
-                if self.session_purpose:
+                if self.session_purpose and self.conductor.submission_stage not in ["detection", "localization", "mitigation"]:
                     atexit.register(exit_cleanup_fault, conductor=self.conductor)
                 raise SystemExit from None
 


### PR DESCRIPTION
The code that would prevent double cleanup while the conductor is in detection/localization/mitigation stage was removed so I'm readding it. Without this check if the user decides to exit during any of the three stages in a problem the program would be stuck when trying to clean up a second time (waiting for a deleted namespace to be ready).