### PR TITLE
Make last_n_minutes match docstring type

### DIFF
--- a/clients/stratus/tools/jaeger_tools.py
+++ b/clients/stratus/tools/jaeger_tools.py
@@ -217,7 +217,7 @@ get_dependency_graph_docstring = """
 
 @tool(description=get_dependency_graph_docstring)
 async def get_dependency_graph(
-    last_n_minutes: str,
+    last_n_minutes: int,
     tool_call_id: Annotated[str, InjectedToolCallId],
 ) -> Command:
 


### PR DESCRIPTION
There is currently a mismatch between the docstring of the get_dependency_graph for the last_n_minutes parameter and the python typing.

The docstring that the agent receives indicates that the parameter's type is int whereas the actual python code is a str. When the agent makes its first get_dependency_graph call, it will likely run into the following error:

```
Error: 1 validation error for get_dependency_graph
last_n_minutes
  Input should be a valid string [type=string_type, input_value=5, input_type=int]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type; This happens usually because you are passing inappropriate arguments to the tool.
```

This really simple fix prevents the agent from encountering this issue to my tests.