### PR TITLE
Replace Flannel with Calico

### DIFF
--- a/scripts/ansible/setup_cluster.yml
+++ b/scripts/ansible/setup_cluster.yml
@@ -591,13 +591,48 @@
     - name: Display cert_hash
       debug:
         msg: "cert_hash is {{ cert_hash }}"
-    - name: Install Flannel network plugin
+    # TODO: Remove this section once all clusters are migrated from Flannel to Calico
+    - name: Remove Flannel if present
       shell: |
-        kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
-      args:
-        creates: /etc/kubernetes/kube-flannel.yml
+        kubectl delete -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml --ignore-not-found=true
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
+      ignore_errors: yes
+
+    - name: Clean up Flannel CNI config files
+      shell: |
+        rm -f /etc/cni/net.d/10-flannel.conflist
+      become: yes
+      delegate_to: "{{ item }}"
+      loop: "{{ groups['control_nodes'] + groups['worker_nodes'] }}"
+      ignore_errors: yes
+    # END TODO
+
+    - name: Download Calico manifest
+      shell: |
+        curl -fsSL https://raw.githubusercontent.com/projectcalico/calico/v3.29.3/manifests/calico.yaml -o /tmp/calico.yaml
+
+    - name: Configure Calico to use cluster pod CIDR (10.244.0.0/16)
+      shell: |
+        sed -i 's|# - name: CALICO_IPV4POOL_CIDR|- name: CALICO_IPV4POOL_CIDR|' /tmp/calico.yaml
+        sed -i 's|#   value: "192.168.0.0/16"|  value: "10.244.0.0/16"|' /tmp/calico.yaml
+      become: yes
+
+    - name: Install Calico network plugin (supports NetworkPolicy enforcement)
+      shell: |
+        kubectl apply -f /tmp/calico.yaml
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+
+    - name: Wait for Calico pods to be ready
+      shell: |
+        kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+      retries: 3
+      delay: 10
+      register: calico_ready
+      until: calico_ready.rc == 0
     - name: Untaint the control plane to host pods
       shell: kubectl taint nodes $(hostname) node-role.kubernetes.io/control-plane:NoSchedule- || true
       environment:


### PR DESCRIPTION
Fixes #765 
This PR replaces Flannel with Calico v3.29.3 in the cluster setup playbook. Calico handles both pod networking and NetworkPolicy enforcement.

Changes made:
1. Remove Flannel install step
2. Add Flannel cleanup (safe to re-run on existing clusters, will remove this part in the future)
3. Download and apply Calico manifest, configured to use the existing pod CIDR (10.244.0.0/16)

*caico pods running successfully*
```bash
$ kubectl get pods -o wide -n kube-system | grep calico

calico-kube-controllers-78576cf5c8-z8pgx                                 1/1     Running   0          28m     10.244.1.16      node2.exp-242212.aiopslab-pg0.wisc.cloudlab.us   <none>           <none>
calico-node-26j5h                                                        1/1     Running   0          28m     128.105.144.41   node0.exp-242212.aiopslab-pg0.wisc.cloudlab.us   <none>           <none>
calico-node-lb7jf                                                        1/1     Running   0          28m     128.105.144.40   node1.exp-242212.aiopslab-pg0.wisc.cloudlab.us   <none>           <none>
calico-node-xkmg8                                                        1/1     Running   0          28m     128.105.144.42   node2.exp-242212.aiopslab-pg0.wisc.cloudlab.us   <none>           <none>
```

After running the `network_policy_block` fault now the probe on `reccomendation` service correctly returns valu 0.

*recommendations service probe result*
```
$  kubectl run test-pod --rm -i --image=curlimages/curl -n observe --restart=Never -- curl -s 'http://prometheus-server.observe.svc.cluster.local:80/api/v1/query?query=probe_success%7Binstance%3D%22recommendation.hotel-reservation%3A8085%22%7D' | jq

 {
        "metric": {
          "__name__": "probe_success",
          "instance": "recommendation.hotel-reservation:8085",
          "job": "blackbox-hotel-reservation",
          "namespace": "hotel-reservation"
        },
        "value": [
          1779398326.707,
          "0"
        ]
}
```

---

### Notes
1. Since the `scripts/ansible/setup_cluster.yml` was changed, the ansible playbook needs to be re-run on existing clusters to apply the fix.

2. Also, for existing clsuter we would need to delete the cached `cluster_baseline_state.json` so that during reconciliation it doesn't nuke Calico ClusterRoles/Bindings as _unexpected_ . Deleting the stale cached baseline means it gets recaptured with Calico.
```bash
rm ~/cache_dir/cluster_baseline_state.json
```

If already ran a fault and the Calico RBAC got deleted then remove the stale state and restore the permissions using the following command:
```bash
rm ~/cache_dir/cluster_baseline_state.json
kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.3/manifests/calico.yaml
```