### PR TITLE
fix(ci): scope problem-validation concurrency by event_name

### DIFF
--- a/.github/workflows/problem-validation.yml
+++ b/.github/workflows/problem-validation.yml
@@ -26,7 +26,10 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  # Include event_name so issue_comment runs aren't cancelled by pull_request
+  # events on the same PR (notably fork PRs whose pull_request runs sit at
+  # action_required and never actually execute).
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
A `pull_request` event on the same PR was cancelling in-flight `issue_comment`-triggered validation runs via the shared concurrency group. For fork PRs, the `pull_request` run then sat at `action_required` without executing — so the comment-triggered run was killed by a run that never actually ran.

Observed on PR #791: a `/validate-problem` comment fired an `issue_comment` run that was cancelled mid-checkout ~25 s later by a `pull_request` event (fork PR, never executed).

Include `github.event_name` in the concurrency group so `pull_request` and `issue_comment` triggers for the same PR no longer cross-cancel. Same-event reruns still cancel their prior run as before.