### PR TITLE
Fix garbled ANSI output in CLI during submit evaluation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -113,6 +113,9 @@ class HumanAgent:
                 continue
             try:
                 resp = await self.conductor.submit(sol)
+                # Wait for background evaluation to finish before re-prompting,
+                if self.conductor._submit_future is not None:
+                    await asyncio.wrap_future(self.conductor._submit_future)
             except Exception as e:
                 env = f"[❌] Grading error: {e}"
             else:


### PR DESCRIPTION
The CLI prompt was redrawing before the background evaluation thread finished logging, causing ANSI output (for the color effects) to collide with prompt_toolkit's terminal state and render as raw escape codes.

*before fix*
```bash
SREGym> submit()
{'status': 'ok', 'message': 'Submission received'}
?[2;36m[05/17/26 08:01:06]?[0m?[2;36m ?[0m?[34mINFO    ?[0m all.sregym.conductor - Evaluating stage ?[32m'diagnosis'?[0m                     
?[2;36m                   ?[0m?[2;36m ?[0m?[34mINFO    ?[0m all.sregym.conductor - Start Eval for Diagnosis                         
== LLM-as-a-Judge Evaluation ==
Warning: Failed to initialize LLM backend for judge: JUDGE_MODEL_ID environment variable is not set.
Returning None - evaluation will be skipped
Warning: LLM judge backend is not initialized - skipping evaluation
⚠️  LLM judge is not initialized - returning null result
?[2;36m                   ?[0m?[2;36m ?[0m?[34mINFO    ?[0m all.sregym.conductor - ?[1m[?[0mEVAL?[1m]?[0m Diagnosis Failed                          
?[2;36m                    ?[0m          TTL: ?[1;36m113.20466423034668?[0m                                                
?[2;36m                   ?[0m?[2;36m ?[0m?[34mINFO    ?[0m all.sregym.conductor - ?[1m[?[0mSTAGE?[1m]?[0m Go to stage mitigation                   
SREGym> 
```

Given fix is to await the evaluation future after submit() returns so all log output completes before the prompt redraws.

*after fix*
```bash
SREGym> submit()
[05/17/26 08:16:31] INFO     all.sregym.conductor - Evaluating stage 'diagnosis'                     
                    INFO     all.sregym.conductor - Start Eval for Diagnosis                         
== LLM-as-a-Judge Evaluation ==
Warning: Failed to initialize LLM backend for judge: JUDGE_MODEL_ID environment variable is not set.
Returning None - evaluation will be skipped
Warning: LLM judge backend is not initialized - skipping evaluation
⚠️  LLM judge is not initialized - returning null result
                    INFO     all.sregym.conductor - [EVAL] Diagnosis Failed                          
                              TTL: 25.680704832077026                                                
                    INFO     all.sregym.conductor - [STAGE] Go to stage mitigation                   
{'status': 'ok', 'message': 'Submission received'}
SREGym> 
```