### PR TITLE
I-337

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -46,7 +46,7 @@ class Conductor:
         self.local_logger = logging.getLogger("all.sregym.conductor")
 
         self.transient_config = {
-            "switch": True,
+            "switch": False,
             "min_duration": 40,
             "max_duration": 60,
             "fault_types": [FaultType.FAIL_SLOW, FaultType.FAIL_STOP],


### PR DESCRIPTION
Fixes #337 

## Root Cause

The error occurs in `Conductor.submit()` method when the submission stage transitions to "done". At line 235, the code attempts to call:

```python
if self.transient_config["switch"]:
      self.transient_issue_generator.stop_continuous_injection()
```

However, `transient_issue_generator` is never initialized because the transient issues feature is disabled. So we get the following error:

```bash
ERROR - all.sregym.cli - [CLI] submit() raised exception: 'Conductor' object has no attribute 'transient_issue_generator'
Traceback (most recent call last):
  File "/home/pial/Academics/UIUC/Projects/SREGym/cli.py", line 117, in interactive_loop
    resp = await self.conductor.submit(wrapped)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pial/Academics/UIUC/Projects/SREGym/sregym/conductor/conductor.py", line 236, in submit
    self.transient_issue_generator.stop_continuous_injection()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Conductor' object has no attribute 'transient_issue_generator'
```

## Solution
Solution is very simple. Set `transient_config["switch"]` default to `False` to match the disabled feature state.

---

Recovery was failing for all the faults, but the issue manifested here because it modified something that does not go away on app cleanup.