### PR TITLE
Add CPU-throttling brownout problem

### DIFF
--- a/sregym/conductor/oracles/cpu_throttling_mitigation.py
+++ b/sregym/conductor/oracles/cpu_throttling_mitigation.py
@@ -1,0 +1,115 @@
+"""Mitigation oracle for CPU-throttling brownout problems."""
+
+import json
+import subprocess
+import time
+import urllib.parse
+
+from sregym.conductor.oracles.base import Oracle
+_PROMETHEUS_URL = "http://localhost:9090"
+
+_THROTTLE_THRESHOLD = 0.10
+_SETTLE_BUFFER_SECONDS = 120
+_SAMPLE_COUNT = 3
+_SAMPLE_INTERVAL_SECONDS = 15
+
+
+class CpuThrottlingRatioOracle(Oracle):
+    """Passes when the faulty service is no longer CFS-throttled."""
+
+    importance = 2.0
+
+    def __init__(self, problem, faulty_service: str, threshold: float = _THROTTLE_THRESHOLD):
+        super().__init__(problem)
+        self.faulty_service = faulty_service
+        self.threshold = threshold
+
+    def _get_cpu_limit(self) -> str | None:
+        """Return the deployment's container[0] cpu limit, "" if none, None on error."""
+        ns = self.problem.namespace
+        cmd = (
+            f"kubectl get deployment {self.faulty_service} -n {ns} "
+            '-o jsonpath="{.spec.template.spec.containers[0].resources.limits.cpu}"'
+        )
+        try:
+            out = self.problem.kubectl.exec_command(cmd)
+        except Exception as exc:
+            print(f"⚠️  Failed to read cpu limit from deployment spec: {exc}")
+            return None
+        return (out or "").strip().strip("'\"")
+
+    def _promql(self) -> str:
+        ns = self.problem.namespace
+        selector = f'namespace="{ns}",pod=~"^{self.faulty_service}-.*",container!="",container!="POD"'
+        return (
+            f"sum(rate(container_cpu_cfs_throttled_periods_total{{{selector}}}[2m]))"
+            f" / "
+            f"sum(rate(container_cpu_cfs_periods_total{{{selector}}}[2m]))"
+        )
+
+    def _query_ratio(self) -> float | None:
+        url = f"{_PROMETHEUS_URL}/api/v1/query?query={urllib.parse.quote(self._promql())}"
+        cmd = [
+            "kubectl", "exec", "-n", "observe",
+            "deploy/prometheus-server", "-c", "prometheus-server",
+            "--", "wget", "-qO-", url,
+        ]
+        try:
+            raw = subprocess.check_output(cmd, text=True, timeout=20)
+            payload = json.loads(raw)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            print(f"⚠️  Failed to query Prometheus: {exc}")
+            return None
+
+        result = payload.get("data", {}).get("result", [])
+        if not result:
+            return None
+        try:
+            value = float(result[0]["value"][1])
+        except (KeyError, IndexError, ValueError):
+            return None
+        if value != value:  
+            return 0.0
+        return value
+
+    def evaluate(self, solution=None, trace=None, duration=None) -> dict:
+        print("== CPU Throttling Oracle Evaluation ==")
+        limit = self._get_cpu_limit()
+        if limit == "":
+            print("✅ CPU limit removed from the deployment — CFS throttling is impossible.")
+            return {"success": True, "accuracy": 100.0}
+        if limit is None:
+            print("⚠️  Could not read deployment spec; falling back to the throttling metric.")
+        else:
+            print(f"ℹ️  CPU limit still set to {limit}; checking the throttling ratio…")
+
+        print(f"⏳ Waiting {_SETTLE_BUFFER_SECONDS}s for post-mitigation metrics to accumulate…")
+        time.sleep(_SETTLE_BUFFER_SECONDS)
+
+        samples = []
+        attempts = 0
+        while len(samples) < _SAMPLE_COUNT and attempts < _SAMPLE_COUNT * 2:
+            attempts += 1
+            ratio = self._query_ratio()
+            if ratio is not None:
+                print(f"   sample {len(samples) + 1}/{_SAMPLE_COUNT}: throttling ratio = {ratio:.3f}")
+                samples.append(ratio)
+            time.sleep(_SAMPLE_INTERVAL_SECONDS)
+
+        if not samples:
+            print(
+                "❌ No CFS throttling data from Prometheus while a CPU limit is still set. "
+                "Verify the kubelet/cAdvisor scrape job and the pod selector."
+            )
+            return {"success": False, "accuracy": 0.0}
+
+        worst = max(samples)
+        success = worst < self.threshold
+        accuracy = max(0.0, min(100.0, 100.0 * (1.0 - worst)))
+
+        if success:
+            print(f"✅ {self.faulty_service} is no longer CFS-throttled (max ratio {worst:.3f} < {self.threshold})")
+        else:
+            print(f"❌ {self.faulty_service} is still CFS-throttled (max ratio {worst:.3f} ≥ {self.threshold})")
+
+        return {"success": success, "accuracy": accuracy}

--- a/sregym/conductor/problems/cpu_throttling_brownout.py
+++ b/sregym/conductor/problems/cpu_throttling_brownout.py
@@ -1,0 +1,84 @@
+"""CPU-throttling brownout problem."""
+
+from sregym.conductor.oracles.compound import CompoundedOracle
+from sregym.conductor.oracles.cpu_throttling_mitigation import CpuThrottlingRatioOracle
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.oracles.mitigation import MitigationOracle
+from sregym.conductor.problems.base import Problem
+from sregym.generators.fault.inject_resource_contention import ResourceContentionFaultInjector
+from sregym.service.apps.astronomy_shop import AstronomyShop
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.apps.social_network import SocialNetwork
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+_APPS = {
+    "hotel_reservation": HotelReservation,
+    "social_network": SocialNetwork,
+    "astronomy_shop": AstronomyShop,
+}
+
+
+class CpuThrottlingBrownout(Problem):
+    """Brownout fault: a too-tight CPU limit causes CFS throttling under load."""
+
+    def __init__(
+        self,
+        app_name: str = "hotel_reservation",
+        faulty_service: str = "frontend",
+        limit_millicores: int = 50,
+    ):
+        if app_name not in _APPS:
+            raise ValueError(f"Unsupported app name: {app_name}")
+
+        self.app_name = app_name
+        self.faulty_service = faulty_service
+        self.limit_millicores = limit_millicores
+
+        self.app = _APPS[app_name]()
+        self.namespace = self.app.namespace
+        super().__init__(app=self.app, namespace=self.namespace)
+
+        self.kubectl = KubeCtl()
+        self.injector = ResourceContentionFaultInjector(namespace=self.namespace)
+
+        self.root_cause = self.build_structured_root_cause(
+            component=f"deployment/{self.faulty_service}",
+            namespace=self.namespace,
+            description=(
+                f"The {self.faulty_service} deployment has resources.limits.cpu set to "
+                f"{self.limit_millicores}m, far below the CPU the service needs under "
+                "request load. Kubernetes enforces this limit as a Linux CFS bandwidth "
+                "quota: once the container exhausts its quota within a 100ms scheduling "
+                "period it is throttled (paused) until the next period. The bursty "
+                "request handler is repeatedly stalled, inflating request and tail "
+                "latency. The pods stay Running and Ready and average CPU utilization "
+                "appears low, so the throttling is only visible in the "
+                "container_cpu_cfs_throttled_periods_total metric. The fix is to raise "
+                "or remove the CPU limit on the deployment."
+            ),
+        )
+
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.mitigation_oracle = CompoundedOracle(
+            self,
+            CpuThrottlingRatioOracle(problem=self, faulty_service=self.faulty_service),
+            MitigationOracle(problem=self),
+        )
+
+        self.app.create_workload()
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+        self.injector.inject_cpu_throttling(
+            microservices=[self.faulty_service],
+            limit_millicores=self.limit_millicores,
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        self.injector.recover_cpu_throttling(microservices=[self.faulty_service])
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -79,6 +79,7 @@ from sregym.conductor.problems.workload_imbalance import WorkloadImbalance
 from sregym.conductor.problems.wrong_bin_usage import WrongBinUsage
 from sregym.conductor.problems.wrong_dns_policy import WrongDNSPolicy
 from sregym.conductor.problems.wrong_service_selector import WrongServiceSelector
+from sregym.conductor.problems.cpu_throttling_brownout import CpuThrottlingBrownout
 from sregym.service.kubectl import KubeCtl
 
 
@@ -153,6 +154,9 @@ class ProblemRegistry:
             "service_port_conflict_astronomy_shop": lambda: ServicePortConflict(app_name="astronomy_shop", faulty_service="ad"),
             "service_port_conflict_hotel_reservation": lambda: ServicePortConflict(app_name="hotel_reservation", faulty_service="recommendation"),
             "service_port_conflict_social_network": lambda: ServicePortConflict(app_name="social_network", faulty_service="media-service"),
+            "cpu_throttling_brownout_hotel_reservation": lambda: CpuThrottlingBrownout(app_name="hotel_reservation", faulty_service="frontend"),
+            "cpu_throttling_brownout_social_network": lambda: CpuThrottlingBrownout(app_name="social_network", faulty_service="user-service"),
+            "cpu_throttling_brownout_astronomy_shop": lambda: CpuThrottlingBrownout(app_name="astronomy_shop", faulty_service="frontend"),
             "stale_coredns_config_astronomy_shop": lambda: StaleCoreDNSConfig(app_name="astronomy_shop"),
             "stale_coredns_config_social_network": lambda: StaleCoreDNSConfig(app_name="social_network"),
             "taint_no_toleration_social_network": lambda: TaintNoToleration(),

--- a/sregym/generators/fault/inject_resource_contention.py
+++ b/sregym/generators/fault/inject_resource_contention.py
@@ -1,0 +1,58 @@
+"""Inject resource-contention / brownout faults via Kubernetes resource limits."""
+
+from sregym.generators.fault.base import FaultInjector
+from sregym.service.kubectl import KubeCtl
+
+
+class ResourceContentionFaultInjector(FaultInjector):
+    def __init__(self, namespace: str):
+        super().__init__(namespace)
+        self.namespace = namespace
+        self.kubectl = KubeCtl()
+        self._original_cpu_limit: dict[str, str] = {}
+
+    def _jsonpath(self, service: str, path: str) -> str:
+        out = self.kubectl.exec_command(
+            f'kubectl get deployment {service} -n {self.namespace} -o jsonpath="{{{path}}}"'
+        )
+        return (out or "").strip().strip("'\"")
+
+    def _first_container_name(self, service: str) -> str:
+        return self._jsonpath(service, ".spec.template.spec.containers[0].name")
+
+    def _read_cpu_limit(self, service: str) -> str:
+        return self._jsonpath(service, ".spec.template.spec.containers[0].resources.limits.cpu")
+
+    def inject_cpu_throttling(self, microservices: list[str], limit_millicores: int):
+        """Add a tight CPU limit in place so the container is CFS-throttled under load."""
+        for service in microservices:
+            container = self._first_container_name(service)
+            self._original_cpu_limit[service] = self._read_cpu_limit(service)
+            self.kubectl.exec_command(
+                f"kubectl set resources deployment/{service} -n {self.namespace} "
+                f"-c {container} --limits=cpu={limit_millicores}m"
+            )
+            self.kubectl.exec_command(
+                f"kubectl rollout status deployment/{service} -n {self.namespace} --timeout=300s"
+            )
+            print(f"Injected cpu limit {limit_millicores}m on deployment/{service} ({container}) in {self.namespace}")
+
+    def recover_cpu_throttling(self, microservices: list[str]):
+        """Restore the original CPU limit, or remove the injected one."""
+        for service in microservices:
+            container = self._first_container_name(service)
+            original = self._original_cpu_limit.get(service, "")
+            if original:
+                self.kubectl.exec_command(
+                    f"kubectl set resources deployment/{service} -n {self.namespace} "
+                    f"-c {container} --limits=cpu={original}"
+                )
+            else:
+                self.kubectl.exec_command(
+                    f"kubectl patch deployment {service} -n {self.namespace} --type=json "
+                    "-p='[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/resources/limits/cpu\"}]'"
+                )
+            self.kubectl.exec_command(
+                f"kubectl rollout status deployment/{service} -n {self.namespace} --timeout=300s"
+            )
+            print(f"Recovered deployment/{service} in {self.namespace}")

--- a/tests/test_cpu_throttling_brownout.py
+++ b/tests/test_cpu_throttling_brownout.py
@@ -1,0 +1,15 @@
+"""Unit tests for the CPU-throttling brownout fault (cluster-free)."""
+
+from sregym.conductor.problems.base import Problem
+
+
+def test_root_cause_is_structured():
+    rc = Problem.build_structured_root_cause(
+        component="deployment/frontend",
+        namespace="hotel-reservation",
+        description="CFS throttling from a too-tight cpu limit.",
+    )
+    assert rc.startswith("[fault_spec]")
+    assert "component=deployment/frontend" in rc
+    assert "namespace=hotel-reservation" in rc
+    assert "||" in rc


### PR DESCRIPTION
# Add CPU-throttling brownout problem (first gray-failure fault + performance oracle)
## Context

Every fault in SREGym is fail-stop: a pod crashes, fails to schedule, or returns errors, and the default `MitigationOracle` treats success as every pod reaching `Running`. But many production incidents are gray failures, or brownouts, where the system stays up but runs degraded. This PR adds this brownout problem to SREGym, based on a well documented real-world failure: latency degradation from Linux CFS CPU-quota throttling under Kubernetes CPU limits ([[kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)](https://github.com/kubernetes/kubernetes/issues/67577)). When a container reaches its CPU limit it is throttled within each 100ms period, so latency rises while pods stay `Running` and average CPU usage looks low. Detecting this needs a new fault category and a performance-based oracle, because liveness checks are blind to a brownout. The problem reuses the existing [[Hotel Reservation application](https://github.com/SREGym/SREGym-applications)](https://github.com/SREGym/SREGym-applications).

## Code changes

New files:

- `sregym/generators/fault/inject_resource_contention.py`: `ResourceContentionFaultInjector`, a new fault category for resource contention. `inject_cpu_throttling` lowers a deployment's CPU request and limit together with `kubectl set resources`, then reads the limit back and raises if it did not apply. The request and limit are moved together because a limit below the existing request is rejected by the Kubernetes API. `recover_cpu_throttling` restores the original request and limit.
- `sregym/conductor/problems/cpu_throttling_brownout.py`: `CpuThrottlingBrownout`, parameterized by app and service, default limit `50m`. Diagnosis is graded by the existing `LLMAsAJudgeOracle`. Mitigation is graded by a `CompoundedOracle`.
- `sregym/conductor/oracles/cpu_throttling_mitigation.py`: `CpuThrottlingRatioOracle`, a performance-based mitigation oracle. It reads the deployment spec first, and if the CPU limit is gone it passes immediately. Otherwise it queries the CFS throttling ratio from Prometheus and passes when it stays below `0.10`.
- `tests/test_cpu_throttling_brownout.py`: cluster-free unit test for the structured root cause.

Modified:

- `sregym/conductor/problems/registry.py`: one import and three problem IDs: `cpu_throttling_brownout_hotel_reservation`, `cpu_throttling_brownout_social_network`, `cpu_throttling_brownout_astronomy_shop`.

To run the problem, start it from the SREGym CLI:

```
SREGym> start cpu_throttling_brownout_hotel_reservation
```

Wait time: the diagnostic query uses a 2-minute Prometheus rate window, so wait about 3 minutes after the problem reaches the diagnosis stage before running throttling queries. Running them earlier returns an empty result, because there is not yet enough data in the window.

Throttling ratio query used during investigation:

```
kubectl exec -n observe deploy/prometheus-server -c prometheus-server -- wget -qO- 'http://localhost:9090/api/v1/query?query=sum(rate(container_cpu_cfs_throttled_periods_total%7Bnamespace%3D%22hotel-reservation%22%2Cpod%3D~%22%5Efrontend-.%2A%22%7D%5B2m%5D))%2Fsum(rate(container_cpu_cfs_periods_total%7Bnamespace%3D%22hotel-reservation%22%2Cpod%3D~%22%5Efrontend-.%2A%22%7D%5B2m%5D))'
```

## Outcomes

Validated on a kind cluster with `cpu_throttling_brownout_hotel_reservation`. After injection:

- `frontend` has `limits.cpu: 50m` and `requests.cpu: 25m`.
- Every pod in the `hotel-reservation` namespace stays `Running`. This is the brownout property: degraded, not down.
- `kubectl top` shows `frontend` at about 39m, under its 50m limit. This is the misdirection. CPU usage looks fine because the container is throttled below its limit.
- The throttling ratio query returns about `0.685`, meaning `frontend` is throttled in roughly 68% of scheduling periods. This is a clear signal and separates well from the `0` ratio seen when no fault is active.

The injector prints a confirmation line on success and raises on failure, so a rejected injection fails loudly instead of reaching the diagnosis stage with no fault active.

## Mitigation

The fix is to raise or remove the CPU limit on the `frontend` deployment, for example:

```
kubectl set resources deployment/frontend -n hotel-reservation --limits=cpu=2
```

The mitigation oracle is a `CompoundedOracle` of `CpuThrottlingRatioOracle` and the stock `MitigationOracle`. The throttling oracle checks the deployment spec first, so removing the limit passes right away. If a limit is still present, it samples the throttling ratio and passes when the ratio stays below `0.10`. The `MitigationOracle` runs alongside as a liveness sanity check, so the agent cannot pass by deleting the service. The oracle waits 120 seconds for post-fix metrics to settle and then takes three samples, so the verdict takes about 3 minutes after submission.