### PR TITLE
docs: fix README TOC links and correct a typo in code comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <h1>SREGym: A Benchmarking Platform for SRE Agents</h1>
 
-[🔍Overview](#🤖overview) |
-[📦Installation](#📦installation) |
-[🚀Quick Start](#🚀quickstart) |
-[⚙️Usage](#⚙️usage) |
+[Overview](#overview) |
+[Installation](#installation) |
+[Quick Start](#quickstart) |
+[Usage](#usage) |
 [🤝Contributing](./CONTRIBUTING.md) |
 [📖Docs](https://sregym.com/docs) |
 [![Slack](https://img.shields.io/badge/-Slack-4A154B?style=flat-square&logo=slack&logoColor=white)](https://join.slack.com/t/SREGym/shared_invite/zt-3gvqxpkpc-RvCUcyBEMvzvXaQS9KtS_w)

--- a/sregym/conductor/conductor_api.py
+++ b/sregym/conductor/conductor_api.py
@@ -188,7 +188,7 @@ def run_api(conductor):
     """
     global _server
     set_conductor(conductor)
-    logger.debug(f"API server is binded to the conductor {conductor}")
+    logger.debug(f"API server is bound to the conductor {conductor}")
 
     # Load from .env with defaults
     host = os.getenv("API_BIND_HOST", "0.0.0.0")

--- a/sregym/conductor/problems/operator_misoperation/invalid_affinity_toleration.py
+++ b/sregym/conductor/problems/operator_misoperation/invalid_affinity_toleration.py
@@ -45,4 +45,4 @@ class K8SOperatorInvalidAffinityTolerationFault(Problem):
 
         injector = K8SOperatorFaultInjector(namespace="tidb-cluster")
         injector.recover_invalid_affinity_toleration()
-        print(f"[FAULT INJECTED] {self.faulty_service} invalid affinity toleration failure\n")
+        print(f"[FAULT RECOVERED] {self.faulty_service} invalid affinity toleration failure\n")

--- a/sregym/conductor/problems/operator_misoperation/wrong_operator_image.py
+++ b/sregym/conductor/problems/operator_misoperation/wrong_operator_image.py
@@ -1,5 +1,5 @@
 """
-This fault specifies an invalid update strategy.
+This fault specifies a wrong operator image.
 """
 
 from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle


### PR DESCRIPTION
## Summary

Four small fixes:

1. **README.md TOC links**: GitHub's markdown anchor generation strips emoji characters, so TOC links like `[🔍Overview](#🤖overview)` never resolve. Fixed by using plain text anchors (`[Overview](#overview)`).

2. **conductor_api.py typo**: "binded" → "bound" in a debug log message.

3. **wrong_operator_image.py docstring**: The module docstring said "This fault specifies an invalid update strategy" but the class is `K8SOperatorWrongOperatorImage`, which is about wrong operator images, not update strategies.

4. **invalid_affinity_toleration.py bug**: The `recover_fault()` method was printing "[FAULT INJECTED]" instead of "[FAULT RECOVERED]" — a copy-paste error.

## Test plan

- [x] Read the changed files to verify correctness
- [x] No functional code changes — only documentation and log message fixes