### PR TITLE
Add loki retention and storage limits

### DIFF
--- a/sregym/observer/loki/loki-values.yaml
+++ b/sregym/observer/loki/loki-values.yaml
@@ -83,7 +83,7 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
-    ephemeral-storage: 12Gi
+    ephemeral-storage: 10Gi
   requests:
     cpu: 100m
     memory: 256Mi


### PR DESCRIPTION
Closes #537

Added 24h log retention policy to Loki. This should be enough for now.

As for cleaning up Loki logs after each problem run, I believe we can use the Loki log deletion API (https://grafana.com/docs/loki/latest/reference/loki-http-api/) for that. Need to test it out though. Not including it now due to time limit.