### PR TITLE
fix: suppress CancelledError log messages during shutdown

### DIFF
--- a/sregym/conductor/conductor_api.py
+++ b/sregym/conductor/conductor_api.py
@@ -61,11 +61,17 @@ class _ShutdownNoiseFilter(logging.Filter):
     """Suppress expected CancelledError tracebacks from uvicorn during shutdown."""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        # Case 1: exc_info carries the exception object directly.
         if record.exc_info and record.exc_info[1] is not None:
             import asyncio
 
             if isinstance(record.exc_info[1], asyncio.CancelledError):
                 return False
+        # Case 2: uvicorn formats the traceback as a plain string message
+        # (e.g. logger.error(traceback.format_exc())) with no exc_info.
+        # The string will end with "asyncio.exceptions.CancelledError".
+        if "CancelledError" in record.getMessage():
+            return False
         return True
 
 


### PR DESCRIPTION
Fixes #576

Extend `_ShutdownNoiseFilter` in `conductor_api.py` to also suppress log records where uvicorn has formatted the exception traceback into the message string (without exc_info). This covers the second logging path that was letting the `asyncio.exceptions.CancelledError` traceback through on benchmark shutdown.

Generated with [Claude Code](https://claude.ai/code)