### PR TITLE
Fix `network_policy_block` pod targeting

### DIFF
--- a/sregym/conductor/problems/network_policy_block.py
+++ b/sregym/conductor/problems/network_policy_block.py
@@ -10,7 +10,10 @@ from sregym.utils.decorators import mark_fault_injected
 
 
 class NetworkPolicyBlock(Problem):
-    def __init__(self, faulty_service="payment-service"):
+    # HotelReservation pods use "io.kompose.service" as their label key
+    POD_LABEL_KEY = "io.kompose.service"
+
+    def __init__(self, faulty_service="recommendation"):
         self.app = HotelReservation()
         self.namespace = self.app.namespace
         super().__init__(app=self.app, namespace=self.namespace)
@@ -28,9 +31,10 @@ class NetworkPolicyBlock(Problem):
             namespace=self.namespace,
             description=(
                 f"A NetworkPolicy `{self.policy_name}` blocks all ingress and egress traffic for pods labeled "
-                f"`app={self.faulty_service}`, creating complete network isolation for the target workload. "
-                "Service-to-service communication to and from the component fails, so dependent request paths break "
-                "even if pods remain Running. Users observe hard failures/timeouts on flows that require this service."
+                f"`{self.POD_LABEL_KEY}={self.faulty_service}`, creating complete network isolation for the target "
+                "workload. Service-to-service communication to and from the component fails, so dependent request "
+                "paths break even if pods remain Running. Users observe hard failures/timeouts on flows that require "
+                "this service."
             ),
         )
         self.networking_v1 = client.NetworkingV1Api()
@@ -46,7 +50,7 @@ class NetworkPolicyBlock(Problem):
             "kind": "NetworkPolicy",
             "metadata": {"name": self.policy_name, "namespace": self.namespace},
             "spec": {
-                "podSelector": {"matchLabels": {"app": self.faulty_service}},
+                "podSelector": {"matchLabels": {self.POD_LABEL_KEY: self.faulty_service}},
                 "policyTypes": ["Ingress", "Egress"],
                 "ingress": [],
                 "egress": [],

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -237,7 +237,7 @@ class ProblemRegistry:
             # ),
             # ==================== DIRECT K8S API ====================
             "ingress_misroute": lambda: IngressMisroute(path="/api", correct_service="frontend-service", wrong_service="recommendation-service"),
-            "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="payment-service"),
+            "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="recommendation"),
             # ==================== MULTIPLE INDEPENDENT FAILURES ====================
             # "port_misconfig_revoke_auth_wrong_svc_selector": \
             #     lambda: MultipleIndependentFailures(problems=[


### PR DESCRIPTION
Closes #759
The fault was using podSelector `app=payment-service` but HotelReservation pods use `io.kompose.service` as their label key and have no `payment-service`. The NetworkPolicy matched zero pods, making the fault a no-op.

This fix given in this PR is switch label key to `io.kompose.service` and target `recommendation`.

*Correct pod targeting*
```
Pial@node0:~$ kubectl get pods -n hotel-reservation -l io.kompose.service=recommendation
NAME                              READY   STATUS    RESTARTS        AGE
recommendation-6879fb56bf-rv2b9   1/1     Running   1 (8m14s ago)   8m29s
```

*After fault injection*
```
=== Hotel Reservation Connectivity Check ===
frontend:5000 -> CONNECTED
geo:8083 -> CONNECTED
profile:8081 -> CONNECTED
rate:8084 -> CONNECTED
recommendation:8085 -> BLOCKED
reservation:8087 -> CONNECTED
search:8082 -> CONNECTED
user:8086 -> CONNECTED
```

*After fault recovery*
```
=== Hotel Reservation Connectivity Check ===
frontend:5000 -> CONNECTED
geo:8083 -> CONNECTED
profile:8081 -> CONNECTED
rate:8084 -> CONNECTED
recommendation:8085 -> CONNECTED
reservation:8087 -> CONNECTED
search:8082 -> CONNECTED
user:8086 -> CONNECTED
```
