### PR TITLE
TiDB and Deployment Not Ready Alerts 

### DIFF
--- a/sregym/observer/prometheus/prometheus/values.yaml
+++ b/sregym/observer/prometheus/prometheus/values.yaml
@@ -907,7 +907,7 @@ serverFiles:
 
             - alert: DeploymentNotReady
               expr: |
-                kube_deployment_status_replicas_available{namespace=~"astronomy-shop|hotel-reservation|social-network|blueprint-hotel-reservation|train-ticket|tidb-cluster"} == 0              for: 2m
+                kube_deployment_status_replicas_available{namespace=~"astronomy-shop|hotel-reservation|social-network|blueprint-hotel-reservation|train-ticket|tidb-cluster"} == 0
               for: 1m
               labels:
                 severity: critical


### PR DESCRIPTION
This PR adds alerts for the TiDB cluster and enables Prometheus to scrape the TiDB cluster. 
The TiDB alerts added:
-an alert that fires if the TiDB database is unreachable
-an alert that fires if there is a mismatch in desired and ready replicas.

In addition, an alert that checks if deployments are not ready was added. This works for problems like namespace_memory_limit, where the frontend deployment is not ready.

