### PR TITLE
Refactor: rename localization to diagnosis in agent workflow

### DIFF
--- a/clients/stratus/configs/diagnosis_agent_config.yaml
+++ b/clients/stratus/configs/diagnosis_agent_config.yaml
@@ -46,9 +46,9 @@ async_tools:
   - name: exec_read_only_kubectl_cmd
     description: |
       This is a tool used to execute read-only kubectl commands.
-      
+
           Args:
-              command (str): The read-only kubectl command you want to execute in a CLI to manage a k8s cluster. It should start with "kubectl". 
+              command (str): The read-only kubectl command you want to execute in a CLI to manage a k8s cluster. It should start with "kubectl".
               Available Read-only Commands:
               "kubectl api-resources",
               "kubectl api-version",
@@ -66,14 +66,24 @@ async_tools:
               "kubectl config view",
               "kubectl config current-context",
               "kubectl config get",
-              INTERACTIVE COMMANDS ARE NOT SUPPORTED, e.g. "kubectl edit" 
+              INTERACTIVE COMMANDS ARE NOT SUPPORTED, e.g. "kubectl edit"
               INTERACTIVE FLAGS ARE NOT SUPPORTED, e.g., "kubectl logs -f"
+  - name: get_resource_uid
+    description: |
+      Use this tool to retrieve the UID of a specified resource.
+
+          Args:
+              resource_type (str): The type of the resource (e.g., 'pod', 'service', 'deployment', 'statefulset', 'persistentvolumeclaim', 'persistentvolume', 'configmap', 'replicaset', 'memoryquota', 'ingress', 'networkpolicy' etc.).
+              resource_name (str): The name of the resource.
+              namespace (str): The namespace where the resource is located.
+          Returns:
+              str: The UID of the specified resource.
   - name: submit_tool
     description: |
       The tool to submit benchmark results
-          
+
           Args:
-              ans (str): the answer you would like to submit to the benchmark. You should only use string "Yes" or "No" with quotes to indicate whether there are anomalies detected.
+              ans (str): the answer you would like to submit to the benchmark. Use natural language to describe the root cause of the failure.
 prompts_path: diagnosis_agent_prompts.yaml
 
 

--- a/clients/stratus/configs/diagnosis_agent_prompts.yaml
+++ b/clients/stratus/configs/diagnosis_agent_prompts.yaml
@@ -44,8 +44,8 @@ system: >
     - **ClusterRoleBinding and RoleBinding**: Bind roles to users or groups for authorization.
     - **ServiceAccount**: Associates processes in pods with permissions for accessing the Kubernetes API.
 
-    After you finished, submit "Yes" to denote that there's an incident in the cluster. 
-    Submit "No" to denote that there is no incidents identified.
+    After you finished, submit the detected faulty components to the orchestrator for evaluation.
+    The submission should be a natural language description of the root cause of the failure.
   
 
 user: >
@@ -68,3 +68,7 @@ user: >
   If you call submit_tool in tool-call stage, the process will end immediately.
   If you exceed this limitation, the system will force you to make a submission.
   You will begin by analyzing the service's state and telemetry with the tools.
+
+diagnosis_summary_prompt: |
+  You are a helper agent to an autonomous SRE agent.
+  Summarize the agent's trace and output the potential fault location and causes.

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -192,7 +192,7 @@ class Conductor:
             and self.problem.diagnosis_oracle
             and isinstance(self.problem.diagnosis_oracle, DiagnosisOracle)
         ):
-            self.problem.diagnosis_oracle.load_localization_checkpoint()
+            self.problem.diagnosis_oracle.load_diagnosis_checkpoint()
             self.local_logger.info("Diagnosis checkpoint loaded after fault injection.")
 
     # -------- AgentAct: diagnosis --------

--- a/sregym/conductor/oracles/diagnosis_oracle.py
+++ b/sregym/conductor/oracles/diagnosis_oracle.py
@@ -7,13 +7,13 @@ from kubernetes.config.config_exception import ConfigException
 
 from sregym.conductor.oracles.base import Oracle
 
-local_logger = getLogger("all.sregym.localization_oracle")
+local_logger = getLogger("all.sregym.diagnosis_oracle")
 local_logger.propagate = True
 local_logger.setLevel(logging.DEBUG)
 
 
 class DiagnosisOracle(Oracle):
-    """Logic of Localization Oracle"""
+    """Logic of Diagnosis Oracle"""
 
     # BEFORE the agent are ask to act, expect function will be called and checkpoint will be saved
     # AFTER the agent finish its run, the expected function will be called AGAIN to compare with agents answer.
@@ -24,7 +24,7 @@ class DiagnosisOracle(Oracle):
         self.checkpoint = None
         self.namespace = namespace
 
-    def load_localization_checkpoint(self):
+    def load_diagnosis_checkpoint(self):
         # load the checkpoint for future comparison
         self.checkpoint = self.expect()
 


### PR DESCRIPTION
The benchmark has pivoted from detection + localization + mitigation
to diagnosis (with LLMAsAJudge) + mitigation (with oracle).

Changes:
- Rename localization_task_main() to diagnosis_with_localization_task_main()
- Update all references from localization_summary to diagnosis_summary
- Add get_resource_uid tool to diagnosis_agent_config.yaml
- Update diagnosis prompts to submit root cause description (not Yes/No)
- Add diagnosis_summary_prompt to diagnosis_agent_prompts.yaml
- Rename load_localization_checkpoint() to load_diagnosis_checkpoint()
- Update logger names and docstrings to use 'diagnosis' terminology
- Update stage tracking from 'localization' to 'diagnosis'

Fixes #403

Generated with [Claude Code](https://claude.ai/code)