### PR TITLE
Check if 3rd party agents are installed before running apps

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,6 +264,10 @@ def main(args):
     config = ConductorConfig(deploy_loki=not args.use_external_harness)
     conductor = Conductor(config=config)
 
+    # If ran with 3rd party agent, check if they are installed
+    if args.agent and args.agent not in ["stratus", "autosubmit"]:
+        conductor.dependency_check([args.agent])
+
     # Start the driver in the background; it will call request_shutdown() when finished
     driver_thread = threading.Thread(
         target=_run_driver_and_shutdown,


### PR DESCRIPTION
Currently, we will only exit the benchmark _after_ we found out that the ported 3rd party agents are not on `PATH`. Considering the amount of time it takes to start up the applications and backends, it can be annoying.

This PR quickily exits the benchmark if those agents are not installed.