### PR TITLE
Increase agent force cleanup timeout from 30s to 60s

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def driver_loop(
                     agent_proc = LAUNCHER._procs.get(agent_to_run)
                     if agent_proc:
                         console.log("⏳ Waiting for agent process to complete...")
-                        timeout = 30  # seconds
+                        timeout = 60  # seconds
                         elapsed = 0
                         while elapsed < timeout:
                             agent_proc.proc.poll()


### PR DESCRIPTION
Fixes #621: Agent traces were not being saved correctly because the 30 second timeout was too short. Increasing to 60 seconds gives the agent process sufficient time to finish saving trajectories.

Generated with [Claude Code](https://claude.ai/code)