### PR TITLE
Add metrics.k8s.io permissions to MCP server clusterrole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,7 @@ AGENTS.md
 .cursor/
 .kiro/
 .claude/
+.pi/
 
 # Ignore CodeQL database
 python-database

--- a/mcp_server/k8s/clusterrole.yaml
+++ b/mcp_server/k8s/clusterrole.yaml
@@ -85,6 +85,13 @@ rules:
       - rolebindings
     verbs: ["get", "list", "watch"]
 
+  # Metrics API - allows kubectl top pods/nodes
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - pods
+      - nodes
+    verbs: ["get", "list"]
+
   # Custom resources (TiDB)
   - apiGroups: ["pingcap.com"]
     resources:

--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -1444,14 +1444,7 @@ class VirtualizationFaultInjector(FaultInjector):
             print(f"Restored original deployment {service}: {apply_result}")
 
     def inject_namespace_memory_limit(self, deployment_name: str, namespace: str, memory_limit: str):
-        # Delete associated ReplicaSet
-        rs_list = self.kubectl.get_matching_replicasets(namespace, deployment_name)
-        if not rs_list:
-            raise RuntimeError(f"No ReplicaSet found for deployment {deployment_name} in {namespace}")
-        rs_name = rs_list[0].metadata.name
-        self.kubectl.delete_replicaset(name=rs_name, namespace=namespace)
-
-        # Create memory resource quota
+        # Create memory resource quota FIRST so new pods are rejected
         quota_body = {
             "apiVersion": "v1",
             "kind": "ResourceQuota",
@@ -1459,6 +1452,13 @@ class VirtualizationFaultInjector(FaultInjector):
             "spec": {"hard": {"memory": memory_limit}},
         }
         self.kubectl.apply_resource(quota_body)
+
+        # Then delete associated ReplicaSet to trigger pod recreation
+        rs_list = self.kubectl.get_matching_replicasets(namespace, deployment_name)
+        if not rs_list:
+            raise RuntimeError(f"No ReplicaSet found for deployment {deployment_name} in {namespace}")
+        rs_name = rs_list[0].metadata.name
+        self.kubectl.delete_replicaset(name=rs_name, namespace=namespace)
 
     def recover_namespace_memory_limit(self, deployment_name: str, namespace: str):
         # Remove all memory-based quotas


### PR DESCRIPTION
Closes #775

Add metrics.k8s.io RBAC to allow `kubectl top pods/nodes` in MCP server clusterrole.

---

Fixed another unrelated bug here.
1.  **Race condition in `namespace_memory_limit` fault injection:** The ReplicaSet was deleted before the ResourceQuota was created, leaving a window wherethe pod could be created before the quota existed. Since ResourceQuotas only block new pod creation and not evict running pods, the fault was flaky. Sometimes working, sometimes having no effect depending on timing. Fixed by swapping the order: create the quota first, then delete the ReplicaSet.
*events after fault injection*
```bash
94s         Warning   FailedCreate            replicaset/search-5f668579c9                   Error creating: pods "search-5f668579c9-vv2xx" is forbidden: failed quota: memory-limit-quota: must specify memory for: hotel-reserv-search
93s         Warning   FailedCreate            replicaset/search-5f668579c9                   Error creating: pods "search-5f668579c9-kfrcx" is forbidden: failed quota: memory-limit-quota: must specify memory for: hotel-reserv-search
```