### PR TITLE
Increase inotify limits in `setup_cluster` playbook

### DIFF
--- a/scripts/ansible/setup_cluster.yml
+++ b/scripts/ansible/setup_cluster.yml
@@ -481,13 +481,25 @@
         dest: /etc/modules-load.d/k8s.conf
       become: yes
 
-    - name: Configure sysctl for Kubernetes networking
+    - name: Configure sysctl for Kubernetes networking and inotify limits
       copy:
         content: |
           net.bridge.bridge-nf-call-iptables  = 1
           net.bridge.bridge-nf-call-ip6tables = 1
           net.ipv4.ip_forward                 = 1
+          fs.inotify.max_user_instances        = 1024
+          fs.inotify.max_user_watches          = 1048576
         dest: /etc/sysctl.d/k8s.conf
+      notify: Reload sysctl
+
+    - name: Remove inotify overrides from legacy /etc/sysctl.conf # Can override sysctl.d otherwise
+      lineinfile:
+        path: /etc/sysctl.conf
+        regexp: "{{ item }}"
+        state: absent
+      loop:
+        - '^fs\.inotify\.max_user_instances\s*='
+        - '^fs\.inotify\.max_user_watches\s*='
       notify: Reload sysctl
 
     - name: Start and enable kubelet


### PR DESCRIPTION
Closes #636 

Added inotify kernel params (`max_user_instances=1024`, `max_user_watches=1048576`) to the sysctl configuration in `setup_cluster.yml`. Also removed any conflicting inotify values from `/etc/sysctl.conf`, which loads last and capable of overriding `sysctl.d` values.
