### PR TITLE
Add external readiness gate stuck Hotel Reservation problem

### DIFF
--- a/sregym/conductor/oracles/readiness_gate.py
+++ b/sregym/conductor/oracles/readiness_gate.py
@@ -1,0 +1,188 @@
+import time
+
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+from sregym.conductor.oracles.base import Oracle
+
+_ROLLOUT_SETTLE_SECONDS = 90
+_ROLLOUT_POLL_INTERVAL = 5
+
+
+class ReadinessGateMitigationOracle(Oracle):
+    """Oracle for faults where an orphaned Pod readiness gate keeps a deployment unavailable.
+
+    The generic MitigationOracle is not strict enough for this class. A Pod blocked by
+    a readiness gate can have phase=Running and all containers ready while the Pod
+    Ready condition remains False. This oracle checks the target Deployment, Pod Ready
+    condition, Service endpoints, and the absence of the injected orphan readiness gate.
+    """
+
+    importance = 1.0
+
+    def __init__(self, problem, deployment_name: str, condition_type: str, expected_replicas: int = 1):
+        super().__init__(problem)
+        self.deployment_name = deployment_name
+        self.condition_type = condition_type
+        self.expected_replicas = expected_replicas
+        self.core_api = client.CoreV1Api()
+
+    def _wait_for_rollouts(self, kubectl, namespace: str) -> None:
+        deadline = time.monotonic() + _ROLLOUT_SETTLE_SECONDS
+
+        while time.monotonic() < deadline:
+            try:
+                deployments = kubectl.list_deployments(namespace)
+            except Exception:
+                time.sleep(_ROLLOUT_POLL_INTERVAL)
+                continue
+
+            all_settled = True
+            for dep in deployments.items:
+                desired = dep.spec.replicas or 0
+                status = dep.status
+
+                if desired == 0:
+                    all_settled = False
+                    break
+
+                if (
+                    (status.updated_replicas or 0) < desired
+                    or (status.ready_replicas or 0) < desired
+                    or (status.unavailable_replicas or 0) > 0
+                ):
+                    all_settled = False
+                    break
+
+            if all_settled:
+                return
+
+            time.sleep(_ROLLOUT_POLL_INTERVAL)
+
+        print("Timed out waiting for deployments to settle; evaluating current state")
+
+    def _template_has_injected_gate(self, deployment) -> bool:
+        readiness_gates = deployment.spec.template.spec.readiness_gates or []
+        return any(gate.condition_type == self.condition_type for gate in readiness_gates)
+
+    def _pod_ready_condition_true(self, pod) -> bool:
+        for condition in pod.status.conditions or []:
+            if condition.type == "Ready":
+                return condition.status == "True"
+        return False
+
+    def _service_has_ready_endpoints(self, namespace: str, service_name: str) -> bool:
+        try:
+            endpoints = self.core_api.read_namespaced_endpoints(name=service_name, namespace=namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False
+            raise
+
+        return any(subset.addresses for subset in endpoints.subsets or [])
+
+    def evaluate(self) -> dict:
+        print("== Readiness Gate Mitigation Evaluation ==")
+        kubectl = self.problem.kubectl
+        namespace = self.problem.namespace
+        results = {}
+
+        try:
+            deployment = kubectl.get_deployment(self.deployment_name, namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                print(f"Deployment '{self.deployment_name}' not found in namespace '{namespace}'")
+                results["success"] = False
+                return results
+            raise
+
+        desired = deployment.spec.replicas or 0
+
+        if desired != self.expected_replicas:
+            print(
+                f"Deployment '{self.deployment_name}' has replicas={desired}; "
+                f"expected {self.expected_replicas}. Scaling to zero is not a valid mitigation."
+            )
+            results["success"] = False
+            return results
+
+        if self._template_has_injected_gate(deployment):
+            print(
+                f"Deployment '{self.deployment_name}' still contains orphan readiness gate "
+                f"'{self.condition_type}' in its pod template."
+            )
+            results["success"] = False
+            return results
+
+        self._wait_for_rollouts(kubectl, namespace)
+        deployment = kubectl.get_deployment(self.deployment_name, namespace)
+
+        desired = deployment.spec.replicas or 0
+        ready = deployment.status.ready_replicas or 0
+        available = deployment.status.available_replicas or 0
+
+        if ready != desired or available != desired:
+            print(
+                f"Deployment '{self.deployment_name}' is not fully available: "
+                f"ready={ready}, available={available}, desired={desired}"
+            )
+            results["success"] = False
+            return results
+
+        pod_list = kubectl.list_pods(namespace)
+        target_pods = [
+            pod
+            for pod in pod_list.items
+            if pod.metadata.labels and pod.metadata.labels.get("io.kompose.service") == self.deployment_name
+        ]
+
+        if not target_pods:
+            print(f"No pods found for deployment '{self.deployment_name}'")
+            results["success"] = False
+            return results
+
+        for pod in target_pods:
+            if pod.status.phase != "Running":
+                print(f"Pod {pod.metadata.name} is in phase {pod.status.phase}")
+                results["success"] = False
+                return results
+
+            if not self._pod_ready_condition_true(pod):
+                print(f"Pod {pod.metadata.name} Ready condition is not True")
+                results["success"] = False
+                return results
+
+            for container_status in pod.status.container_statuses or []:
+                if not container_status.ready:
+                    print(f"Container {container_status.name} in pod {pod.metadata.name} is not ready")
+                    results["success"] = False
+                    return results
+
+        if not self._service_has_ready_endpoints(namespace, self.deployment_name):
+            print(f"Service '{self.deployment_name}' has no ready endpoints")
+            results["success"] = False
+            return results
+
+        for pod in pod_list.items:
+            if pod.status.phase != "Running":
+                print(f"Pod {pod.metadata.name} is in phase {pod.status.phase}")
+                results["success"] = False
+                return results
+
+            for container_status in pod.status.container_statuses or []:
+                if container_status.state.waiting and container_status.state.waiting.reason:
+                    print(f"Container {container_status.name} is waiting: {container_status.state.waiting.reason}")
+                    results["success"] = False
+                    return results
+
+                if container_status.state.terminated and container_status.state.terminated.reason != "Completed":
+                    print(f"Container {container_status.name} terminated: {container_status.state.terminated.reason}")
+                    results["success"] = False
+                    return results
+
+        print(
+            f"Deployment '{self.deployment_name}' has {ready}/{desired} replicas ready, "
+            "service endpoints are populated, and the orphan readiness gate is gone."
+        )
+        results["success"] = True
+        return results

--- a/sregym/conductor/problems/external_readiness_gate_stuck.py
+++ b/sregym/conductor/problems/external_readiness_gate_stuck.py
@@ -1,0 +1,185 @@
+"""Problem: orphan external readiness gate keeps a healthy frontend Pod out of service.
+
+This models a cloud load-balancer/controller integration failure. In managed Kubernetes
+setups, controllers such as GKE NEG or AWS Load Balancer Controller may inject custom
+Pod readiness gates so traffic is only routed after external load-balancer health is
+confirmed. If the external controller is missing, crashed, or no longer updating the
+condition, the container can be running and healthy while the Pod Ready condition remains
+False. Kubernetes then keeps the Pod out of Service endpoints, causing user-facing
+requests to fail even though logs and container status look mostly normal.
+"""
+
+import copy
+import time
+
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.oracles.readiness_gate import ReadinessGateMitigationOracle
+from sregym.conductor.problems.base import Problem
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+
+class ExternalReadinessGateStuck(Problem):
+    """Inject a stale external readiness gate into Hotel Reservation's frontend deployment."""
+
+    FAULTY_SERVICE = "frontend"
+    CONDITION_TYPE = "cloud.google.com/load-balancer-neg-ready"
+
+    def __init__(self):
+        self.app = HotelReservation()
+        self.namespace = self.app.namespace
+        self.faulty_service = self.FAULTY_SERVICE
+        self.condition_type = self.CONDITION_TYPE
+
+        super().__init__(app=self.app, namespace=self.namespace)
+
+        self.kubectl = KubeCtl()
+        self.apps_api = client.AppsV1Api()
+
+        self.root_cause = self.build_structured_root_cause(
+            component=f"deployment/{self.faulty_service}",
+            namespace=self.namespace,
+            description=(
+                f"The `{self.faulty_service}` deployment was recreated with a custom Pod readiness gate "
+                f"`{self.condition_type}` that is normally set by an external cloud load-balancer or NEG "
+                "controller. No controller in the cluster sets this custom Pod condition, so Kubernetes "
+                "defaults the missing readiness-gate condition to False. The frontend container can be "
+                "Running and internally healthy, but the Pod Ready condition remains False, the Deployment "
+                "has zero ready replicas, and the frontend Service has no ready endpoints. The root cause "
+                "is an orphan/stale external readiness gate in the frontend Deployment template, not a "
+                "bad image, bad port, resource shortage, or application crash. Mitigation is to remove the "
+                "orphan readiness gate from the Deployment template or restore the external controller that "
+                "sets the condition, then allow the Deployment to roll out a ready frontend pod."
+            ),
+        )
+
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.app.create_workload()
+        self.mitigation_oracle = ReadinessGateMitigationOracle(
+            problem=self,
+            deployment_name=self.faulty_service,
+            condition_type=self.condition_type,
+            expected_replicas=1,
+        )
+
+    def _strip_server_fields(self, deployment):
+        deployment = copy.deepcopy(deployment)
+        deployment.status = None
+
+        deployment.metadata.resource_version = None
+        deployment.metadata.uid = None
+        deployment.metadata.creation_timestamp = None
+        deployment.metadata.generation = None
+        deployment.metadata.managed_fields = None
+        deployment.metadata.self_link = None
+
+        return deployment
+
+    def _wait_for_deployment_deleted(self, timeout_seconds: int = 90) -> None:
+        deadline = time.monotonic() + timeout_seconds
+
+        while time.monotonic() < deadline:
+            try:
+                self.apps_api.read_namespaced_deployment(
+                    name=self.faulty_service,
+                    namespace=self.namespace,
+                )
+            except ApiException as exc:
+                if exc.status == 404:
+                    return
+                raise
+
+            time.sleep(2)
+
+        raise TimeoutError(
+            f"Timed out waiting for deployment/{self.faulty_service} in namespace {self.namespace} to delete"
+        )
+
+    def _deployment_with_orphan_readiness_gate(self, deployment):
+        deployment = self._strip_server_fields(deployment)
+
+        pod_spec = deployment.spec.template.spec
+        readiness_gates = list(pod_spec.readiness_gates or [])
+
+        if not any(gate.condition_type == self.condition_type for gate in readiness_gates):
+            readiness_gates.append(client.V1PodReadinessGate(condition_type=self.condition_type))
+
+        pod_spec.readiness_gates = readiness_gates
+
+        annotations = deployment.spec.template.metadata.annotations or {}
+        annotations["cloud.google.com/neg"] = '{"ingress": true}'
+        annotations["sre.demo/external-readiness-controller"] = "missing"
+        deployment.spec.template.metadata.annotations = annotations
+
+        return deployment
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection ==")
+
+        original = self.apps_api.read_namespaced_deployment(
+            name=self.faulty_service,
+            namespace=self.namespace,
+        )
+        faulty = self._deployment_with_orphan_readiness_gate(original)
+
+        self.apps_api.delete_namespaced_deployment(
+            name=self.faulty_service,
+            namespace=self.namespace,
+            body=client.V1DeleteOptions(propagation_policy="Foreground"),
+        )
+        self._wait_for_deployment_deleted()
+
+        self.apps_api.create_namespaced_deployment(
+            namespace=self.namespace,
+            body=faulty,
+        )
+
+        message = f"Recreated deployment/{self.faulty_service} with orphan readiness gate '{self.condition_type}'."
+        print(message)
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+
+        try:
+            deployment = self.apps_api.read_namespaced_deployment(
+                name=self.faulty_service,
+                namespace=self.namespace,
+            )
+        except ApiException as exc:
+            if exc.status == 404:
+                print(f"Deployment/{self.faulty_service} already absent; nothing to patch")
+                return
+            raise
+
+        readiness_gates = deployment.spec.template.spec.readiness_gates or []
+        remaining_gates = [gate for gate in readiness_gates if gate.condition_type != self.condition_type]
+
+        if len(remaining_gates) == len(readiness_gates):
+            print(f"Readiness gate '{self.condition_type}' already absent")
+            return
+
+        patch_body = {"spec": {"template": {"spec": {}}}}
+
+        if remaining_gates:
+            patch_body["spec"]["template"]["spec"]["readinessGates"] = [
+                {"conditionType": gate.condition_type} for gate in remaining_gates
+            ]
+        else:
+            patch_body["spec"]["template"]["spec"]["readinessGates"] = None
+
+        self.apps_api.patch_namespaced_deployment(
+            name=self.faulty_service,
+            namespace=self.namespace,
+            body=patch_body,
+        )
+
+        message = f"Removed orphan readiness gate '{self.condition_type}' from deployment/{self.faulty_service}."
+        print(message)
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -16,6 +16,7 @@ from sregym.conductor.problems.duplicate_pvc_mounts import DuplicatePVCMounts
 from sregym.conductor.problems.edge_request_filter_cpu_saturation import EdgeRequestFilterCPUSaturation
 from sregym.conductor.problems.env_variable_shadowing import EnvVariableShadowing
 from sregym.conductor.problems.expired_tls_hotel_reservation import ExpiredTlsHotelReservation
+from sregym.conductor.problems.external_readiness_gate_stuck import ExternalReadinessGateStuck
 from sregym.conductor.problems.failed_readiness_probe import FailedReadinessProbe
 from sregym.conductor.problems.faulty_image_correlated import FaultyImageCorrelated
 from sregym.conductor.problems.gc_capacity_degradation import GCCapacityDegradation
@@ -254,6 +255,7 @@ class ProblemRegistry:
             # ==================== DIRECT K8S API ====================
             "expired_tls_hotel_reservation": ExpiredTlsHotelReservation,
             "ingress_misroute": lambda: IngressMisroute(path="/api", correct_service="frontend-service", wrong_service="recommendation-service"),
+            "external_readiness_gate_stuck_hotel_reservation": ExternalReadinessGateStuck,
             "network_policy_block": lambda: NetworkPolicyBlock(faulty_service="recommendation"),
             "node_conntrack_exhaustion_hotel_reservation": NodeConntrackExhaustionHotelReservation,
             "admission_webhook_outage_hotel_reservation": lambda: AdmissionWebhookOutage(app_name="hotel_reservation", faulty_service="recommendation"),


### PR DESCRIPTION
## Summary

This PR adds `external_readiness_gate_stuck_hotel_reservation`, a Hotel Reservation problem where the frontend container is healthy but the frontend service cannot receive traffic.

The fault adds an external Pod readiness gate to `deployment/frontend`. Since no controller sets the matching Pod condition, Kubernetes keeps the Pod `Ready=False` and removes it from `service/frontend` endpoints.

## Real-world failure story

This is inspired by a real Kubernetes load-balancer readiness-gate failure pattern.

Load-balancer controllers use Pod readiness gates to delay traffic until the external target is actually healthy. AWS Load Balancer Controller documents this behavior for ALB/NLB target health, and user reports show pods getting stuck or delayed around the target-health readiness gate.

References

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/deploy/pod_readiness_gate/

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3622

This SREGym problem simulates the broken-controller side of that class of incident. The readiness gate exists, but the controller that should update the Pod condition is absent.

## How the failure is simulated

The injector recreates `deployment/frontend` in the `hotel-reservation` namespace with this readiness gate.

~~~yaml
readinessGates:
- conditionType: cloud.google.com/load-balancer-neg-ready
~~~

The Pod template is also annotated to look like it expects an external readiness controller. In the SREGym Kind cluster, no controller sets that custom Pod condition, so Kubernetes treats the readiness gate as unsatisfied.

## Runtime behavior

When the fault is active, the obvious container-level checks look healthy.

Expected symptoms

- `frontend` Pod is `Running`
- frontend container is ready
- `ContainersReady=True`
- Pod `Ready=False`
- `READINESS GATES=0/1`
- `service/frontend` has no ready endpoints

A correct diagnosis should identify the stale readiness gate in the frontend Deployment template. It should not blame the image, app code, DNS, ports, probes, or resource pressure.

## Implementation

This PR adds the problem implementation, a custom mitigation oracle, and the registry entry.

Changed files

- `sregym/conductor/problems/external_readiness_gate_stuck.py`
- `sregym/conductor/oracles/readiness_gate.py`
- `sregym/conductor/problems/registry.py`

The custom oracle is needed because a generic Pod-running check is not enough for this failure. A broken Pod can be `Running` with ready containers while still being excluded from Service endpoints. The oracle verifies the expected replica count, removal of the injected readiness gate, frontend Deployment availability, Pod `Ready=True`, ready endpoints for `service/frontend`, and no application Pods stuck in waiting or failed terminal states.

## Agent behavior

I tested the full SREGym CLI diagnosis and mitigation flow manually with `groq/openai/gpt-oss-120b` as the diagnosis judge model.

The accepted diagnosis identified the orphan readiness gate on `deployment/frontend`, explained why `ContainersReady=True` did not imply Pod `Ready=True`, and connected the empty frontend Service endpoints to the unsatisfied readiness gate.

Manual result

~~~text
Diagnosis score: 100.0
Mitigation: success
~~~

The tested mitigation removes the stale readiness gate from the frontend Deployment template.

~~~bash
kubectl patch deployment frontend -n hotel-reservation --type=merge -p '{"spec":{"template":{"spec":{"readinessGates":null}}}}'
~~~

## Validation

Validated locally with the SREGym problem validator.

~~~bash
uv run python tests/integration/validate_problem.py --problem external_readiness_gate_stuck_hotel_reservation
~~~

Result

~~~text
Resolve problem in registry: passed
Deploy application: passed
Inject fault: passed
Oracle fails after fault injection: passed
Recover fault: passed
Oracle passes after recovery: passed
Result: PASSED (83s)
~~~
