### PR TITLE
support OpenAI-compatible Bedrock endpoint to bypass Converse read-timeout

### DIFF
--- a/llm_backend/get_llm_backend.py
+++ b/llm_backend/get_llm_backend.py
@@ -18,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 LLM_QUERY_MAX_RETRIES = int(os.getenv("LLM_QUERY_MAX_RETRIES", "5"))
 LLM_QUERY_INIT_RETRY_DELAY = int(os.getenv("LLM_QUERY_INIT_RETRY_DELAY", "1"))
+# Per-request timeout. Default 120s shrinks the chronic Bedrock Converse-API
+# read-timeout cost from ~600s to one short timeout + a fast retry.
+LLM_REQUEST_TIMEOUT_S = int(os.getenv("LLM_REQUEST_TIMEOUT_S", "120"))
 
 
 class LiteLLMBackend:
@@ -38,6 +41,7 @@ class LiteLLMBackend:
         self.max_tokens = max_tokens
         litellm.drop_params = True
         litellm.modify_params = True
+        litellm.request_timeout = LLM_REQUEST_TIMEOUT_S
 
     def inference(
         self,

--- a/llm_backend/init_backend.py
+++ b/llm_backend/init_backend.py
@@ -4,9 +4,20 @@ from llm_backend.get_llm_backend import LiteLLMBackend
 
 
 def get_llm_backend(model_name: str) -> LiteLLMBackend:
-    """Initialize an LLM backend for the given litellm model string."""
+    """Initialize an LLM backend for the given litellm model string.
+
+    Optional env vars:
+      LLM_API_BASE — override the litellm api_base (e.g. Bedrock's
+        OpenAI-compatible endpoint to bypass the Converse-API read-timeout
+        regression on Moonshot/Kimi models, see langchain-aws#819).
+      LLM_API_KEY — override the litellm api_key.
+    """
     print(f"🔧 Initializing LLM backend — model: {model_name}")
-    return LiteLLMBackend(model_name=model_name)
+    return LiteLLMBackend(
+        model_name=model_name,
+        api_base=os.environ.get("LLM_API_BASE"),
+        api_key=os.environ.get("LLM_API_KEY"),
+    )
 
 
 def get_llm_backend_for_agent() -> LiteLLMBackend:

--- a/scripts/probe_llm_backend.py
+++ b/scripts/probe_llm_backend.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Probe the configured LLM backend with a small prompt and report latency.
+
+Run before kicking off a rerun batch to confirm the endpoint is reachable
+and the latency tail looks normal.
+
+Reads the same env vars as a real SREGym run:
+    AGENT_MODEL_ID    — litellm model string
+    LLM_API_BASE      — optional, override api_base
+    LLM_API_KEY       — optional, override api_key
+    LLM_REQUEST_TIMEOUT_S — optional, per-request timeout
+
+Usage:
+    python scripts/probe_llm_backend.py [--n 5]
+"""
+
+import argparse
+import os
+import sys
+import time
+
+from llm_backend.init_backend import get_llm_backend
+
+
+def probe_once(backend) -> tuple[float, str]:
+    t0 = time.monotonic()
+    out = backend.inference(
+        "Say the single word OK and nothing else.",
+        system_prompt="You answer with exactly one word.",
+    )
+    elapsed = time.monotonic() - t0
+    text = getattr(out, "content", str(out)).strip()
+    return elapsed, text
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=5, help="number of probes (default 5)")
+    args = ap.parse_args()
+
+    model_id = os.environ.get("AGENT_MODEL_ID")
+    if not model_id:
+        print("AGENT_MODEL_ID is not set", file=sys.stderr)
+        sys.exit(2)
+
+    print(
+        f"Probing model={model_id} api_base={os.environ.get('LLM_API_BASE') or '<default>'} "
+        f"timeout={os.environ.get('LLM_REQUEST_TIMEOUT_S', '120')}s"
+    )
+    backend = get_llm_backend(model_id)
+
+    latencies: list[float] = []
+    failures = 0
+    for i in range(args.n):
+        try:
+            elapsed, text = probe_once(backend)
+            latencies.append(elapsed)
+            print(f"  [{i + 1}/{args.n}] {elapsed:.2f}s  → {text[:60]!r}")
+        except Exception as e:
+            failures += 1
+            print(f"  [{i + 1}/{args.n}] FAILED: {type(e).__name__}: {e}")
+
+    if not latencies:
+        print("\nAll probes failed.")
+        sys.exit(1)
+
+    latencies.sort()
+    n = len(latencies)
+    print(f"\nSummary: n={n}  failures={failures}")
+    print(f"  min={latencies[0]:.2f}s  median={latencies[n // 2]:.2f}s  max={latencies[-1]:.2f}s")
+    print(f"  mean={sum(latencies) / n:.2f}s")
+
+    # Sanity gate: bail loudly if any probe took >60s — that's a bad sign for
+    # a one-token completion and likely means the chronic Bedrock Converse
+    # read-timeout regression is firing on this endpoint right now.
+    if any(lat > 60 for lat in latencies):
+        print("\n⚠️  At least one probe exceeded 60s for a one-word completion.")
+        print("    Endpoint is degraded; postpone the rerun.")
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds optional LLM_API_BASE and LLM_API_KEY env vars (read in init_backend and passed through to LiteLLMBackend), plus an LLM_REQUEST_TIMEOUT_S env var that defaults to 120s. The default short-circuits the chronic ~600s Converse read-timeout regression (langchain-aws#819) so the existing retry loop can recover quickly.

Also adds scripts/probe_llm_backend.py — a 5-call latency probe that reads the same env vars and exits non-zero if any one-token completion takes >60s. Use it as a gate before kicking off rerun batches.

Workaround for the Bedrock Converse-API tool-call / read-timeout bugs seen on Moonshot/Kimi models: set AGENT_MODEL_ID=openai/moonshotai.kimi-k2.5 LLM_API_BASE=<Bedrock OpenAI-compatible endpoint> LLM_API_KEY=<Bedrock API key>

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>