### PR TITLE
use tasklist to specify subset of problems to run

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,12 +65,22 @@ def driver_loop(
 
         # Get all problem IDs and filter if needed
         problem_ids = conductor.problems.get_problem_ids()
+        all_problem_ids = conductor.problems.get_problem_ids(all=True)
         if problem_filter:
-            if problem_filter not in problem_ids:
+            if problem_filter not in all_problem_ids:
                 console.log(f"⚠️  Problem '{problem_filter}' not found in registry. Available problems: {problem_ids}")
                 sys.exit(1)
             problem_ids = [problem_filter]
             console.log(f"🎯 Running single problem: {problem_filter}")
+
+        # sanity check: are there any specified problem ids that do not exist in the registry?
+        unknown_problem_ids = set(problem_ids) - set(all_problem_ids)
+        if unknown_problem_ids:
+            console.log(
+                f"⚠️  These problem ids do not exist in the registry and they will be skipped: {unknown_problem_ids}"
+            )
+        for unknown_problem_id in unknown_problem_ids:
+            problem_ids.remove(unknown_problem_id)
 
         for pid in problem_ids:
             console.log(f"\n🔍 Starting problem: {pid}")

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -65,7 +65,7 @@ class Conductor:
                 self.local_logger.error(f"Required dependency '{b}' not found.")
                 raise RuntimeError(f"[❌] Required dependency '{b}' not found.")
 
-    def get_tasklist(self):
+    def get_problem_stages(self):
         file_dir = Path(__file__).resolve().parent
         tasklist_path = file_dir / "tasklist.yml"
 
@@ -288,7 +288,7 @@ class Conductor:
 
         self.fix_kubernetes()
 
-        self.get_tasklist()
+        self.get_problem_stages()
         self._build_stage_sequence()
 
         self.local_logger.info("Undeploying app leftovers...")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import yaml
+
 from sregym.conductor.problems.ad_service_failure import AdServiceFailure
 from sregym.conductor.problems.ad_service_high_cpu import AdServiceHighCpu
 from sregym.conductor.problems.ad_service_manual_gc import AdServiceManualGc
@@ -237,10 +241,24 @@ class ProblemRegistry:
     def get_problem(self, problem_id: str):
         return self.PROBLEM_REGISTRY.get(problem_id)
 
-    def get_problem_ids(self, task_type: str = None):
+    def get_problem_ids(self, task_type: str = None, all: bool = False):
         if task_type:
             return [k for k in self.PROBLEM_REGISTRY.keys() if task_type in k]
-        return list(self.PROBLEM_REGISTRY.keys())
+        if all:
+            return list(self.PROBLEM_REGISTRY.keys())
+
+        # by default, only run problems defined in tasklist.yml
+        file_dir = Path(__file__).parent.parent
+        tasklist_path = file_dir / "tasklist.yml"
+
+        if not tasklist_path.exists():
+            # if tasklist.yml does not exist, run all the problems
+            return list(self.PROBLEM_REGISTRY.keys())
+
+        with open(tasklist_path, "r") as f:
+            tasklist = yaml.safe_load(f)
+        return list(tasklist["all"]["problems"].keys())
+
 
     def get_problem_count(self, task_type: str = None):
         if task_type:


### PR DESCRIPTION
This PR closes #452 .
Now specifying problems in `tasklist.yml` will take effect in limiting the benchmark to only run a subset of the problems. If `tasklist.yml` is not found, the benchmark runs all the problems. There is also a sanity check to take out problem ids that do not exist in the registry to avoid a typo crashing an eval run.