### PR TITLE
Store diagnosis agent's submission in result CSV

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -293,6 +293,7 @@ class Conductor:
 
         self.logger.info("Start Eval for Diagnosis", extra={"sol": solution})
         r = problem.diagnosis_oracle.evaluate(solution)
+        r["submission"] = solution
         self.results["Diagnosis"] = r
         self.results["TTL"] = time.time() - self.execution_start_time
         self.logger.info(


### PR DESCRIPTION
Store the agent's submitted diagnosis text in conductor results so it is automatically written as `Diagnosis.submission` in the results CSV for any agent. The submission is the direct input passed to the LLM judge, making it easy to audit judge decisions.

Closes #707

Generated with [Claude Code](https://claude.ai/code)