### PR TITLE
refactor: remove redundant import and fix typo in conductor_api

### DIFF
--- a/sregym/conductor/conductor_api.py
+++ b/sregym/conductor/conductor_api.py
@@ -71,8 +71,6 @@ class _ShutdownNoiseFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         # Case 1: exc_info carries the exception object directly.
         if record.exc_info and record.exc_info[1] is not None:
-            import asyncio
-
             if isinstance(record.exc_info[1], asyncio.CancelledError):
                 return False
         # Case 2: uvicorn formats the traceback as a plain string message
@@ -188,7 +186,7 @@ def run_api(conductor):
     """
     global _server
     set_conductor(conductor)
-    logger.debug(f"API server is binded to the conductor {conductor}")
+    logger.debug(f"API server is bound to the conductor {conductor}")
 
     # Load from .env with defaults
     host = os.getenv("API_BIND_HOST", "0.0.0.0")


### PR DESCRIPTION
## Summary
- Remove redundant `import asyncio` inside `_ShutdownNoiseFilter.filter()` — `asyncio` is already imported at module level (line 1)
- Fix `binded` → `bound` in debug log message

## Test plan
- [x] `python -m py_compile sregym/conductor/conductor_api.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)