### PR TITLE
Fix `astronomy-shop` feature flag being set to to invalid variant

### DIFF
--- a/sregym/generators/fault/inject_otel.py
+++ b/sregym/generators/fault/inject_otel.py
@@ -28,6 +28,15 @@ _FLAG_TO_DEPLOYMENTS: dict[str, list[str]] = {
     "llmRateLimitError": ["llm"],
 }
 
+# Flags whose "enabled" variant is NOT the standard "on".
+# These flags use percentage/multiplier variants instead of boolean on/off.
+# Source: https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/flagd/demo.flagd.json
+_FLAG_INJECT_VARIANT: dict[str, str] = {
+    "imageSlowLoad": "10sec",
+    "paymentFailure": "100%",
+    "emailMemoryLeak": "1000x",
+}
+
 
 class OtelFaultInjector(FaultInjector):
     def __init__(self, namespace: str):
@@ -62,10 +71,8 @@ class OtelFaultInjector(FaultInjector):
         flagd_data = json.loads(configmap["data"]["demo.flagd.json"])
 
         if feature_flag in flagd_data["flags"]:
-            if feature_flag == "imageSlowLoad":
-                flagd_data["flags"][feature_flag]["defaultVariant"] = "10sec"
-            else:
-                flagd_data["flags"][feature_flag]["defaultVariant"] = "on"
+            variant = _FLAG_INJECT_VARIANT.get(feature_flag, "on")
+            flagd_data["flags"][feature_flag]["defaultVariant"] = variant
         else:
             raise ValueError(f"Feature flag '{feature_flag}' not found in ConfigMap '{self.configmap_name}'.")
 
@@ -74,7 +81,7 @@ class OtelFaultInjector(FaultInjector):
 
         self._restart_flagd_and_consumers(feature_flag)
 
-        print(f"Fault injected: Feature flag '{feature_flag}' set to 'on'.")
+        print(f"Fault injected: Feature flag '{feature_flag}' set to '{variant}'.")
 
     def recover_fault(self, feature_flag: str):
         command = f"kubectl get configmap {self.configmap_name} -n {self.namespace} -o json"


### PR DESCRIPTION
Closes #728

## Problem

`inject_fault()` in `OtelFaultInjector` hardcodes `defaultVariant: "on"` for all flags except `imageSlowLoad`. However, several flags in the upstream OpenTelemetry demo [demo.flagd.json](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/flagd/demo.flagd.json) don't have `"on"` as a valid variant (though all of them do have `"off"` as a universal recovery variant).

- `paymentFailure` uses `"100%"`, `"90%"`, `"75%"`, `"50%"`, `"25%"`, `"10%"`, `"off"`
- `imageSlowLoad` uses `"10sec"`, `"5sec"`, `"off"` (was already special-cased)
- `emailMemoryLeak` uses `"1x"`, `"10x"`, `"100x"`, `"1000x"`, `"10000x"`, `"off"`


## Fix

Introduced a `_FLAG_INJECT_VARIANT` mapping for flags that don't use the standard `"on"` pattern. `inject_fault()` now looks up the correct variant from this map, falling back to `"on"` for standard boolean flags.
