### PR TITLE
Add installation checks for codex and claude code CLI tools

### DIFF
--- a/clients/claudecode/driver.py
+++ b/clients/claudecode/driver.py
@@ -220,6 +220,11 @@ def main():
         default=None,
         help="Claude Code sessions directory (default: logs-dir/sessions)",
     )
+    parser.add_argument(
+        "--no-auto-install",
+        action="store_true",
+        help="Disable auto-installation of Claude Code CLI if not found",
+    )
 
     args = parser.parse_args()
 
@@ -228,6 +233,13 @@ def main():
     logger.info(f"Model: {args.model}")
     logger.info(f"Logs directory: {args.logs_dir}")
     logger.info("=" * 80)
+
+    # Check if Claude Code CLI is installed
+    try:
+        ClaudeCodeAgent.ensure_installed(auto_install=not args.no_auto_install)
+    except RuntimeError as e:
+        logger.error(f"Claude Code CLI installation check failed: {e}")
+        sys.exit(1)
 
     # Wait for conductor to be ready
     try:

--- a/clients/codex/driver.py
+++ b/clients/codex/driver.py
@@ -220,6 +220,11 @@ def main():
         default=None,
         help="Codex home directory (default: same as logs-dir)",
     )
+    parser.add_argument(
+        "--no-auto-install",
+        action="store_true",
+        help="Disable auto-installation of Codex CLI if not found",
+    )
 
     args = parser.parse_args()
 
@@ -228,6 +233,13 @@ def main():
     logger.info(f"Model: {args.model}")
     logger.info(f"Logs directory: {args.logs_dir}")
     logger.info("=" * 80)
+
+    # Check if Codex CLI is installed
+    try:
+        CodexAgent.ensure_installed(auto_install=not args.no_auto_install)
+    except RuntimeError as e:
+        logger.error(f"Codex CLI installation check failed: {e}")
+        sys.exit(1)
 
     # Wait for conductor to be ready
     try:


### PR DESCRIPTION
This PR addresses issue #437 by adding installation checks for the codex and claude code CLI tools.

## Changes
- Added `check_installation()` and `ensure_installed()` methods to both CodexAgent and ClaudeCodeAgent
- Drivers now verify CLI tools are installed before running
- Supports automatic installation via pip (codex) and npm (claude code)
- Added `--no-auto-install` flag to disable auto-installation
- Clear error messages with installation instructions on failure

Fixes #437

Generated with [Claude Code](https://claude.ai/code)