### PR TITLE
Grant MCP server patch/update on TidbCluster CRs (fix #744)

### DIFF
--- a/mcp_server/k8s/clusterrole.yaml
+++ b/mcp_server/k8s/clusterrole.yaml
@@ -80,4 +80,4 @@ rules:
   - apiGroups: ["pingcap.com"]
     resources:
       - tidbclusters
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch", "update"]


### PR DESCRIPTION
Adds `patch` and `update` verbs to the `tidbclusters` rule in the mcp-server ClusterRole so agents can edit the CR through the MCP server. Without this, the `operator_non_existent_storage` mitigation oracle was unsolvable because the agent could not change `pd.storageClassName` on the CR. The ClusterRole is reapplied on each run by `sregym/service/mcp_server.py`, so existing deployments pick up the new permissions automatically.

Fixes #744