### PR TITLE
feat(ci): show progress for problem validation runs

### DIFF
--- a/.github/workflows/problem-validation.yml
+++ b/.github/workflows/problem-validation.yml
@@ -209,6 +209,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       # ── Checkout (PR merged with main; default ref for pull_request/dispatch) ──
       - name: Checkout repository
@@ -221,6 +222,51 @@ jobs:
       - name: Record checked-out commit
         id: gitsha
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      # ── Progress: signal "started" before the long cluster steps ──
+      - name: Post "running" sticky comment
+        if: needs.resolve.outputs.pr_number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          PROBLEM_ID: ${{ needs.resolve.outputs.problem_id }}
+          COMMIT_SHA: ${{ steps.gitsha.outputs.sha }}
+        with:
+          script: |
+            const marker = '<!-- problem-validation -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body =
+              `${marker}\n## 🧪 Problem Validation\n\n` +
+              `**Status: 🟡 Running** for \`${process.env.PROBLEM_ID}\`\n\n` +
+              `Deploying app → injecting fault → checking oracle → recovering → checking oracle.\n` +
+              `Typical runtime is 5–15 minutes.\n\n` +
+              `_[Live workflow run](${runUrl}) · commit \`${process.env.COMMIT_SHA}\`_`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: React 👀 to triggering comment
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
 
       # ── Cluster tooling ───────────────────────────────────────────────
       - name: Install Kind
@@ -322,16 +368,25 @@ jobs:
                 `The validation run did not produce a summary — it likely crashed before ` +
                 `completing. Check the [workflow logs](${runUrl}).`;
             }
-            body += `\n\n_[Workflow run](${runUrl}) · commit \`${process.env.COMMIT_SHA}\`_`;
-
-            const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number,
-            });
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+      - name: React to triggering comment with final result
+        if: always() && github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const content = process.env.JOB_STATUS === 'success' ? '+1' : '-1';
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content,
+            });


### PR DESCRIPTION
Until now the problem-validation workflow stayed silent until completion, leaving PR authors and reviewers wondering whether anything was happening for the 5–15 minutes of cluster provisioning + lifecycle validation.

Adds two lightweight progress signals:

- **Reactions on the triggering `/validate-problem` comment**: 👀 when the run starts, ✅ / ❌ on completion. Comment triggers now get an immediate ack instead of looking ignored.

Both steps use `continue-on-error` so a permissions hiccup (e.g. fork PRs with read-only tokens) never fails the validation itself. Adds `issues: write` permission to the `validate` job so the reaction calls have the scope they need.

Out of scope (could follow up): per-phase status updates (deploy → inject → oracle → recover → oracle). That requires either splitting `validate_problem.py` into separate workflow steps or having it emit phase markers — worth doing only if 'is anything happening?' visibility isn't enough.