### PR TITLE
Add ImagePullBackOff problem variants for Hotel Reservation

### DIFF
--- a/sregym/conductor/oracles/image_pull_backoff_mitigation.py
+++ b/sregym/conductor/oracles/image_pull_backoff_mitigation.py
@@ -1,0 +1,92 @@
+import time
+
+from sregym.conductor.oracles.base import Oracle
+
+_ROLLOUT_SETTLE_SECONDS = 60
+_ROLLOUT_POLL_INTERVAL = 5
+_INVALID_TAG = "nonexistent-tag-xyzzy"
+
+
+class ImagePullBackoffMitigationOracle(Oracle):
+    """Stricter mitigation oracle for ImagePullBackoff problems.
+
+    Checks:
+    1. The faulty deployment still exists (not deleted as a shortcut).
+    2. The deployment has at least 1 desired replica (not scaled to 0).
+    3. The container image no longer uses the injected invalid tag.
+    4. All pods in the namespace are Running and ready.
+    """
+
+    importance = 1.0
+
+    def __init__(self, problem, faulty_service: str, invalid_tag: str = _INVALID_TAG):
+        super().__init__(problem)
+        self.faulty_service = faulty_service
+        self.invalid_tag = invalid_tag
+
+    def _wait_for_rollouts(self, kubectl, namespace):
+        deadline = time.monotonic() + _ROLLOUT_SETTLE_SECONDS
+        while time.monotonic() < deadline:
+            deployments = kubectl.list_deployments(namespace)
+            all_settled = all(
+                (dep.status.updated_replicas or 0) >= (dep.spec.replicas or 1)
+                and (dep.status.ready_replicas or 0) >= (dep.spec.replicas or 1)
+                and (dep.status.unavailable_replicas or 0) == 0
+                for dep in deployments.items
+            )
+            if all_settled:
+                return
+            time.sleep(_ROLLOUT_POLL_INTERVAL)
+        print("⚠️ Timed out waiting for rollouts to settle; evaluating current state")
+
+    def evaluate(self) -> dict:
+        print("== Mitigation Evaluation (ImagePullBackoff) ==")
+
+        kubectl = self.problem.kubectl
+        namespace = self.problem.namespace
+
+        # 1. Deployment must still exist
+        try:
+            deployment = kubectl.get_deployment(self.faulty_service, namespace)
+        except Exception:
+            print(f"❌ Deployment '{self.faulty_service}' not found — deleting it is not a valid fix")
+            return {"success": False}
+
+        # 2. Deployment must have >= 1 desired replica
+        desired = deployment.spec.replicas or 0
+        if desired < 1:
+            print(
+                f"❌ Deployment '{self.faulty_service}' scaled to {desired} replicas — scaling to 0 is not a valid fix"
+            )
+            return {"success": False}
+
+        # 3. Container image must not still use the invalid tag
+        containers = deployment.spec.template.spec.containers
+        for container in containers:
+            if self.invalid_tag in (container.image or ""):
+                print(f"❌ Container '{container.name}' still uses invalid image: {container.image}")
+                return {"success": False}
+        print(f"✅ Deployment '{self.faulty_service}' image tag is fixed")
+
+        # 4. All pods must be Running and ready
+        self._wait_for_rollouts(kubectl, namespace)
+        pod_list = kubectl.list_pods(namespace)
+
+        if not pod_list.items:
+            print("❌ No pods found in namespace")
+            return {"success": False}
+
+        for pod in pod_list.items:
+            if pod.status.phase != "Running":
+                print(f"❌ Pod {pod.metadata.name} is in phase: {pod.status.phase}")
+                return {"success": False}
+            for cs in pod.status.container_statuses or []:
+                if cs.state.waiting and cs.state.waiting.reason:
+                    print(f"❌ Container {cs.name} is waiting: {cs.state.waiting.reason}")
+                    return {"success": False}
+                if not cs.ready:
+                    print(f"❌ Container {cs.name} is not ready")
+                    return {"success": False}
+
+        print("✅ All pods are Running and ready")
+        return {"success": True}

--- a/sregym/conductor/problems/image_pull_backoff.py
+++ b/sregym/conductor/problems/image_pull_backoff.py
@@ -1,0 +1,55 @@
+from sregym.conductor.oracles.image_pull_backoff_mitigation import ImagePullBackoffMitigationOracle
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.problems.base import Problem
+from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+
+class ImagePullBackoff(Problem):
+    """Problem that injects an invalid container image tag, causing ImagePullBackOff.
+
+    This simulates a real-world scenario where a deployment is updated with a
+    non-existent image tag (e.g., after a bad push, a typo, or a deleted registry tag),
+    causing pods to fail to start with ErrImagePull / ImagePullBackOff status.
+    """
+
+    def __init__(self, app_name: str = "hotel_reservation", faulty_service: str = "search"):
+        self.app_name = app_name
+        self.faulty_service = faulty_service
+        self.app = HotelReservation()
+        self.namespace = self.app.namespace
+        super().__init__(app=self.app, namespace=self.namespace)
+
+        self.kubectl = KubeCtl()
+        self.root_cause = self.build_structured_root_cause(
+            component=f"deployment/{self.faulty_service}",
+            namespace=self.namespace,
+            description=(
+                f"The {self.faulty_service} deployment was updated with a non-existent container image tag. "
+                "Kubernetes cannot pull the image from the registry, causing the pod to enter "
+                "ErrImagePull and then ImagePullBackOff status, making the service unavailable."
+            ),
+        )
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+
+        self.app.create_workload()
+        self.mitigation_oracle = ImagePullBackoffMitigationOracle(
+            problem=self,
+            faulty_service=self.faulty_service,
+        )
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+        injector = VirtualizationFaultInjector(namespace=self.namespace)
+        injector.inject_image_pull_backoff(microservices=[self.faulty_service])
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        injector = VirtualizationFaultInjector(namespace=self.namespace)
+        injector.recover_image_pull_backoff(microservices=[self.faulty_service])
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/image_pull_wrong_secret.py
+++ b/sregym/conductor/problems/image_pull_wrong_secret.py
@@ -1,0 +1,60 @@
+from sregym.conductor.oracles.image_pull_backoff_mitigation import ImagePullBackoffMitigationOracle
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.problems.base import Problem
+from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+_FAKE_REGISTRY = "fake-private-registry.sregym.internal"
+
+
+class ImagePullWrongSecret(Problem):
+    """Problem that injects incorrect registry credentials causing ImagePullBackOff.
+
+    This simulates a real-world scenario where a deployment is updated to pull
+    from a private container registry but the imagePullSecret contains invalid
+    credentials (or the registry is unreachable), causing the pod to fail image
+    pull with ErrImagePull / ImagePullBackOff.
+    """
+
+    def __init__(self, app_name: str = "hotel_reservation", faulty_service: str = "profile"):
+        self.app_name = app_name
+        self.faulty_service = faulty_service
+        self.app = HotelReservation()
+        self.namespace = self.app.namespace
+        super().__init__(app=self.app, namespace=self.namespace)
+
+        self.kubectl = KubeCtl()
+        self.root_cause = self.build_structured_root_cause(
+            component=f"deployment/{self.faulty_service}",
+            namespace=self.namespace,
+            description=(
+                f"The {self.faulty_service} deployment was configured to pull its container image "
+                f"from a private registry ({_FAKE_REGISTRY}) using an imagePullSecret with invalid "
+                "credentials. Kubernetes cannot authenticate to the registry, causing the pod to "
+                "enter ErrImagePull and then ImagePullBackOff status."
+            ),
+        )
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+
+        self.app.create_workload()
+        self.mitigation_oracle = ImagePullBackoffMitigationOracle(
+            problem=self,
+            faulty_service=self.faulty_service,
+            invalid_tag=_FAKE_REGISTRY,
+        )
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+        injector = VirtualizationFaultInjector(namespace=self.namespace)
+        injector.inject_wrong_pull_secret(microservices=[self.faulty_service])
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        injector = VirtualizationFaultInjector(namespace=self.namespace)
+        injector.recover_wrong_pull_secret(microservices=[self.faulty_service])
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -16,6 +16,8 @@ from sregym.conductor.problems.env_variable_shadowing import EnvVariableShadowin
 from sregym.conductor.problems.failed_readiness_probe import FailedReadinessProbe
 from sregym.conductor.problems.faulty_image_correlated import FaultyImageCorrelated
 from sregym.conductor.problems.gc_capacity_degradation import GCCapacityDegradation
+from sregym.conductor.problems.image_pull_backoff import ImagePullBackoff
+from sregym.conductor.problems.image_pull_wrong_secret import ImagePullWrongSecret
 from sregym.conductor.problems.image_slow_load import ImageSlowLoad
 from sregym.conductor.problems.incorrect_image import IncorrectImage
 from sregym.conductor.problems.incorrect_port_assignment import IncorrectPortAssignment
@@ -244,6 +246,8 @@ class ProblemRegistry:
             "ingress_misroute": lambda: IngressMisroute(path="/api", correct_service="frontend-service", wrong_service="recommendation-service"),
             "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="recommendation"),
             "admission_webhook_outage_hotel_reservation": lambda: AdmissionWebhookOutage(app_name="hotel_reservation", faulty_service="recommendation"),
+            "image_pull_backoff_hotel_reservation": lambda: ImagePullBackoff(app_name="hotel_reservation", faulty_service="search"),
+            "image_pull_wrong_secret_hotel_reservation": lambda: ImagePullWrongSecret(app_name="hotel_reservation", faulty_service="profile"),
             # ==================== MULTIPLE INDEPENDENT FAILURES ====================
             # "port_misconfig_revoke_auth_wrong_svc_selector": \
             #     lambda: MultipleIndependentFailures(problems=[

--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -1161,6 +1161,125 @@ class VirtualizationFaultInjector(FaultInjector):
 
             print(f"Recovered from liveness probe misconfiguration fault for service: {service}")
 
+    def inject_image_pull_backoff(self, microservices: list[str]):
+        """Inject a fault by setting an invalid container image tag, causing ImagePullBackOff."""
+        for service in microservices:
+            deployment_yaml = self._get_deployment_yaml(service)
+            original_deployment_yaml = copy.deepcopy(deployment_yaml)
+
+            containers = deployment_yaml["spec"]["template"]["spec"]["containers"]
+            for container in containers:
+                image_parts = container["image"].rsplit(":", 1)
+                container["image"] = f"{image_parts[0]}:nonexistent-tag-xyzzy"
+
+            modified_yaml_path = self._write_yaml_to_file(service, deployment_yaml)
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {modified_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+            # Save original YAML for recovery (overwrites the temp path)
+            self._write_yaml_to_file(service, original_deployment_yaml)
+
+            print(f"Injected invalid image tag for service: {service}")
+
+    def recover_image_pull_backoff(self, microservices: list[str]):
+        """Recover from ImagePullBackOff by restoring the original container image."""
+        for service in microservices:
+            original_yaml_path = f"/tmp/{service}_modified.yaml"
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {original_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+            self.kubectl.wait_for_ready(self.namespace)
+
+            print(f"Recovered from ImagePullBackOff fault for service: {service}")
+
+    def inject_wrong_pull_secret(self, microservices: list[str]):
+        """Simulate wrong registry credentials by pointing to a fake private registry with an invalid pull secret."""
+        import base64
+        import json
+
+        fake_registry = "fake-private-registry.sregym.internal"
+        secret_name = "fake-registry-credentials"
+
+        # Build a .dockerconfigjson with fake credentials
+        fake_auth = base64.b64encode(b"fakeuser:fakepassword").decode()
+        docker_config = {"auths": {fake_registry: {"auth": fake_auth}}}
+        docker_config_b64 = base64.b64encode(json.dumps(docker_config).encode()).decode()
+
+        secret_manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": secret_name, "namespace": self.namespace},
+            "type": "kubernetes.io/dockerconfigjson",
+            "data": {".dockerconfigjson": docker_config_b64},
+        }
+        secret_path = "/tmp/fake-registry-secret.yaml"
+        with open(secret_path, "w") as f:
+            yaml.dump(secret_manifest, f)
+        self.kubectl.exec_command(f"kubectl apply -f {secret_path} -n {self.namespace}")
+
+        for service in microservices:
+            deployment_yaml = self._get_deployment_yaml(service)
+            original_deployment_yaml = copy.deepcopy(deployment_yaml)
+
+            # Point image at the fake private registry
+            containers = deployment_yaml["spec"]["template"]["spec"]["containers"]
+            for container in containers:
+                image_name = container["image"].split("/")[-1]
+                container["image"] = f"{fake_registry}/{image_name}"
+
+            # Add imagePullSecrets
+            deployment_yaml["spec"]["template"]["spec"]["imagePullSecrets"] = [{"name": secret_name}]
+
+            modified_yaml_path = self._write_yaml_to_file(service, deployment_yaml)
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {modified_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+            # Save original for recovery
+            self._write_yaml_to_file(service, original_deployment_yaml)
+
+            print(f"Injected wrong pull secret fault for service: {service}")
+
+    def recover_wrong_pull_secret(self, microservices: list[str]):
+        """Recover from wrong pull secret by restoring the original deployment and removing the fake secret."""
+        for service in microservices:
+            original_yaml_path = f"/tmp/{service}_modified.yaml"
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {original_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+        self.kubectl.exec_command(
+            f"kubectl delete secret fake-registry-credentials -n {self.namespace} --ignore-not-found"
+        )
+        self.kubectl.wait_for_ready(self.namespace)
+        print(f"Recovered from wrong pull secret fault for services: {microservices}")
+
     # Duplicate PVC mounts multiple replicas share ReadWriteOnce PVC causing mount conflict
     def inject_duplicate_pvc_mounts(self, microservices: list[str]):
         for service in microservices:

--- a/sregym/observer/loki/loki-values.yaml
+++ b/sregym/observer/loki/loki-values.yaml
@@ -90,6 +90,12 @@ monitoring:
 test:
   enabled: false
 
+# Disable cache components to reduce memory usage on local clusters
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
 # Resource limits
 resources:
   limits:


### PR DESCRIPTION
## Real-world failure stories

### Problem 1 — Wrong image tag (`image_pull_backoff_hotel_reservation`)

On December 17, 2023, **Logto** (an open-source authentication platform) suffered an 18-minute full outage. An automated GitHub Container Registry image retention workflow deleted production image layers that were untagged but still referenced by the live `prod` tag (a multi-arch manifest structure). When Kubernetes tried to schedule new pods, it could not pull the image, causing `ImagePullBackOff` across all instances.

> Reference: https://blog.logto.io/postmortem-docker-image-not-found

### Problem 2 — Invalid registry credentials (`image_pull_wrong_secret_hotel_reservation`)

In June 2022, **Airwallex** (a payments company) experienced nearly a full day of degradation after a GKE cluster auto-upgrade broke the `gke-metadata-server` endpoint. Nodes could no longer fetch Google Cloud credentials for pulling images from GCR. All image pulls failed with authentication errors, preventing pod restarts and new deployments.

> Reference: https://medium.com/airwallex-engineering/how-we-deal-with-a-google-kubernetes-engine-gke-metadata-server-outage-b627958ee7ad

---

## How the failures are simulated on SREGym

**Problem 1** — The `search` deployment's container image tag is replaced with `nonexistent-tag-xyzzy` (a tag that does not exist in the registry). Kubernetes attempts to pull it, fails, and the pod enters `ErrImagePull` → `ImagePullBackOff`.

**Problem 2** — The `profile` deployment's image is pointed at a fake private registry (`fake-private-registry.sregym.internal`) and an `imagePullSecret` with invalid base64-encoded credentials is injected. Kubernetes cannot authenticate to the unreachable registry, causing the same `ErrImagePull` → `ImagePullBackOff` failure but with a distinct root cause.

Both faults use `VirtualizationFaultInjector` and target Hotel Reservation microservices not already used by other problems (`search` and `profile`). They are distinct from the existing `incorrect_image` problem which targets AstronomyShop using `ApplicationFaultInjector`.

---

## Problem runtime behavior

1. All Hotel Reservation pods start healthy.
2. Fault is injected — the target pod immediately enters `ErrImagePull` then `ImagePullBackOff`.
3. All other pods remain `Running`; only the faulted service is affected.
4. Agent investigates with `kubectl get pods`, `kubectl describe pod`, reads the image pull error event.
5. **Diagnosis stage**: agent identifies the root cause (wrong tag / bad credentials).
6. **Mitigation stage**: agent patches the deployment to restore a valid image and removes the fake pull secret (Problem 2).
7. A custom `ImagePullBackoffMitigationOracle` verifies the fix is genuine — it rejects shortcuts such as deleting the deployment or scaling it to zero replicas.

---

## Agent behavior

Both problems were tested end-to-end using the SREGym CLI as the human agent with `gemini/gemini-2.5-pro` as judge:

| Problem | Diagnosis score | Mitigation | TTL | TTM |
|---|---|---|---|---|
| `image_pull_backoff_hotel_reservation` | 100/100 ✅ | success ✅ | 56s | 92s |
| `image_pull_wrong_secret_hotel_reservation` | 100/100 ✅ | success ✅ | 80s | 114s |

The oracle correctly rejected shortcuts (deleting the deployment, scaling to 0 replicas) and only passed when the image was genuinely fixed.

---

## Files changed

- `sregym/conductor/problems/image_pull_backoff.py` — new problem (wrong tag)
- `sregym/conductor/problems/image_pull_wrong_secret.py` — new problem (bad credentials)
- `sregym/conductor/oracles/image_pull_backoff_mitigation.py` — strict mitigation oracle
- `sregym/generators/fault/inject_virtual.py` — two new injector/recovery method pairs
- `sregym/conductor/problems/registry.py` — register both problems
- `sregym/observer/loki/loki-values.yaml` — disable chunksCache/resultsCache for local kind clusters (fixes OOM on machines with < 16GB RAM)

/validate-problem image_pull_backoff_hotel_reservation
/validate-problem image_pull_wrong_secret_hotel_reservation