### PR TITLE
[#321] Add AWS Bedrock support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,10 +46,14 @@ LLM_QUERY_INIT_RETRY_DELAY=1
 # MODEL_TOOLS="gemini/gemini-2.5-flash"
 # MODEL_TOOLS="openai/gpt-4o"
 # MODEL_TOOLS="anthropic/claude-sonnet-4-20250514" # this one is ok, but the model on the doc of LiteLLM seems to be invalid. 
+# MODEL_TOOLS="bedrock/meta.llama3-1-70b-instruct-v1:0"
 
 # GEMINI_API_KEY="AIHaveFreeFood_LotsOfIt"
 # OPENAI_API_KEY="sk-proj-HaveSleep_LotsOfIt"
 # ANTHROPIC_API_KEY="sk-ant-api03-HaveCats_LotsOfIt_Meow"
+
+# AWS_PROFILE="default"
+# AWS_DEFAULT_REGION=us-east-2
 
 
 ### LLM Config2: WatsonX ###

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "bcrypt==4.3.0",
     "black==24.10.0",
     "blake3==1.0.5",
+    "boto3>=1.28.57",
     "bs4>=0.0.2",
     "cachetools==5.5.2",
     "certifi==2025.4.26",


### PR DESCRIPTION
Updates pyproject.toml to include boto3 for AWS Bedrock support and adds an example configuration to .env.example.

Note: the provided Bedrock example requires AWS credentials to be configured via 'aws configure'.