### PR TITLE
Fix audit bugs (pial)

### DIFF
--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -312,6 +312,10 @@ class VirtualizationFaultInjector(FaultInjector):
             result = self.kubectl.exec_command(create_service_command)
             print(f"Recreated service {service} to recover from the fault: {result}")
 
+        # Restart all pods to clear cached DNS failures from the fault period
+        self.kubectl.exec_command(f"kubectl delete pods --all -n {self.namespace}")
+        self.kubectl.wait_for_stable(namespace=self.namespace)
+
     # V.8 - Inject a fault by modifying the resource request of a service
     def inject_resource_request(self, microservices: list[str], memory_limit_func):
         """Inject a fault by modifying the resource request of a service."""


### PR DESCRIPTION
Closes #598 
Closes #600 

For 598: Scale deployments to 0 before scaling back to 1 in `inject_auth_miss_mongodb` and `inject_missing_configmap`, replacing the rolling restart approach that left both healthy and faulty pods running simultaneously.

For 600: Use `kubectl delete pods --all` in `recover_missing_service` to flush stale DNS caches after recreating a K8s Service object.