### PR TITLE
Fix race condition in application cleanup between problem runs

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -282,8 +282,6 @@ class Conductor:
         self._finish_problem()
 
     def _finish_problem(self):
-        self.submission_stage = "done"
-
         self.logger.info(f"[STAGE] Done, recover fault")
 
         # Stop noises
@@ -298,6 +296,10 @@ class Conductor:
 
         self.logger.info(f"[STAGE] Undeploy app")
         self.undeploy_app()
+
+        # Set to "done" after all cleanup is complete to prevent race condition
+        # where the next problem starts before cleanup finishes
+        self.submission_stage = "done"
 
     async def start_problem(self) -> StartProblemResult:
         """


### PR DESCRIPTION
### Summary

Fixed a race condition where applications were not being cleaned up properly between problem runs. This caused multiple applications to run simultaneously (e.g., social-network still running when hotel-reservation starts).

### Changes

- Moved `submission_stage = "done"` assignment to the end of `_finish_problem()` method
- Ensures all cleanup operations (noise manager stop, fault recovery, app undeploy) complete before marking the problem as done
- Prevents the driver loop from starting the next problem while cleanup is still in progress

### Testing

The fix ensures proper sequencing of cleanup operations. The namespace deletion includes a wait loop that confirms full cleanup before proceeding.

Fixes #408

Generated with [Claude Code](https://claude.ai/code)