### PR TITLE
fix: Add resource limits to Prometheus server to prevent OOMKills

### DIFF
--- a/sregym/observer/prometheus/prometheus/values.yaml
+++ b/sregym/observer/prometheus/prometheus/values.yaml
@@ -585,13 +585,13 @@ server:
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
-    # limits:
-    #   cpu: 500m
-    #   memory: 512Mi
-    # requests:
-    #   cpu: 500m
-    #   memory: 512Mi
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
 
   # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
   # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working


### PR DESCRIPTION
## Summary

Fixed Prometheus server crashes on kind by adding resource limits and requests.

## Changes

- Added memory limit (2Gi) and request (1Gi) to prevent OOMKills
- Added CPU limit (1000m) and request (500m) for stable scheduling

These resource constraints prevent the Prometheus server from consuming unlimited memory in kind environments, which was causing the container to be killed by Kubernetes.

Fixes #448

---

Generated with [Claude Code](https://claude.ai/code)