### PR TITLE
Revert kubelet crash injection method from kubectl debug to SSH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dependencies = [
     "opentelemetry-semantic-conventions==0.52b1",
     "opentelemetry-util-http==0.52b1",
     "packaging>=24.0",
+    "paramiko>=5.0.0",
     "pandas==2.2.3",
     "pathspec==0.12.1",
     "platformdirs==4.3.8",

--- a/sregym/generators/fault/inject_remote_os.py
+++ b/sregym/generators/fault/inject_remote_os.py
@@ -1,9 +1,16 @@
-"""Inject faults at the OS layer via kubectl debug node (remote clusters) or docker exec (Kind)."""
+"""Inject faults at the OS layer via SSH (remote clusters) or docker exec (Kind)."""
 
+import os
+import re
 import subprocess
 import time
 
+import paramiko
+import yaml
+from paramiko.client import AutoAddPolicy
+
 from sregym.generators.fault.base import FaultInjector
+from sregym.paths import BASE_DIR
 from sregym.service.kubectl import KubeCtl
 
 NODE_NOT_READY_TIMEOUT = 120  # seconds
@@ -13,6 +20,7 @@ NODE_NOT_READY_POLL_INTERVAL = 5  # seconds
 class RemoteOSFaultInjector(FaultInjector):
     def __init__(self):
         self.kubectl = KubeCtl()
+        self.worker_info = None
         self._is_kind = None
 
     def _check_is_kind(self):
@@ -22,24 +30,61 @@ class RemoteOSFaultInjector(FaultInjector):
             self._is_kind = "kind-worker" in out
         return self._is_kind
 
-    def _get_worker_node_names(self) -> list[str]:
-        """Return the names of all worker (non-control-plane) nodes via kubectl."""
-        output = self.kubectl.exec_command("kubectl get nodes --no-headers")
-        names = []
-        for line in output.strip().splitlines():
-            parts = line.split()
-            if len(parts) >= 3 and "control-plane" not in parts[2]:
-                names.append(parts[0])
-        return names
+    def _check_remote_host(self):
+        """Verify the remote cluster has an inventory file."""
+        if not os.path.exists(f"{BASE_DIR}/../scripts/ansible/inventory.yml"):
+            print("Inventory file not found: " + f"{BASE_DIR}/../scripts/ansible/inventory.yml")
+            return False
+        return True
 
-    def _node_exec(self, node_name: str, command: str):
-        """Run a command on a node's host OS using ``kubectl debug node``.
+    def _get_remote_worker_info(self):
+        """Read worker node SSH info from the Ansible inventory."""
+        if self.worker_info:
+            return self.worker_info
 
-        Creates an ephemeral privileged container, runs the command via
-        ``chroot /host``, and cleans up automatically (--rm).
-        """
-        cmd = f"kubectl debug node/{node_name} -it --rm --image=busybox -- chroot /host sh -c {_shell_quote(command)}"
-        return self.kubectl.exec_command(cmd)
+        worker_info = {}
+        with open(f"{BASE_DIR}/../scripts/ansible/inventory.yml") as f:
+            inventory = yaml.safe_load(f)
+
+        variables = inventory.get("all", {}).get("vars", {})
+        children = inventory.get("all", {}).get("children", {})
+        workers = children.get("worker_nodes", {}).get("hosts", {})
+
+        if not workers:
+            print("No worker nodes found in inventory.")
+            return None
+
+        for name, info in workers.items():
+            host = info["ansible_host"]
+            user = self._replace_variables(info["ansible_user"], variables)
+            if "{{" in user:
+                print(f"Warning: Unresolved variables in {name} user: {user}")
+                continue
+            worker_info[host] = user
+
+        self.worker_info = worker_info
+        return self.worker_info
+
+    def _replace_variables(self, text: str, variables: dict) -> str:
+        """Replace {{ variable_name }} with actual values from variables dict."""
+
+        def replace_var(match):
+            var_name = match.group(1).strip()
+            return str(variables[var_name]) if var_name in variables else match.group(0)
+
+        return re.sub(r"\{\{\s*(\w+)\s*\}\}", replace_var, text)
+
+    def _ssh_exec(self, host: str, user: str, command: str):
+        """Run a command on a remote host via SSH."""
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(AutoAddPolicy())
+        try:
+            ssh.connect(host, username=user)
+            stdin, stdout, stderr = ssh.exec_command(command)
+            stdout.channel.recv_exit_status()
+            return stdout.read().decode()
+        finally:
+            ssh.close()
 
     def _docker_exec(self, container: str, command: str):
         """Run a command inside a Docker container (for Kind nodes)."""
@@ -69,7 +114,12 @@ class RemoteOSFaultInjector(FaultInjector):
 
     def _wait_for_worker_nodes(self, target_status="NotReady", timeout=NODE_NOT_READY_TIMEOUT):
         """Poll until all worker nodes reach the target status ('Ready' or 'NotReady')."""
-        worker_node_names = set(self._get_worker_node_names())
+        output = self.kubectl.exec_command("kubectl get nodes --no-headers")
+        worker_node_names = set()
+        for line in output.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and "control-plane" not in parts[2]:
+                worker_node_names.add(parts[0])
 
         if not worker_node_names:
             print("No worker nodes found in cluster.")
@@ -104,14 +154,15 @@ class RemoteOSFaultInjector(FaultInjector):
                 self._docker_exec(container, "kill -9 $(pgrep -x kubelet) 2>/dev/null; systemctl stop kubelet")
                 print(f"Kubelet stopped in {container}")
         else:
-            worker_nodes = self._get_worker_node_names()
-            if not worker_nodes:
-                print("No worker nodes found.")
+            if not self._check_remote_host():
                 return
-            for node in worker_nodes:
-                print(f"Killing kubelet on {node}...")
-                self._node_exec(node, "kill -9 $(pgrep -x kubelet) 2>/dev/null; systemctl stop kubelet")
-                print(f"Kubelet stopped on {node}")
+            worker_info = self._get_remote_worker_info()
+            if not worker_info:
+                return
+            for host, user in worker_info.items():
+                print(f"Killing kubelet on {host}...")
+                self._ssh_exec(host, user, "sudo kill -9 $(pgrep -x kubelet) 2>/dev/null; sudo systemctl stop kubelet")
+                print(f"Kubelet stopped on {host}")
 
         self._wait_for_worker_nodes("NotReady")
 
@@ -126,21 +177,17 @@ class RemoteOSFaultInjector(FaultInjector):
                 self._docker_exec(container, "systemctl start kubelet")
                 print(f"Kubelet started in {container}")
         else:
-            worker_nodes = self._get_worker_node_names()
-            if not worker_nodes:
-                print("No worker nodes found.")
+            if not self._check_remote_host():
                 return
-            for node in worker_nodes:
-                print(f"Starting kubelet on {node}...")
-                self._node_exec(node, "systemctl start kubelet")
-                print(f"Kubelet started on {node}")
+            worker_info = self._get_remote_worker_info()
+            if not worker_info:
+                return
+            for host, user in worker_info.items():
+                print(f"Starting kubelet on {host}...")
+                self._ssh_exec(host, user, "sudo systemctl start kubelet")
+                print(f"Kubelet started on {host}")
 
         self._wait_for_worker_nodes("Ready")
-
-
-def _shell_quote(s: str) -> str:
-    """Single-quote a string for safe shell interpolation."""
-    return "'" + s.replace("'", "'\"'\"'") + "'"
 
 
 def main():

--- a/sregym/service/kubectl.py
+++ b/sregym/service/kubectl.py
@@ -692,7 +692,9 @@ class KubeCtl:
             out = subprocess.run(command, shell=True, check=True, capture_output=True, input=input_data)
             return out.stdout.decode("utf-8")
         except subprocess.CalledProcessError as e:
-            return e.stderr.decode("utf-8")
+            stderr = e.stderr.decode("utf-8")
+            logger.error("Command failed (exit %d): %s\n  stderr: %s", e.returncode, command, stderr.strip())
+            return stderr
 
         # if out.stderr:
         #     return out.stderr.decode("utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -1723,6 +1723,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2977,6 +2986,21 @@ wheels = [
 ]
 
 [[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4026,6 +4050,7 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "packaging" },
     { name = "pandas" },
+    { name = "paramiko" },
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "prek" },
@@ -4187,6 +4212,7 @@ requires-dist = [
     { name = "opentelemetry-util-http", specifier = "==0.52b1" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pandas", specifier = "==2.2.3" },
+    { name = "paramiko", specifier = ">=5.0.0" },
     { name = "pathspec", specifier = "==0.12.1" },
     { name = "platformdirs", specifier = "==4.3.8" },
     { name = "prek", specifier = ">=0.3.4" },


### PR DESCRIPTION
Reverts the kubelet crash fault injection method from `kubectl debug node` back to SSH (paramiko).

`kubectl debug node` introduced in two issues:

1. `--rm` flag doesn't exist, causing silent injection failure. Added error log to `kubectl.py` to detect these errors in the future.
2. Recovery is impossible. Can't schedule debug pods on nodes with dead kubelet so `recover_inject` won't work.

Since recovery is impossible in this way, we are reverting to previous ssh approch.