### PR TITLE
Add admission webhook TLS mismatch problem

### DIFF
--- a/sregym/conductor/problems/admission_webhook_tls_mismatch.py
+++ b/sregym/conductor/problems/admission_webhook_tls_mismatch.py
@@ -1,0 +1,382 @@
+"""Problem: admission webhook TLS trust mismatch blocks pod admission in an app namespace.
+
+This models a production-style Kubernetes failure during webhook certificate
+rotation: a ValidatingWebhookConfiguration with ``failurePolicy: Fail`` points
+at a reachable HTTPS webhook backend, but its ``caBundle`` is stale/wrong.
+The kube-apiserver therefore cannot verify the webhook server's TLS certificate
+and rejects pod CREATE admission requests.
+
+In SREGym we scope the failure to a single application namespace via
+``namespaceSelector`` and then delete one pod of a single-replica deployment
+(e.g. ``recommendation`` in hotel-reservation). The ReplicaSet's recreate
+attempt hits the webhook and is rejected with a TLS/x509 admission error, so the
+deployment stays under-replicated even though its spec, image, service, and
+resources are healthy.
+
+Valid mitigations include deleting the webhook config, changing
+``failurePolicy`` to ``Ignore``, or repairing the webhook TLS trust chain by
+restoring a valid ``caBundle``.
+"""
+
+import base64
+import subprocess
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+from sregym.conductor.oracles.deployment_readiness import DeploymentReadinessOracle
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.problems.base import Problem
+from sregym.service.apps.astronomy_shop import AstronomyShop
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.apps.social_network import SocialNetwork
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+
+class AdmissionWebhookTLSMismatch(Problem):
+    """Inject a reachable admission webhook backend but configure the
+    ValidatingWebhookConfiguration with a stale/wrong caBundle."""
+
+    APPS = {
+        "hotel_reservation": HotelReservation,
+        "social_network": SocialNetwork,
+        "astronomy_shop": AstronomyShop,
+    }
+
+    WEBHOOK_NAME = "pod-policy.validation.k8s.io"
+    BACKEND_SVC_NAME = "pod-policy-webhook"
+    BACKEND_SVC_NAMESPACE = "policy-system"
+    BACKEND_DEPLOYMENT_NAME = "pod-policy-webhook"
+
+    def __init__(self, app_name: str = "hotel_reservation", faulty_service: str = "recommendation"):
+        if app_name not in self.APPS:
+            raise ValueError(f"Unsupported app name: {app_name}")
+
+        self.app_name = app_name
+        self.faulty_service = faulty_service
+        self.app = self.APPS[app_name]()
+        super().__init__(app=self.app, namespace=self.app.namespace)
+
+        self.namespace = self.app.namespace
+        self.kubectl = KubeCtl()
+        self.admission_api = client.AdmissionregistrationV1Api()
+        self.core_api = client.CoreV1Api()
+        self.wrong_ca_bundle = None
+
+        self.root_cause = self.build_structured_root_cause(
+            component=f"ValidatingWebhookConfiguration/{self.WEBHOOK_NAME}",
+            namespace=self.namespace,
+            description=(
+                f"A cluster-scoped ValidatingWebhookConfiguration named `{self.WEBHOOK_NAME}` has been installed "
+                f"with `failurePolicy: Fail` and a `namespaceSelector` scoped to the `{self.namespace}` namespace. "
+                f"The webhook intercepts pod CREATE operations and points to the reachable HTTPS service "
+                f"`{self.BACKEND_SVC_NAMESPACE}/{self.BACKEND_SVC_NAME}`, but the webhook configuration contains "
+                "a stale/wrong `caBundle`. As a result, the kube-apiserver cannot verify the webhook server's TLS "
+                "certificate and rejects pod creation with a `failed calling webhook` / `x509` certificate error. "
+                f"The ReplicaSet controlling the `{self.faulty_service}` deployment cannot recreate pods after "
+                "they are deleted, leaving the deployment under-replicated. The deployment itself is healthy; it is "
+                "an innocent victim of a cluster-scoped admission TLS trust dependency. The mitigation is to remove "
+                "the broken ValidatingWebhookConfiguration, change `failurePolicy` to `Ignore`, or repair the "
+                "webhook TLS trust chain by restoring the correct `caBundle`."
+            ),
+        )
+
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.app.create_workload()
+        self.mitigation_oracle = DeploymentReadinessOracle(problem=self)
+
+    def _run(self, args, **kwargs):
+        return subprocess.run(args, check=True, text=True, **kwargs)
+
+    def _generate_tls_material(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            ca_key = d / "ca.key"
+            ca_crt = d / "ca.crt"
+            wrong_ca_key = d / "wrong-ca.key"
+            wrong_ca_crt = d / "wrong-ca.crt"
+            server_key = d / "server.key"
+            server_csr = d / "server.csr"
+            server_crt = d / "server.crt"
+            ext = d / "server.ext"
+
+            self._run(["openssl", "genrsa", "-out", str(ca_key), "2048"], stdout=subprocess.DEVNULL)
+            self._run([
+                "openssl", "req", "-x509", "-new", "-nodes",
+                "-key", str(ca_key),
+                "-sha256", "-days", "365",
+                "-subj", "/CN=sregym-real-webhook-ca",
+                "-out", str(ca_crt),
+            ], stdout=subprocess.DEVNULL)
+
+            self._run(["openssl", "genrsa", "-out", str(wrong_ca_key), "2048"], stdout=subprocess.DEVNULL)
+            self._run([
+                "openssl", "req", "-x509", "-new", "-nodes",
+                "-key", str(wrong_ca_key),
+                "-sha256", "-days", "365",
+                "-subj", "/CN=sregym-stale-wrong-ca",
+                "-out", str(wrong_ca_crt),
+            ], stdout=subprocess.DEVNULL)
+
+            self._run(["openssl", "genrsa", "-out", str(server_key), "2048"], stdout=subprocess.DEVNULL)
+            self._run([
+                "openssl", "req", "-new",
+                "-key", str(server_key),
+                "-subj", f"/CN={self.BACKEND_SVC_NAME}.{self.BACKEND_SVC_NAMESPACE}.svc",
+                "-out", str(server_csr),
+            ], stdout=subprocess.DEVNULL)
+
+            ext.write_text(
+                f"subjectAltName=DNS:{self.BACKEND_SVC_NAME}.{self.BACKEND_SVC_NAMESPACE}.svc,"
+                f"DNS:{self.BACKEND_SVC_NAME}.{self.BACKEND_SVC_NAMESPACE}.svc.cluster.local\n"
+            )
+
+            self._run([
+                "openssl", "x509", "-req",
+                "-in", str(server_csr),
+                "-CA", str(ca_crt),
+                "-CAkey", str(ca_key),
+                "-CAcreateserial",
+                "-out", str(server_crt),
+                "-days", "365",
+                "-sha256",
+                "-extfile", str(ext),
+            ], stdout=subprocess.DEVNULL)
+
+            return {
+                "tls_crt_b64": base64.b64encode(server_crt.read_bytes()).decode(),
+                "tls_key_b64": base64.b64encode(server_key.read_bytes()).decode(),
+                "wrong_ca_bundle": base64.b64encode(wrong_ca_crt.read_bytes()).decode(),
+            }
+
+    def _ensure_webhook_backend(self):
+        print("[Backend] Creating reachable HTTPS webhook backend with intentionally mismatched CA trust")
+        material = self._generate_tls_material()
+        self.wrong_ca_bundle = material["wrong_ca_bundle"]
+
+        server_code = r'''
+import json
+import ssl
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0") or 0)
+        raw = self.rfile.read(length)
+        uid = ""
+        try:
+            uid = json.loads(raw).get("request", {}).get("uid", "")
+        except Exception:
+            pass
+
+        response = {
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "response": {"uid": uid, "allowed": True},
+        }
+        data = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt, *args):
+        return
+
+httpd = HTTPServer(("0.0.0.0", 8443), Handler)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain("/certs/tls.crt", "/certs/tls.key")
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+httpd.serve_forever()
+'''
+
+        manifest = f"""
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {self.BACKEND_SVC_NAMESPACE}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pod-policy-webhook-tls
+  namespace: {self.BACKEND_SVC_NAMESPACE}
+type: kubernetes.io/tls
+data:
+  tls.crt: {material["tls_crt_b64"]}
+  tls.key: {material["tls_key_b64"]}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-policy-webhook-server
+  namespace: {self.BACKEND_SVC_NAMESPACE}
+data:
+  server.py: |
+{textwrap.indent(server_code.strip(), "    ")}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {self.BACKEND_DEPLOYMENT_NAME}
+  namespace: {self.BACKEND_SVC_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {self.BACKEND_DEPLOYMENT_NAME}
+  template:
+    metadata:
+      labels:
+        app: {self.BACKEND_DEPLOYMENT_NAME}
+    spec:
+      containers:
+      - name: webhook
+        image: python:3.12-alpine
+        imagePullPolicy: IfNotPresent
+        command: ["python", "/app/server.py"]
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - name: server-code
+          mountPath: /app
+        - name: tls
+          mountPath: /certs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      volumes:
+      - name: server-code
+        configMap:
+          name: pod-policy-webhook-server
+      - name: tls
+        secret:
+          secretName: pod-policy-webhook-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {self.BACKEND_SVC_NAME}
+  namespace: {self.BACKEND_SVC_NAMESPACE}
+spec:
+  selector:
+    app: {self.BACKEND_DEPLOYMENT_NAME}
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8443
+"""
+
+        self._run(["kubectl", "apply", "-f", "-"], input=manifest)
+        self._run([
+            "kubectl", "-n", self.BACKEND_SVC_NAMESPACE,
+            "rollout", "status", f"deployment/{self.BACKEND_DEPLOYMENT_NAME}",
+            "--timeout=180s",
+        ])
+
+    def _build_webhook_body(self) -> dict:
+        if not self.wrong_ca_bundle:
+            raise RuntimeError("wrong_ca_bundle is not initialized; call _ensure_webhook_backend first")
+
+        return {
+            "apiVersion": "admissionregistration.k8s.io/v1",
+            "kind": "ValidatingWebhookConfiguration",
+            "metadata": {"name": self.WEBHOOK_NAME},
+            "webhooks": [
+                {
+                    "name": self.WEBHOOK_NAME,
+                    "clientConfig": {
+                        "service": {
+                            "name": self.BACKEND_SVC_NAME,
+                            "namespace": self.BACKEND_SVC_NAMESPACE,
+                            "path": "/validate",
+                            "port": 443,
+                        },
+                        "caBundle": self.wrong_ca_bundle,
+                    },
+                    "rules": [
+                        {
+                            "apiGroups": [""],
+                            "apiVersions": ["v1"],
+                            "operations": ["CREATE"],
+                            "resources": ["pods"],
+                            "scope": "Namespaced",
+                        }
+                    ],
+                    "failurePolicy": "Fail",
+                    "sideEffects": "None",
+                    "admissionReviewVersions": ["v1"],
+                    "namespaceSelector": {
+                        "matchLabels": {"kubernetes.io/metadata.name": self.namespace},
+                    },
+                    "timeoutSeconds": 5,
+                }
+            ],
+        }
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+
+        self._ensure_webhook_backend()
+
+        webhook = self._build_webhook_body()
+        try:
+            self.admission_api.create_validating_webhook_configuration(body=webhook)
+            print(f"Created ValidatingWebhookConfiguration: {self.WEBHOOK_NAME}")
+        except ApiException as e:
+            if e.status == 409:
+                print(f"ValidatingWebhookConfiguration {self.WEBHOOK_NAME} exists; replacing")
+                existing = self.admission_api.read_validating_webhook_configuration(name=self.WEBHOOK_NAME)
+                webhook["metadata"]["resourceVersion"] = existing.metadata.resource_version
+                self.admission_api.replace_validating_webhook_configuration(name=self.WEBHOOK_NAME, body=webhook)
+            else:
+                raise
+
+        time.sleep(2)
+
+        pods = self.core_api.list_namespaced_pod(
+            namespace=self.namespace,
+            label_selector=f"io.kompose.service={self.faulty_service}",
+        )
+        if not pods.items:
+            raise RuntimeError(f"No pods found for service '{self.faulty_service}' in namespace '{self.namespace}'")
+
+        target = pods.items[0].metadata.name
+        self.core_api.delete_namespaced_pod(
+            name=target,
+            namespace=self.namespace,
+            body=client.V1DeleteOptions(grace_period_seconds=0),
+        )
+        print(f"Deleted pod {target}; ReplicaSet recreate will be blocked by webhook TLS trust failure")
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        try:
+            self.admission_api.delete_validating_webhook_configuration(name=self.WEBHOOK_NAME)
+            print(f"Deleted ValidatingWebhookConfiguration: {self.WEBHOOK_NAME}")
+        except ApiException as e:
+            if e.status == 404:
+                print(f"ValidatingWebhookConfiguration {self.WEBHOOK_NAME} already absent")
+            else:
+                raise
+
+        subprocess.run(
+            ["kubectl", "delete", "namespace", self.BACKEND_SVC_NAMESPACE, "--ignore-not-found"],
+            check=False,
+            text=True,
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/admission_webhook_tls_mismatch.py
+++ b/sregym/conductor/problems/admission_webhook_tls_mismatch.py
@@ -110,7 +110,7 @@ class AdmissionWebhookTLSMismatch(Problem):
                 "openssl", "req", "-x509", "-new", "-nodes",
                 "-key", str(ca_key),
                 "-sha256", "-days", "365",
-                "-subj", "/CN=sregym-real-webhook-ca",
+                "-subj", "/CN=platform-services-ca",
                 "-out", str(ca_crt),
             ], stdout=subprocess.DEVNULL)
 
@@ -119,7 +119,7 @@ class AdmissionWebhookTLSMismatch(Problem):
                 "openssl", "req", "-x509", "-new", "-nodes",
                 "-key", str(wrong_ca_key),
                 "-sha256", "-days", "365",
-                "-subj", "/CN=sregym-stale-wrong-ca",
+                "-subj", "/CN=cluster-policy-ca",
                 "-out", str(wrong_ca_crt),
             ], stdout=subprocess.DEVNULL)
 

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -6,6 +6,7 @@ from sregym.conductor.problems.ad_service_failure import AdServiceFailure
 from sregym.conductor.problems.ad_service_high_cpu import AdServiceHighCpu
 from sregym.conductor.problems.ad_service_manual_gc import AdServiceManualGc
 from sregym.conductor.problems.admission_webhook_outage import AdmissionWebhookOutage
+from sregym.conductor.problems.admission_webhook_tls_mismatch import AdmissionWebhookTLSMismatch
 from sregym.conductor.problems.assign_non_existent_node import AssignNonExistentNode
 from sregym.conductor.problems.auth_miss_mongodb import MongoDBAuthMissing
 from sregym.conductor.problems.capacity_decrease_rpc_retry_storm import CapacityDecreaseRPCRetryStorm
@@ -244,6 +245,7 @@ class ProblemRegistry:
             "ingress_misroute": lambda: IngressMisroute(path="/api", correct_service="frontend-service", wrong_service="recommendation-service"),
             "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="recommendation"),
             "admission_webhook_outage_hotel_reservation": lambda: AdmissionWebhookOutage(app_name="hotel_reservation", faulty_service="recommendation"),
+            "admission_webhook_tls_mismatch_hotel_reservation": lambda: AdmissionWebhookTLSMismatch(app_name="hotel_reservation", faulty_service="recommendation"),
             # ==================== MULTIPLE INDEPENDENT FAILURES ====================
             # "port_misconfig_revoke_auth_wrong_svc_selector": \
             #     lambda: MultipleIndependentFailures(problems=[


### PR DESCRIPTION
Adds a new SREGym problem simulating an admission-webhook TLS trust mismatch in the Hotel Reservation app. The failure is a production-style Kubernetes admission-control issue: the webhook backend is reachable, but the `ValidatingWebhookConfiguration` contains a stale/wrong `caBundle`, so the kube-apiserver rejects pod CREATE requests with an `x509` verification error.

The PR is limited to the new problem plus registry wiring.

---

## 1. The real-world failure story

Admission webhooks sit directly in the Kubernetes API request path. If a `ValidatingWebhookConfiguration` has `failurePolicy: Fail`, then matching requests are rejected whenever the webhook call fails. This is risky because the affected application can be healthy, but Kubernetes may still be unable to create replacement pods.

This problem models a certificate-rotation / CA-drift failure: the webhook backend is reachable and serving HTTPS, but the `caBundle` stored in the `ValidatingWebhookConfiguration` is stale or wrong. The kube-apiserver therefore cannot verify the webhook server certificate and rejects pod CREATE admission requests with an `x509` error.

Several real-world reports anchor this simulation:

- **OPA cert-controller, October 2020** — [“CA and Server certificate potentially get updated before ValidatingWebhookConfiguration”](https://github.com/open-policy-agent/cert-controller/issues/13). The issue describes the risk this problem models: the CA is renewed, but the `ValidatingWebhookConfiguration` may still contain the old CA, so webhook calls can fail.

- **ingress-nginx, August 2020** — [“apply ingress rule error after install ingress-nginx: x509 certificate is not valid”](https://github.com/kubernetes/ingress-nginx/issues/5968). A validating admission webhook rejects resource creation because the serving certificate does not validate for the webhook service DNS name.

- **ingress-nginx, January 2022** — [“Kubernetes: ingress-nginx-controller-admission error, x509 certificate signed by unknown authority”](https://fabianlee.org/2022/01/29/nginx-ingress-nginx-controller-admission-error-x509-certificate-signed-by-unknown-authority/). The writeup shows an admission-controller `x509` failure after reinstalling ingress-nginx, with a workaround that patches the validating webhook `caBundle`.

- **cert-manager, September 2023** — [“Webhook inject-ca-from annotation causes downtime”](https://github.com/cert-manager/cert-manager/issues/6350). The report describes a rotation race where the API server accepts one certificate chain while the webhook server still serves another, causing webhook downtime.

The SREGym scenario keeps the same failure class but makes it reproducible: the backend exists and is reachable, while the trust relationship between the kube-apiserver and webhook is intentionally broken.

---

## 2. How the failure is simulated in SREGym

The new problem class lives at:

`sregym/conductor/problems/admission_webhook_tls_mismatch.py`

and is registered as:

`admission_webhook_tls_mismatch_hotel_reservation`

The fault injection does the following:

1. Creates a temporary `policy-system` namespace.
2. Generates TLS material:
   - one CA that signs the webhook server certificate,
   - a separate wrong CA used as the stale `caBundle`.
3. Deploys a small HTTPS webhook backend as `policy-system/pod-policy-webhook`.
4. Installs a `ValidatingWebhookConfiguration` named `pod-policy.validation.k8s.io`.
5. Scopes the webhook to the target app namespace using `namespaceSelector`.
6. Configures the webhook with:
   - `failurePolicy: Fail`
   - pod `CREATE` admission rules
   - the reachable webhook service
   - the intentionally wrong `caBundle`
7. Deletes one pod from the `recommendation` deployment so the ReplicaSet has to recreate it.

The recreate attempt then hits the webhook and fails during TLS verification.

---

## 3. Problem runtime behaviour

Verified locally through the SREGym CLI and Kubernetes events.

| Phase | Observation |
|---|---|
| App deploy | Hotel Reservation deploys normally before fault injection |
| Backend setup | `policy-system/pod-policy-webhook` is created as a reachable HTTPS service |
| Fault injection | `recommendation` pod is deleted |
| Symptom | `recommendation` ReplicaSet has `desired=1`, `current=0`, `ready=0` |
| Diagnostic signal | ReplicaSet events show `failed calling webhook` with an `x509` certificate error |
| Blast radius | Scoped to `hotel-reservation` through `namespaceSelector` |
| Recovery | Deleting the broken webhook allows the ReplicaSet to recreate the missing pod |

The key event observed locally:

```text
failed calling webhook "pod-policy.validation.k8s.io":
tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

This is the main diagnostic signal an agent should follow. The pod is not failing because of its own image, command, memory, or service config; pod creation is being rejected by admission control.

---

## 4. Mitigation and validation

Valid mitigations:

- delete the broken `ValidatingWebhookConfiguration`,
- patch `failurePolicy` from `Fail` to `Ignore`,
- or repair the webhook trust chain by restoring the correct `caBundle`.

Local mitigation test used the first path:

```bash
kubectl delete validatingwebhookconfiguration pod-policy.validation.k8s.io
```

After that, the ReplicaSet recreated the missing `recommendation` pod and the SREGym mitigation oracle passed.

Local final result:

| Check | Result |
|---|---|
| Problem starts | Passed |
| Fault injection | Passed |
| Runtime symptom | `recommendation` under-replicated |
| Expected event | `x509: certificate signed by unknown authority` observed |
| Mitigation oracle | Passed |
| Diagnosis judge | Skipped locally because `JUDGE_MODEL_ID` was not configured |

---

## 5. Expected agent behaviour

I have not run Stratus end-to-end on this problem yet.

Expected successful agent path:

1. Notice `recommendation` is under-replicated.
2. Inspect the ReplicaSet / events instead of only checking the application pod logs.
3. Find that pod creation is failing at admission time.
4. Identify the cluster-scoped `ValidatingWebhookConfiguration`.
5. Distinguish a TLS trust mismatch from a missing webhook backend.
6. Mitigate by deleting the webhook, changing `failurePolicy`, or repairing `caBundle`.

The intended challenge is that the visible symptom is application-level availability loss, but the root cause is a cluster-scoped admission-control dependency.

---

## Notes for reviewers

- No new Python package dependency is added.
- The webhook backend is created dynamically as a small Python HTTPS server.
- The failure is scoped to the target app namespace using `namespaceSelector`.
- Recovery deletes both the webhook configuration and the temporary `policy-system` namespace.
- Currently only the Hotel Reservation variant is registered; sibling variants for `social_network` or `astronomy_shop` can be added if useful.