### PR TITLE
fixed the argument bug in Wrk2.py

### DIFF
--- a/srearena/generators/workload/wrk2.py
+++ b/srearena/generators/workload/wrk2.py
@@ -132,9 +132,9 @@ class Wrk2:
         namespace = "default"
         configmap_name = "wrk2-payload-script"
 
-        self.create_configmap(name=configmap_name, namespace=namespace, payload_script_path=payload_script)
+        self.create_configmap(name=configmap_name, namespace=namespace, payload_script_path=payload_script, url=url)
 
-        self.create_wrk_job(job_name="wrk2-job", namespace=namespace, payload_script=payload_script.name, url=url)
+        self.create_wrk_job(job_name="wrk2-job", namespace=namespace, payload_script=payload_script.name)
 
     def stop_workload(self, job_name="wrk2-job"):
         namespace = "default"


### PR DESCRIPTION
The unexpected wrong argument `url` was passed to `create_wrk_job`, while `url` should have been passed to `create_configmap`.
Fixed the problem.