### PR TITLE
fix: correct default variant for imageSlowLoad

### DIFF
--- a/sregym/generators/fault/inject_otel.py
+++ b/sregym/generators/fault/inject_otel.py
@@ -24,7 +24,10 @@ class OtelFaultInjector(FaultInjector):
         flagd_data = json.loads(configmap["data"]["demo.flagd.json"])
 
         if feature_flag in flagd_data["flags"]:
-            flagd_data["flags"][feature_flag]["defaultVariant"] = "on"
+            if feature_flag == "imageSlowLoad":
+                flagd_data["flags"][feature_flag]["defaultVariant"] = "10sec"
+            else:
+                flagd_data["flags"][feature_flag]["defaultVariant"] = "on"
         else:
             raise ValueError(f"Feature flag '{feature_flag}' not found in ConfigMap '{self.configmap_name}'.")
 


### PR DESCRIPTION
# Problem

The current fault injection for the imageSlowLoad scenario in the astronomy-shop problem set incorrectly sets the default variant for the flag to "on".

However, for the slowImageLoad, the default variant must be one of the variants: "10sec", "5sec", "off" instead of "on". This can be verified by checking the logs for the flagd service:

```
______   __       ________   _______    ______      
		/_____/\ /_/\     /_______/\ /______/\  /_____/\     
		\::::_\/_\:\ \    \::: _  \ \\::::__\/__\:::_ \ \    
		 \:\/___/\\:\ \    \::(_)  \ \\:\ /____/\\:\ \ \ \   
		  \:::._\/ \:\ \____\:: __  \ \\:\\_  _\/ \:\ \ \ \  
		   \:\ \    \:\/___/\\:.\ \  \ \\:\_\ \ \  \:\/.:| | 
		    \_\/     \_____\/ \__\/\__\/ \_____\/   \____/_/ 														

2026-01-19T14:57:07.258Z	info	cmd/start.go:107	flagd version: v0.11.1 (9ac329f9206360e532d615904f977309b0af71a5), built at: 2024-07-08	{"component": "start"}
2026-01-19T14:57:07.259Z	info	flag-sync/sync_service.go:54	starting flag sync service on port 8015	{"component": "FlagSyncService"}
2026-01-19T14:57:07.260Z	info	file/filepath_sync.go:45	Starting filepath sync notifier	{"component": "sync", "sync": "filepath"}
2026-01-19T14:57:07.260Z	info	flag-evaluation/connect_service.go:247	metrics and probes listening at 8014	{"component": "service"}
2026-01-19T14:57:07.260Z	info	file/filepath_sync.go:74	watching filepath: ./etc/flagd/demo.flagd.json	{"component": "sync", "sync": "filepath"}
2026-01-19T14:57:07.260Z	info	ofrep/ofrep_service.go:56	ofrep service listening at 8016	{"component": "OFREPService"}
2026-01-19T14:57:07.260Z	info	flag-evaluation/connect_service.go:227	Flag IResolver listening at [::]:8013	{"component": "service"}
2026-01-19T14:57:07.263Z	error	runtime/runtime.go:146	default variant: 'on' isn't a valid variant of flag: 'imageSlowLoad'	{"component": "runtime"}
github.com/open-feature/flagd/flagd/pkg/runtime.(*Runtime).updateAndEmit
	/src/flagd/pkg/runtime/runtime.go:146
github.com/open-feature/flagd/flagd/pkg/runtime.(*Runtime).Start.func1
	/src/flagd/pkg/runtime/runtime.go:56
golang.org/x/sync/errgroup.(*Group).Go.func1
	/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78
2026-01-19T14:57:12.260Z	warn	flag-sync/sync_service.go:80	timeout while waiting for all sync sources to complete their initial sync. continuing sync service	{"component": "FlagSyncService"}
```

# Solution

This pull request just changes the current defaultVariant for the fault injection to "10sec" at the moment. The fix has been manually verified.