### PR TITLE
Rename train-ticket flags

### DIFF
--- a/sregym/conductor/problems/train_ticket_f22.py
+++ b/sregym/conductor/problems/train_ticket_f22.py
@@ -15,7 +15,7 @@ class TrainTicketF22(Problem):
     def __init__(self):
         self.app_name = "train-ticket"
         self.faulty_service = "ts-contacts-service"
-        self.fault_name = "tt-feat-22"
+        self.fault_name = "fault-22-sql-column-name-mismatch-error"
         self.app = TrainTicket()
 
         self.namespace = self.app.namespace
@@ -42,7 +42,7 @@ class TrainTicketF22(Problem):
         self.injector._inject(
             fault_type="tt-feat-22",
         )
-        print(f"Injected tt-feat-22 | Namespace: {self.namespace}\n")
+        print(f"Injected fault-22-sql-column-name-mismatch-error | Namespace: {self.namespace}\n")
 
     @mark_fault_injected
     def recover_fault(self):
@@ -51,4 +51,4 @@ class TrainTicketF22(Problem):
         self.injector._recover(
             fault_type="tt-feat-22",
         )
-        print(f"Recovered from tt-feat-22 | Namespace: {self.namespace}\n")
+        print(f"Recovered from fault-22-sql-column-name-mismatch-error | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/train_ticket_f22.py
+++ b/sregym/conductor/problems/train_ticket_f22.py
@@ -15,7 +15,7 @@ class TrainTicketF22(Problem):
     def __init__(self):
         self.app_name = "train-ticket"
         self.faulty_service = "ts-contacts-service"
-        self.fault_name = "fault-22-sql-column-name-mismatch-error"
+        self.fault_name = "tt-feat-22"
         self.app = TrainTicket()
 
         self.namespace = self.app.namespace
@@ -40,15 +40,15 @@ class TrainTicketF22(Problem):
         print("== Fault Injection ==")
         self.injector = TrainTicketFaultInjector(namespace=self.namespace)
         self.injector._inject(
-            fault_type="fault-22-sql-column-name-mismatch-error",
+            fault_type="tt-feat-22",
         )
-        print(f"Injected fault-22-sql-column-name-mismatch-error | Namespace: {self.namespace}\n")
+        print(f"Injected tt-feat-22 | Namespace: {self.namespace}\n")
 
     @mark_fault_injected
     def recover_fault(self):
         print("== Fault Recovery ==")
         self.injector = TrainTicketFaultInjector(namespace=self.namespace)
         self.injector._recover(
-            fault_type="fault-22-sql-column-name-mismatch-error",
+            fault_type="tt-feat-22",
         )
-        print(f"Recovered from fault-22-sql-column-name-mismatch-error | Namespace: {self.namespace}\n")
+        print(f"Recovered from tt-feat-22 | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/trainticket_f17.py
+++ b/sregym/conductor/problems/trainticket_f17.py
@@ -16,7 +16,7 @@ class TrainTicketF17(Problem):
     def __init__(self):
         self.app_name = "train-ticket"
         self.faulty_service = "ts-voucher-service"
-        self.fault_name = "tt-feat-17"
+        self.fault_name = "fault-17-nested-sql-select-clause-error"
         self.app = TrainTicket()
 
         self.namespace = self.app.namespace
@@ -46,7 +46,7 @@ class TrainTicketF17(Problem):
         self.injector._inject(
             fault_type="tt-feat-17",
         )
-        print(f"Injected tt-feat-17 | Namespace: {self.namespace}\n")
+        print(f"Injected fault-17-nested-sql-select-clause-error | Namespace: {self.namespace}\n")
 
     @mark_fault_injected
     def recover_fault(self):
@@ -55,4 +55,4 @@ class TrainTicketF17(Problem):
         self.injector._recover(
             fault_type="tt-feat-17",
         )
-        print(f"Recovered from tt-feat-17 | Namespace: {self.namespace}\n")
+        print(f"Recovered from fault-17-nested-sql-select-clause-error | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/trainticket_f17.py
+++ b/sregym/conductor/problems/trainticket_f17.py
@@ -16,7 +16,7 @@ class TrainTicketF17(Problem):
     def __init__(self):
         self.app_name = "train-ticket"
         self.faulty_service = "ts-voucher-service"
-        self.fault_name = "fault-17-nested-sql-select-clause-error"
+        self.fault_name = "tt-feat-17"
         self.app = TrainTicket()
 
         self.namespace = self.app.namespace
@@ -44,15 +44,15 @@ class TrainTicketF17(Problem):
         print("== Fault Injection ==")
         self.injector = TrainTicketFaultInjector(namespace=self.namespace)
         self.injector._inject(
-            fault_type="fault-17-nested-sql-select-clause-error",
+            fault_type="tt-feat-17",
         )
-        print(f"Injected fault-17-nested-sql-select-clause-error | Namespace: {self.namespace}\n")
+        print(f"Injected tt-feat-17 | Namespace: {self.namespace}\n")
 
     @mark_fault_injected
     def recover_fault(self):
         print("== Fault Recovery ==")
         self.injector = TrainTicketFaultInjector(namespace=self.namespace)
         self.injector._recover(
-            fault_type="fault-17-nested-sql-select-clause-error",
+            fault_type="tt-feat-17",
         )
-        print(f"Recovered from fault-17-nested-sql-select-clause-error | Namespace: {self.namespace}\n")
+        print(f"Recovered from tt-feat-17 | Namespace: {self.namespace}\n")

--- a/sregym/generators/fault/inject_tt.py
+++ b/sregym/generators/fault/inject_tt.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import random
 import time
 from typing import Any
 
@@ -19,38 +20,32 @@ class TrainTicketFaultInjector(FaultInjector):
         self.configmap_name = "flagd-config"
         self.flagd_deployment = "flagd"
 
-        self.fault_mapping = {
-            "tt-feat-01": "F1: Asynchronous message delivery lacks sequence control",
-            "tt-feat-02": "F2: Different data requests for the same report are returned in an unexpected order",
-            "tt-feat-03": "F3: JVM configurations are inconsistent with Docker configurations",
-            "tt-feat-04": "F4: SSL offloading happens in a fine granularity (happening in almost each Docker instance)",
-            "tt-feat-05": "F5: The high load of a type of requests causes the timeout failure of another type of requests",
-            "tt-feat-06": "F6: Endless recursive requests of a microservice are caused by SQL errors of another dependent microservice",
-            "tt-feat-07": "F7: The overload of requests to a third-party service leads to denial of service",
-            "tt-feat-08": "F8: The key in the request of one microservice is not passed to its dependent microservice",
-            "tt-feat-09": "F9: There is a CSS display style error in bi-directional",
-            "tt-feat-10": "F10: An API used in a special case of BOM updating returns unexpected output",
-            "tt-feat-11": "F11: The BOM data is updated in an unexpected sequence",
-            "tt-feat-12": "F12: Price status querying does not consider an unexpected output of a microservice in its call chain",
-            "tt-feat-13": "F13: Price optimization steps are executed in an unexpected order",
-            "tt-feat-14": "F14: There is a mistake in including the locked product in CPI calculation",
-            "tt-feat-15": "F15: The spark actor is used for the configuration of actorSystem (part of Apache Spark) instead of the system actor",
-            "tt-feat-16": "F16: The 'max-content-length' configuration of spray is only 2 Mb, not allowing to support to upload a big file",
-            "tt-feat-17": "F17: Too many nested 'select' and 'from' clauses are in the constructed SQL statement",
-            "tt-feat-18": "F18: One key of the returned JSON data for the UI chart includes the null value",
-            "tt-feat-19": "F19: The product price is not formatted correctly in the French format",
-            "tt-feat-20": "F20: The JBoss startup classpath parameter does not include the right DB2 jar package",
-            "tt-feat-21": "F21: The 'aria-labeled-by' element for accessibility cannot be located by the JAWS",
-            "tt-feat-22": "F22: The constructed SQL statement includes a wrong column name in the 'select' part according to its 'from' part",
+        self.supported_faults = {"tt-feat-17", "tt-feat-22"}
+        self.excluded_from_decoy = self.supported_faults | {"tt-feat-01"}
+        self.all_flags = {
+            "tt-feat-01",
+            "tt-feat-02",
+            "tt-feat-03",
+            "tt-feat-04",
+            "tt-feat-05",
+            "tt-feat-06",
+            "tt-feat-07",
+            "tt-feat-08",
+            "tt-feat-09",
+            "tt-feat-10",
+            "tt-feat-11",
+            "tt-feat-12",
+            "tt-feat-13",
+            "tt-feat-14",
+            "tt-feat-15",
+            "tt-feat-16",
+            "tt-feat-17",
+            "tt-feat-18",
+            "tt-feat-19",
+            "tt-feat-20",
+            "tt-feat-21",
+            "tt-feat-22",
         }
-
-    def inject_fault(self, fault_type: str) -> bool:
-        print(f"[TrainTicket] Injecting fault: {fault_type}")
-        return self._set_fault_state(fault_type, "on")
-
-    def recover_fault(self, fault_type: str) -> bool:
-        print(f"[TrainTicket] Recovering from fault: {fault_type}")
-        return self._set_fault_state(fault_type, "off")
 
     def _get_configmap(self) -> dict[str, Any]:
         try:
@@ -58,7 +53,6 @@ class TrainTicketFaultInjector(FaultInjector):
                 f"kubectl get configmap {self.configmap_name} -n {self.namespace} -o json"
             )
             return json.loads(result) if result else {}
-
         except Exception as e:
             logger.error(f"Error getting ConfigMap: {e}")
             return {}
@@ -67,9 +61,13 @@ class TrainTicketFaultInjector(FaultInjector):
         """Update fault state in ConfigMap.
 
         Args:
-            fault_type: Name of the fault (e.g., 'tt-feat-06')
+            fault_type: Name of the fault (e.g., 'tt-feat-17')
             state: 'on' or 'off'
         """
+        if fault_type not in self.supported_faults:
+            print(f"Unsupported fault type: {fault_type}")
+            return False
+
         print(f"Setting {fault_type} to {state}...")
 
         configmap = self._get_configmap()
@@ -84,9 +82,7 @@ class TrainTicketFaultInjector(FaultInjector):
             print(f"Fault '{fault_type}' not found in ConfigMap")
             return False
 
-        # Update fault state
         flags_data["flags"][fault_type]["defaultVariant"] = state
-
         updated_yaml = yaml.dump(flags_data, default_flow_style=False)
 
         try:
@@ -110,7 +106,7 @@ class TrainTicketFaultInjector(FaultInjector):
                 self._restart_flagd()
                 print("✅ flagd restarted successfully")
 
-                print("Sleeping for 20 seconds to flag value change to take effect...")
+                print("Sleeping for 20 seconds for flag value change to take effect...")
                 time.sleep(20)
                 return True
             else:
@@ -123,52 +119,99 @@ class TrainTicketFaultInjector(FaultInjector):
 
     def _restart_flagd(self):
         print("[TrainTicket] Restarting flagd deployment...")
-
         try:
             result = self.kubectl.exec_command(
                 f"kubectl rollout restart deployment/{self.flagd_deployment} -n {self.namespace}"
             )
-            print(f"[TrainTicket] flagd deployment restarted successfully: {result}")
-
+            print(f"[TrainTicket] flagd deployment restarted: {result}")
         except Exception as e:
             logger.error(f"Error restarting flagd: {e}")
 
-    def get_fault_status(self, fault_type: str) -> str:
+    def activate_decoy_flags(self, count: int = 3) -> bool:
+        """Turn on a random subset of dud flags so the real fault doesn't stand out.
+
+        Args:
+            count: How many decoy flags to enable.
+        """
+        dud_flags = list(self.all_flags - self.excluded_from_decoy)
+        random.shuffle(dud_flags)
+        chosen = dud_flags[: min(count, len(dud_flags))]
+
+        configmap = self._get_configmap()
+        if not configmap:
+            print("Failed to get ConfigMap for decoy activation")
+            return False
+
+        flags_yaml = configmap["data"]["flags.yaml"]
+        flags_data = yaml.safe_load(flags_yaml)
+
+        activated = []
+        for flag in chosen:
+            if flag in flags_data["flags"]:
+                flags_data["flags"][flag]["defaultVariant"] = "on"
+                activated.append(flag)
+
+        if not activated:
+            print("No decoy flags available in ConfigMap")
+            return False
+
+        updated_yaml = yaml.dump(flags_data, default_flow_style=False)
         try:
-            result = self.kubectl.exec_command(
-                f"kubectl get configmap {self.configmap_name} -n {self.namespace} -o jsonpath='{{.data.flags\\.yaml}}'"
+            result = self.kubectl.update_configmap(
+                name=self.configmap_name, namespace=self.namespace, data={"flags.yaml": updated_yaml}
             )
-
-            if result and fault_type in result:
-                import yaml
-
-                flags_data = yaml.safe_load(result)
-
-                if "flags" in flags_data and fault_type in flags_data["flags"]:
-                    return flags_data["flags"][fault_type].get("defaultVariant", "unknown")
-
+            if result:
+                print(f"Decoy flags activated: {activated}")
+                return True
+            else:
+                print("Failed to update ConfigMap with decoy flags")
+                return False
         except Exception as e:
-            logger.error(f"Error getting fault status: {e}")
+            print(f"Error activating decoy flags: {e}")
+            return False
 
-        return "unknown"
+    def deactivate_decoy_flags(self) -> bool:
+        """Turn off all dud flags (everything except supported faults)."""
+        configmap = self._get_configmap()
+        if not configmap:
+            print("Failed to get ConfigMap for decoy deactivation")
+            return False
 
-    def list_available_faults(self) -> list[str]:
-        return list(self.fault_mapping.keys())
+        flags_yaml = configmap["data"]["flags.yaml"]
+        flags_data = yaml.safe_load(flags_yaml)
 
-    def get_fault_description(self, fault_name: str) -> str | None:
-        return self.fault_mapping.get(fault_name)
+        deactivated = []
+        for flag in self.all_flags - self.excluded_from_decoy:
+            if flag in flags_data["flags"] and flags_data["flags"][flag].get("defaultVariant") == "on":
+                flags_data["flags"][flag]["defaultVariant"] = "off"
+                deactivated.append(flag)
 
-    # Override base class methods to use feature flag-based fault injection
-    def _inject(self, fault_type: str, microservices: list[str] = None, duration: str = None):
+        if not deactivated:
+            print("No decoy flags were active")
+            return True
+
+        updated_yaml = yaml.dump(flags_data, default_flow_style=False)
+        try:
+            result = self.kubectl.update_configmap(
+                name=self.configmap_name, namespace=self.namespace, data={"flags.yaml": updated_yaml}
+            )
+            if result:
+                print(f"Decoy flags deactivated: {deactivated}")
+                return True
+            else:
+                print("Failed to update ConfigMap for decoy deactivation")
+                return False
+        except Exception as e:
+            print(f"Error deactivating decoy flags: {e}")
+            return False
+
+    def _inject(self, fault_type: str, microservices: list[str] | None = None, duration: str | None = None):
         """Override base class _inject to use feature flag-based injection."""
-        print(f"[TrainTicket] Using feature flag injection for: {fault_type}")
-        return self.inject_fault(fault_type)
+        self.activate_decoy_flags(count=10)
+        return self._set_fault_state(fault_type, "on")
 
-    def _recover(self, fault_type: str, microservices: list[str] = None):
+    def _recover(self, fault_type: str, microservices: list[str] | None = None):
         """Override base class _recover to use feature flag-based recovery."""
-        print(f"[TrainTicket] Using feature flag recovery for: {fault_type}")
-        return self.recover_fault(fault_type)
-
-
-if __name__ == "__main__":
-    print("TrainTicketFaultInjector - Use via SREGym CLI")
+        result = self._set_fault_state(fault_type, "off")
+        self.deactivate_decoy_flags()
+        return result

--- a/sregym/generators/fault/inject_tt.py
+++ b/sregym/generators/fault/inject_tt.py
@@ -20,28 +20,28 @@ class TrainTicketFaultInjector(FaultInjector):
         self.flagd_deployment = "flagd"
 
         self.fault_mapping = {
-            "fault-1-async-message-sequence-control": "F1: Asynchronous message delivery lacks sequence control",
-            "fault-2-data-request-order-inconsistency": "F2: Different data requests for the same report are returned in an unexpected order",
-            "fault-3-jvm-docker-config-mismatch": "F3: JVM configurations are inconsistent with Docker configurations",
-            "fault-4-ssl-offloading-granularity": "F4: SSL offloading happens in a fine granularity (happening in almost each Docker instance)",
-            "fault-5-high-load-timeout-cascade": "F5: The high load of a type of requests causes the timeout failure of another type of requests",
-            "fault-6-sql-error-recursive-requests": "F6: Endless recursive requests of a microservice are caused by SQL errors of another dependent microservice",
-            "fault-7-third-party-service-overload": "F7: The overload of requests to a third-party service leads to denial of service",
-            "fault-8-request-key-propagation-failure": "F8: The key in the request of one microservice is not passed to its dependent microservice",
-            "fault-9-css-bidirectional-display-error": "F9: There is a CSS display style error in bi-directional",
-            "fault-10-bom-api-unexpected-output": "F10: An API used in a special case of BOM updating returns unexpected output",
-            "fault-11-bom-data-sequence-error": "F11: The BOM data is updated in an unexpected sequence",
-            "fault-12-price-status-query-chain-error": "F12: Price status querying does not consider an unexpected output of a microservice in its call chain",
-            "fault-13-price-optimization-order-error": "F13: Price optimization steps are executed in an unexpected order",
-            "fault-14-locked-product-cpi-calculation-error": "F14: There is a mistake in including the locked product in CPI calculation",
-            "fault-15-spark-actor-system-config-error": "F15: The spark actor is used for the configuration of actorSystem (part of Apache Spark) instead of the system actor",
-            "fault-16-spray-max-content-length-limit": "F16: The 'max-content-length' configuration of spray is only 2 Mb, not allowing to support to upload a big file",
-            "fault-17-nested-sql-select-clause-error": "F17: Too many nested 'select' and 'from' clauses are in the constructed SQL statement",
-            "fault-18-json-chart-data-null-value": "F18: One key of the returned JSON data for the UI chart includes the null value",
-            "fault-19-product-price-french-format-error": "F19: The product price is not formatted correctly in the French format",
-            "fault-20-jboss-db2-jar-classpath-error": "F20: The JBoss startup classpath parameter does not include the right DB2 jar package",
-            "fault-21-aria-labeled-accessibility-error": "F21: The 'aria-labeled-by' element for accessibility cannot be located by the JAWS",
-            "fault-22-sql-column-name-mismatch-error": "F22: The constructed SQL statement includes a wrong column name in the 'select' part according to its 'from' part",
+            "tt-feat-01": "F1: Asynchronous message delivery lacks sequence control",
+            "tt-feat-02": "F2: Different data requests for the same report are returned in an unexpected order",
+            "tt-feat-03": "F3: JVM configurations are inconsistent with Docker configurations",
+            "tt-feat-04": "F4: SSL offloading happens in a fine granularity (happening in almost each Docker instance)",
+            "tt-feat-05": "F5: The high load of a type of requests causes the timeout failure of another type of requests",
+            "tt-feat-06": "F6: Endless recursive requests of a microservice are caused by SQL errors of another dependent microservice",
+            "tt-feat-07": "F7: The overload of requests to a third-party service leads to denial of service",
+            "tt-feat-08": "F8: The key in the request of one microservice is not passed to its dependent microservice",
+            "tt-feat-09": "F9: There is a CSS display style error in bi-directional",
+            "tt-feat-10": "F10: An API used in a special case of BOM updating returns unexpected output",
+            "tt-feat-11": "F11: The BOM data is updated in an unexpected sequence",
+            "tt-feat-12": "F12: Price status querying does not consider an unexpected output of a microservice in its call chain",
+            "tt-feat-13": "F13: Price optimization steps are executed in an unexpected order",
+            "tt-feat-14": "F14: There is a mistake in including the locked product in CPI calculation",
+            "tt-feat-15": "F15: The spark actor is used for the configuration of actorSystem (part of Apache Spark) instead of the system actor",
+            "tt-feat-16": "F16: The 'max-content-length' configuration of spray is only 2 Mb, not allowing to support to upload a big file",
+            "tt-feat-17": "F17: Too many nested 'select' and 'from' clauses are in the constructed SQL statement",
+            "tt-feat-18": "F18: One key of the returned JSON data for the UI chart includes the null value",
+            "tt-feat-19": "F19: The product price is not formatted correctly in the French format",
+            "tt-feat-20": "F20: The JBoss startup classpath parameter does not include the right DB2 jar package",
+            "tt-feat-21": "F21: The 'aria-labeled-by' element for accessibility cannot be located by the JAWS",
+            "tt-feat-22": "F22: The constructed SQL statement includes a wrong column name in the 'select' part according to its 'from' part",
         }
 
     def inject_fault(self, fault_type: str) -> bool:
@@ -67,7 +67,7 @@ class TrainTicketFaultInjector(FaultInjector):
         """Update fault state in ConfigMap.
 
         Args:
-            fault_type: Name of the fault (e.g., 'fault-6-sql-error-recursive-requests')
+            fault_type: Name of the fault (e.g., 'tt-feat-06')
             state: 'on' or 'off'
         """
         print(f"Setting {fault_type} to {state}...")

--- a/sregym/resources/trainticket/locustfile.py
+++ b/sregym/resources/trainticket/locustfile.py
@@ -28,7 +28,7 @@ class TrainTicketUser(HttpUser):
             self.token = data.get("data", {}).get("token", "")
             self.user_id = data.get("data", {}).get("userId", "")
             self.headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
-            print(f"[Login] Successfully logged in at {current_time}, token: {self.token[:20]}...")
+            print(f"[Login] Successfully logged in at {current_time}")
         else:
             print(f"[Login] Failed: {response.status_code}")
             self.token = ""
@@ -65,18 +65,14 @@ class TrainTicketUser(HttpUser):
                     if oid:
                         return oid
             else:
-                print(f"Orderservice refresh failed: {resp.status_code} {resp.text[:200]}")
+                print(f"[Orders] Refresh failed: {resp.status_code} {resp.text[:200]}")
         except Exception as e:
-            print(f"Error calling orderservice refresh: {e}")
+            print(f"[Orders] Error calling refresh: {e}")
             return None
 
     @task(1)
-    def test_fault_17_voucher_slow(self):
-        """Test F-17: slow DB due to nested SELECTs via direct voucher service call.
-        Expected:
-          - F-17 ON: /getVoucher takes >5s and times out -> failure
-          - F-17 OFF: /getVoucher returns quickly (<5s) -> success
-        """
+    def request_voucher(self):
+        """Request a voucher for an existing order via the voucher service."""
         if not getattr(self, "headers", None):
             return
 
@@ -92,39 +88,29 @@ class TrainTicketUser(HttpUser):
                 "http://ts-voucher-service:16101/getVoucher",
                 json=payload,
                 headers={"Content-Type": "application/json"},
-                name="/getVoucher (F17)",
+                name="/getVoucher",
                 timeout=5,
                 catch_response=True,
             ) as response:
                 elapsed = time.time() - start
-                print(f"[F17] /getVoucher status={response.status_code} elapsed={elapsed:.2f}s")
+                print(f"[Voucher] /getVoucher status={response.status_code} elapsed={elapsed:.2f}s")
 
                 if response.status_code == 200:
-                    print(f"[F17] SUCCESS: Voucher retrieved in {elapsed:.2f}s | response: {response.text}")
                     response.success()
                 else:
-                    print(f"[F17] FAILURE: Status {response.status_code} in {elapsed:.2f}s")
-                    response.failure(
-                        f"[F17] Voucher service failed to retrieve voucher. Error: {response.text}. Elapsed: {elapsed:.2f}s"
-                    )
+                    response.failure(f"Voucher service returned status {response.status_code}. Elapsed: {elapsed:.2f}s")
 
-        except requests.exceptions.ReadTimeout as e:
-            # F-17 ON: Voucher service sleeps for 10s, causing >5s timeout
+        except requests.exceptions.ReadTimeout:
             elapsed = time.time() - start
-            print(f"[F17] /getVoucher timed out after {elapsed:.2f}s (F17 ON - expected behavior!): {e}")
+            print(f"[Voucher] /getVoucher timed out after {elapsed:.2f}s")
 
         except Exception as e:
-            # Other errors
             elapsed = time.time() - start
-            print(f"[F17] /getVoucher error after {elapsed:.2f}s: {e}")
+            print(f"[Voucher] /getVoucher error after {elapsed:.2f}s: {e}")
 
     @task(1)
-    def test_fault_22_sql_column_missing(self):
-        """Test F-22: SQL column missing error in contacts service.
-        Expected:
-          - F-22 ON: Contact creation fails with SQL column missing error -> status 0
-          - F-22 OFF: Contact creation succeeds -> status 1
-        """
+    def create_contact(self):
+        """Create a new contact and clean it up afterwards."""
         if not getattr(self, "headers", None):
             return
 
@@ -134,7 +120,6 @@ class TrainTicketUser(HttpUser):
 
         unique_name = f"TestContact_{uuid.uuid4().hex[:8]}"
 
-        # Create contact payload
         contact_payload = {
             "name": unique_name,
             "accountId": self.user_id,
@@ -143,15 +128,14 @@ class TrainTicketUser(HttpUser):
             "phoneNumber": f"555-{unique_name[-4:]}",
         }
 
-        print(f"[F22] Testing contact creation: {unique_name}")
+        print(f"[Contacts] Creating contact: {unique_name}")
 
         try:
-            # Create contact
             with self.client.post(
                 "/api/v1/contactservice/contacts",
                 json=contact_payload,
                 headers=self.headers,
-                name="/contacts/create (F22)",
+                name="/contacts/create",
                 catch_response=True,
             ) as response:
                 if response.status_code == 201:
@@ -160,8 +144,7 @@ class TrainTicketUser(HttpUser):
                     msg = data.get("msg", "")
 
                     if status == 1:
-                        print(f"[F22] SUCCESS: Contact created successfully | status: {status} | msg: {msg}")
-                        print(f"[F22] Contact data: {data.get('data', {})}")
+                        print("[Contacts] Contact created successfully")
 
                         # Clean up: Delete the contact to avoid crowding the list
                         contact_id = data.get("data", {}).get("id")
@@ -173,37 +156,33 @@ class TrainTicketUser(HttpUser):
                                     name="/contacts/delete",
                                 )
                                 if delete_response.status_code == 200:
-                                    print(f"[F22] Cleanup: Contact {contact_id} deleted successfully")
+                                    print(f"[Contacts] Cleanup: Contact {contact_id} deleted")
                                 else:
                                     print(
-                                        f"[F22] Cleanup: Failed to delete contact {contact_id}, status: {delete_response.status_code}"
+                                        f"[Contacts] Cleanup: Failed to delete contact {contact_id}, status: {delete_response.status_code}"
                                     )
                             except Exception as e:
-                                print(f"[F22] Cleanup: Error deleting contact {contact_id}: {e}")
+                                print(f"[Contacts] Cleanup: Error deleting contact {contact_id}: {e}")
 
                         response.success()
 
                     elif status == 0:
-                        print(f"[F22] FAILURE: Contact creation failed | status: {status} | msg: {msg}")
-                        response.failure(f"[F22] Contact creation failed: {msg}")
+                        print(f"[Contacts] Contact creation failed: {msg}")
+                        response.failure(f"Contact creation failed: {msg}")
                     else:
-                        print(f"[F22] UNKNOWN: Unexpected status {status} | msg: {msg}")
-                        response.failure(f"[F22] Contact creation returned unexpected status: {status}")
+                        print(f"[Contacts] Unexpected status {status}: {msg}")
+                        response.failure(f"Contact creation returned unexpected status: {status}")
 
                 else:
-                    print(f"[F22] HTTP ERROR: Status {response.status_code} | Response: {response.text}")
-                    response.failure(f"[F22] Contact creation HTTP error: {response.status_code}")
+                    print(f"[Contacts] HTTP error: {response.status_code}")
+                    response.failure(f"Contact creation HTTP error: {response.status_code}")
 
         except Exception as e:
-            print(f"[F22] EXCEPTION: Error during contact creation: {e}")
-            # Can't call response.failure() here since response is not in scope
-            print(f"[F22] Exception details: {e}")
+            print(f"[Contacts] Error during contact creation: {e}")
 
     @task(2)
     def get_routes(self):
-        """
-        Get all available train routes.
-        """
+        """Get all available train routes."""
         if not getattr(self, "headers", None):
             return
 
@@ -219,7 +198,7 @@ class TrainTicketUser(HttpUser):
             if response.status_code == 200:
                 data = response.json()
                 routes_count = len(data.get("data", [])) if isinstance(data.get("data"), list) else 0  # noqa: F841
-                print(f"[Routes] Successfully retrieved {routes_count} routes")
+                print(f"[Routes] Retrieved {routes_count} routes")
             else:
                 print(f"[Routes] Failed to get routes: {response.status_code}")
 
@@ -228,9 +207,7 @@ class TrainTicketUser(HttpUser):
 
     @task(2)
     def get_stations(self):
-        """
-        Get all available train stations.
-        """
+        """Get all available train stations."""
         if not getattr(self, "headers", None):
             return
 
@@ -246,7 +223,7 @@ class TrainTicketUser(HttpUser):
             if response.status_code == 200:
                 data = response.json()
                 stations_count = len(data.get("data", [])) if isinstance(data.get("data"), list) else 0  # noqa: F841
-                print(f"[Stations] Successfully retrieved {stations_count} stations")
+                print(f"[Stations] Retrieved {stations_count} stations")
             else:
                 print(f"[Stations] Failed to get stations: {response.status_code}")
 


### PR DESCRIPTION
The old flag names like `fault-22-sql-column-name-mismatch-error` leak the root cause directly. If the agent discovers the flag names, it can easily find the root cause and turn off the flag to mitigate the fault, bypassing the actual diagnosis work. This PR renames all 22 flags in the train-ticket `flagd` config to `tt-feat-01` through `tt-feat-22` and updates all references.

Related PR: https://github.com/xlab-uiuc/train-ticket/pull/12

Need to update the submodule version in `SREGym` after merging the train-ticket PR.