### PR TITLE
Fix/wsl stratus connection refused

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -68,6 +68,8 @@ class HumanAgent:
         while True:
             inp = await self._prompt()
             cmd = inp.strip().split(maxsplit=1)
+            if not cmd:
+                continue
             if cmd[0].lower() == "exit":
                 sys.exit(0)
             if cmd[0].lower() == "options":

--- a/sregym/conductor/problems/expired_tls_hotel_reservation.py
+++ b/sregym/conductor/problems/expired_tls_hotel_reservation.py
@@ -1,0 +1,110 @@
+import os
+import subprocess
+import logging
+from sregym.conductor.problems.base import Problem
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.utils.decorators import mark_fault_injected
+
+# Initialize a standard Python logger
+logger = logging.getLogger(__name__)
+
+class ExpiredTlsHotelReservation(Problem):
+    def __init__(self):
+        self.app = HotelReservation()
+        super().__init__(app=self.app, namespace=self.app.namespace)
+        
+        self.problem_id = "expired_tls_hotel_reservation"
+        self.secret_name = "expired-frontend-cert"
+        self.ingress_yaml_path = os.path.join(os.path.dirname(__file__), "manifests", "frontend_ingress.yaml")
+        
+        self.root_cause = self.build_structured_root_cause(
+            component="frontend-ingress",
+            namespace=self.namespace,
+            description=(
+                "The frontend Ingress resource is configured with a TLS secret named "
+                f"`{self.secret_name}` which contains an expired TLS certificate. "
+                "This breaks HTTPS connections."
+            ),
+        )
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+
+    @mark_fault_injected
+    def inject_fault(self) -> bool:
+        logger.info("Injecting Expired TLS Certificate fault...")
+        
+        # 1. Forge the expired certificate
+        self._generate_expired_cert()
+        
+        # 2. Inject the TLS Secret into the cluster
+        subprocess.run([
+            "kubectl", "create", "secret", "tls", self.secret_name, 
+            "--cert=/tmp/tls.crt", "--key=/tmp/tls.key", "-n", self.namespace
+        ], check=False)
+        
+        # 3. Apply the Ingress routing rule
+        subprocess.run([
+            "kubectl", "apply", "-f", self.ingress_yaml_path, "-n", self.namespace
+        ], check=True)
+        
+        logger.info("Injected expired TLS cert into Ingress.")
+        return True
+
+    @mark_fault_injected
+    def recover_fault(self) -> bool:
+        logger.info("Recovering from Expired TLS Certificate fault...")
+        
+        subprocess.run(["kubectl", "delete", "-f", self.ingress_yaml_path, "-n", self.namespace], check=False)
+        subprocess.run(["kubectl", "delete", "secret", self.secret_name, "-n", self.namespace], check=False)
+        
+        logger.info("Fault recovered.")
+        return True
+
+    def _generate_expired_cert(self):
+        logger.info("Generating TLS certificate expired 10 days ago using cryptography...")
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric import rsa
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.x509.oid import NameOID
+            from cryptography import x509
+            import datetime
+        except ImportError:
+            logger.error("Missing 'cryptography' library. Run `uv add cryptography`.")
+            raise
+
+        # Generate a private RSA key
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        
+        # Setup the Subject/Issuer Name
+        subject = issuer = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, u"hotel.local"),
+        ])
+        
+        # Forge the dates (Starts 10 days ago, expired 1 day ago)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cert = x509.CertificateBuilder().subject_name(
+            subject
+        ).issuer_name(
+            issuer
+        ).public_key(
+            key.public_key()
+        ).serial_number(
+            x509.random_serial_number()
+        ).not_valid_before(
+            now - datetime.timedelta(days=10)
+        ).not_valid_after(
+            now - datetime.timedelta(days=1)
+        ).sign(key, hashes.SHA256())
+
+        # Save Private Key to /tmp/
+        with open("/tmp/tls.key", "wb") as f:
+            f.write(key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption()
+            ))
+
+        # Save Public Cert to /tmp/
+        with open("/tmp/tls.crt", "wb") as f:
+            f.write(cert.public_bytes(serialization.Encoding.PEM))

--- a/sregym/conductor/problems/expired_tls_hotel_reservation.py
+++ b/sregym/conductor/problems/expired_tls_hotel_reservation.py
@@ -32,17 +32,14 @@ class ExpiredTlsHotelReservation(Problem):
     @mark_fault_injected
     def inject_fault(self) -> bool:
         logger.info("Injecting Expired TLS Certificate fault...")
-        
-        # 1. Forge the expired certificate
         self._generate_expired_cert()
         
-        # 2. Inject the TLS Secret into the cluster
+        # inject the TLS Secret into the cluster
         subprocess.run([
             "kubectl", "create", "secret", "tls", self.secret_name, 
             "--cert=/tmp/tls.crt", "--key=/tmp/tls.key", "-n", self.namespace
         ], check=False)
         
-        # 3. Apply the Ingress routing rule
         subprocess.run([
             "kubectl", "apply", "-f", self.ingress_yaml_path, "-n", self.namespace
         ], check=True)
@@ -81,7 +78,7 @@ class ExpiredTlsHotelReservation(Problem):
             x509.NameAttribute(NameOID.COMMON_NAME, u"hotel.local"),
         ])
         
-        # Forge the dates (Starts 10 days ago, expired 1 day ago)
+        # Make the certificate expire 10 days ago
         now = datetime.datetime.now(datetime.timezone.utc)
         cert = x509.CertificateBuilder().subject_name(
             subject

--- a/sregym/conductor/problems/manifests/frontend_ingress.yaml
+++ b/sregym/conductor/problems/manifests/frontend_ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  namespace: hotel-reservation
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+  - hosts:
+    - hotel.local
+    secretName: expired-frontend-cert
+  rules:
+  - host: hotel.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              number: 5000

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -14,6 +14,7 @@ from sregym.conductor.problems.configmap_drift import ConfigMapDrift
 from sregym.conductor.problems.duplicate_pvc_mounts import DuplicatePVCMounts
 from sregym.conductor.problems.edge_request_filter_cpu_saturation import EdgeRequestFilterCPUSaturation
 from sregym.conductor.problems.env_variable_shadowing import EnvVariableShadowing
+from sregym.conductor.problems.expired_tls_hotel_reservation import ExpiredTlsHotelReservation
 from sregym.conductor.problems.failed_readiness_probe import FailedReadinessProbe
 from sregym.conductor.problems.faulty_image_correlated import FaultyImageCorrelated
 from sregym.conductor.problems.gc_capacity_degradation import GCCapacityDegradation
@@ -243,6 +244,7 @@ class ProblemRegistry:
             #     root_cause=_HW_DNS_RESOLVER_FAILURE,
             # ),
             # ==================== DIRECT K8S API ====================
+            "expired_tls_hotel_reservation": ExpiredTlsHotelReservation,
             "ingress_misroute": lambda: IngressMisroute(path="/api", correct_service="frontend-service", wrong_service="recommendation-service"),
             "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="recommendation"),
             "admission_webhook_outage_hotel_reservation": lambda: AdmissionWebhookOutage(app_name="hotel_reservation", faulty_service="recommendation"),

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -161,6 +161,10 @@ class ContainerRunner:
             env_vars["API_HOSTNAME"] = "host.docker.internal"
             mcp_port = env_vars.get("MCP_SERVER_PORT", os.environ.get("MCP_SERVER_PORT", "9954"))
             env_vars["MCP_SERVER_URL"] = f"http://host.docker.internal:{mcp_port}"
+        elif self.config.network_mode == "host":  # Linux
+            env_vars["API_HOSTNAME"] = "host.docker.internal"
+            mcp_port = env_vars.get("MCP_SERVER_PORT", os.environ.get("MCP_SERVER_PORT", "9954"))
+            env_vars["MCP_SERVER_URL"] = f"http://host.docker.internal:{mcp_port}"
 
         for key, value in env_vars.items():
             flags.extend(["-e", f"{key}={value}"])
@@ -178,12 +182,12 @@ class ContainerRunner:
         # Configure networking based on the network mode
         if self.config.network_mode == "host":
             if platform.system() == "Darwin":
-                # macOS: Don't use --network host (it's ignored), rely on host.docker.internal
                 args.append("--add-host=host.docker.internal:host-gateway")
             else:
-                # Linux: --network=host shares the host's network stack, so
-                # localhost already reaches host services directly.
-                args.append(f"--network={self.config.network_mode}")
+                # Linux: --network=host is unreliable in some configurations.
+                # --add-host injects the host IP directly into /etc/hosts.
+                args.append("--network=host")
+                args.append("--add-host=host.docker.internal:host-gateway")
         else:
             args.append(f"--network={self.config.network_mode}")
 


### PR DESCRIPTION
## Fix: Stratus agent `Connection refused` on WSL/Linux

`API_HOSTNAME` was being forwarded into the agent container as `0.0.0.0`, which is a valid bind address but not a valid connect address. On WSL this causes the agent to fail immediately with `Connection refused` on port 8000.

Added an `elif` for Linux in `_build_env_flags` mirroring the existing macOS block, and added `--add-host=host.docker.internal:host-gateway` to the docker run args so the hostname resolves correctly inside the container.

Fixes #785 