### PR TITLE
Add resource_quota_exhaustion Problem

### DIFF
--- a/main.py
+++ b/main.py
@@ -240,7 +240,7 @@ def main(args):
     conductor = Conductor(config=config)
 
     # If ran with 3rd party agent, check if they are installed
-    if args.agent and args.agent not in ["stratus", "autosubmit"]:
+    if args.agent and args.agent not in ["stratus", "autosubmit", "debug"]:
         conductor.dependency_check([args.agent])
 
     # Start the driver in the background; it will call request_shutdown() when finished

--- a/sregym/conductor/oracles/resource_quota_exhaustion_mitigation.py
+++ b/sregym/conductor/oracles/resource_quota_exhaustion_mitigation.py
@@ -1,0 +1,61 @@
+from sregym.conductor.oracles.base import Oracle
+
+
+class ResourceQuotaExhaustionMitigationOracle(Oracle):
+    importance = 1.0
+
+    def evaluate(self) -> dict:
+        print("== Mitigation Evaluation ==")
+        kubectl = self.problem.kubectl
+        namespace = self.problem.namespace
+        quota_name = self.problem.quota_name
+        results = {}
+
+        # 1. Check if ResourceQuota still exists
+        quota_exists = False
+        quota_has_headroom = False
+        quotas = kubectl.get_resource_quotas(namespace)
+
+        for quota in quotas:
+            if quota.metadata.name == quota_name:
+                quota_exists = True
+                # Check if it has pod limit and if there's headroom
+                if "pods" in quota.spec.hard:
+                    hard_limit = int(quota.spec.hard["pods"])
+                    # Get current pod count
+                    pod_list = kubectl.list_pods(namespace)
+                    running_pods = [pod for pod in pod_list.items if pod.status.phase == "Running"]
+                    current_pod_count = len(running_pods)
+
+                    if hard_limit > current_pod_count:
+                        quota_has_headroom = True
+                        print(f"✅ ResourceQuota '{quota_name}' has headroom: {hard_limit} > {current_pod_count}")
+                    else:
+                        print(f"❌ ResourceQuota '{quota_name}' has no headroom: {hard_limit} <= {current_pod_count}")
+                break
+
+        if not quota_exists:
+            print(f"❌ ResourceQuota '{quota_name}' does not exist (should be modified, not deleted)")
+            results["success"] = False
+            return results
+
+        # 2. Check if all pods in namespace are Running (no Pending pods)
+        pod_list = kubectl.list_pods(namespace)
+        all_pods_running = True
+
+        for pod in pod_list.items:
+            if pod.status.phase == "Pending":
+                print(f"❌ Pod {pod.metadata.name} is in Pending state")
+                all_pods_running = False
+            elif pod.status.phase != "Running":
+                print(f"⚠️ Pod {pod.metadata.name} is in {pod.status.phase} state")
+
+        if all_pods_running:
+            print("✅ All pods in namespace are Running (no Pending pods)")
+
+        # Success if: ResourceQuota exists, has headroom, and all pods are running
+        success = quota_exists and quota_has_headroom and all_pods_running
+        results["success"] = success
+
+        print(f"Mitigation Result: {'✅ Pass' if success else '❌ Fail'}")
+        return results

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -52,6 +52,7 @@ from sregym.conductor.problems.pvc_claim_mismatch import PVCClaimMismatch
 from sregym.conductor.problems.rbac_misconfiguration import RBACMisconfiguration
 from sregym.conductor.problems.readiness_probe_misconfiguration import ReadinessProbeMisconfiguration
 from sregym.conductor.problems.recommendation_service_cache_failure import RecommendationServiceCacheFailure
+from sregym.conductor.problems.resource_quota_exhaustion import ResourceQuotaExhaustion
 from sregym.conductor.problems.resource_request import ResourceRequestTooLarge, ResourceRequestTooSmall
 from sregym.conductor.problems.revoke_auth import MongoDBRevokeAuth
 from sregym.conductor.problems.rolling_update_misconfigured import RollingUpdateMisconfigured
@@ -128,6 +129,7 @@ class ProblemRegistry:
             "readiness_probe_misconfiguration_astronomy_shop": lambda: ReadinessProbeMisconfiguration(app_name="astronomy_shop", faulty_service="frontend"),
             "readiness_probe_misconfiguration_hotel_reservation": lambda: ReadinessProbeMisconfiguration(app_name="hotel_reservation", faulty_service="frontend"),
             "readiness_probe_misconfiguration_social_network": lambda: ReadinessProbeMisconfiguration(app_name="social_network", faulty_service="user-service"),
+            "resource_quota_exhaustion": ResourceQuotaExhaustion,
             "resource_request_too_large": lambda: ResourceRequestTooLarge(app_name="hotel_reservation", faulty_service="mongodb-rate"),
             "resource_request_too_small": lambda: ResourceRequestTooSmall(app_name="hotel_reservation", faulty_service="mongodb-rate"),
             "rolling_update_misconfigured_hotel_reservation": lambda: RollingUpdateMisconfigured(app_name="hotel_reservation"),

--- a/sregym/conductor/problems/resource_quota_exhaustion.py
+++ b/sregym/conductor/problems/resource_quota_exhaustion.py
@@ -1,0 +1,53 @@
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.oracles.resource_quota_exhaustion_mitigation import ResourceQuotaExhaustionMitigationOracle
+from sregym.conductor.problems.base import Problem
+from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+
+class ResourceQuotaExhaustion(Problem):
+    def __init__(self):
+        self.app = HotelReservation()
+        super().__init__(app=self.app, namespace=self.app.namespace)
+        self.kubectl = KubeCtl()
+        self.namespace = self.app.namespace
+        self.faulty_service = "frontend"
+        self.quota_name = "team-quota"
+        self.target_replicas = 5
+        self.original_replicas = None
+        self.current_pod_count = None
+        self.injector = VirtualizationFaultInjector(namespace=self.namespace)
+
+        self.root_cause = (
+            "The namespace has a ResourceQuota limiting pod count that is already consumed by existing workloads. "
+            f"When attempting to scale the deployment {self.faulty_service}, new pods remain in Pending state "
+            "because the quota for pod count is exhausted."
+        )
+
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.mitigation_oracle = ResourceQuotaExhaustionMitigationOracle(problem=self)
+
+        self.app.create_workload()
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+        self.current_pod_count, self.original_replicas = self.injector.inject_resource_quota_exhaustion(
+            deployment_name=self.faulty_service,
+            namespace=self.namespace,
+            quota_name=self.quota_name,
+            target_replicas=self.target_replicas,
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        self.injector.recover_resource_quota_exhaustion(
+            deployment_name=self.faulty_service,
+            namespace=self.namespace,
+            quota_name=self.quota_name,
+            original_replicas=self.original_replicas,
+        )


### PR DESCRIPTION
## Add `resource_quota_exhaustion` Problem [Fixes #526]

### Description
Adds a new Kubernetes problem that simulates namespace pod quota exhaustion, preventing new pods from being scheduled. Python code style formatter black and isort has been manually applied.

### Problem Details
- **Name**: `resource_quota_exhaustion`
- **Application**: HotelReservation
- **Target Service**: `frontend`
- **Category**: Virtualization fault (Kubernetes ResourceQuota)

### Fault Injection Mechanism
1. Counts current running pods in the namespace
2. Creates a ResourceQuota named `team-quota` with `hard.pods` limit set to exactly the current pod count (no headroom)
3. Attempts to scale the `frontend` deployment from current replicas to 5 replicas
4. New pods remain in `Pending` state due to quota exhaustion

### Expected Behavior
**Symptoms:**
- Pods stuck in `Pending` state with event: `"Error creating: pods "frontend-xxx" is forbidden: exceeded quota: team-quota, requested: pods=1, used: pods=N+1, limited: pods=N"`
- Deployment unable to scale beyond current pod count
- Application may experience degraded performance if scaling was needed for load

**Root Cause:**
The namespace has a ResourceQuota limiting pod count that is already consumed by existing workloads, preventing horizontal scaling.


### Implementation
- **Problem Class**: `sregym/conductor/problems/resource_quota_exhaustion.py`
- **Fault Injector Methods**: `VirtualizationFaultInjector.inject_resource_quota_exhaustion()` and `recover_resource_quota_exhaustion()` in `sregym/generators/fault/inject_virtual.py`
- **Registry**: Added to `sregym/conductor/problems/registry.py`

### Files Changed
- `sregym/conductor/problems/resource_quota_exhaustion.py` (new)
- `sregym/generators/fault/inject_virtual.py` (added 2 methods)
- `sregym/conductor/problems/registry.py` (registered problem)


### Testing
SREGym> kubectl get events -n hotel-reservation --sort-by='.lastTimestamp' | tail -1

4m26s       Warning   FailedCreate            replicaset/frontend-7fc7ddc9db                 (combined from similar events): Error creating: pods "frontend-7fc7ddc9db-nj6rz" is forbidden: exceeded quota: team-quota, requested: pods=1, used: pods=20, limited: pods=19

SREGym> kubectl describe resourcequota team-quota -n hotel-reservation
Name:       team-quota
Namespace:  hotel-reservation
|Resource |   Used | Hard |
|---|---|---|
|pods        |    20     |  19 |

SREGym> kubectl describe deployment frontend -n hotel-reservation
Name:                   frontend
Namespace:              hotel-reservation
CreationTimestamp:      Mon, 09 Feb 2026 02:22:55 +0000
Labels:                 io.kompose.service=frontend
Annotations:            deployment.kubernetes.io/revision: 1
                        kompose.cmd: kompose convert
                        kompose.version: 1.22.0 (955b78124)
Selector:               io.kompose.service=frontend
Replicas:               5 desired | 1 updated | 1 total | 1 available | 4 unavailable