### PR TITLE
Made MCP server port consistent to default port in code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ API_HOSTNAME="0.0.0.0"
 API_PORT="8000"
 
 # MCP Server Setting
-MCP_SERVER_PORT=8001
+MCP_SERVER_PORT=9954
 EXPOSE_SERVER=False
 # The size of session that can be hold at most; LRU session will be evicted if overflowing
 SESSION_CACHE_SIZE=10000


### PR DESCRIPTION
`stratus` fails silently if the agent tool's port not the port that MCP server is listening on.