### PR TITLE
Add Calico CNI to CI workflows and MCP RBAC

### DIFF
--- a/.github/workflows/problem-validation.yml
+++ b/.github/workflows/problem-validation.yml
@@ -285,18 +285,8 @@ jobs:
       - name: Prepare /run/udev for OpenEBS NDM
         run: sudo mkdir -p /run/udev
 
-      - name: Create kind cluster
-        run: |
-          kind create cluster --config kind/kind-config-x86.yaml
-          kubectl cluster-info
-          kubectl get nodes -o wide
-
-      - name: Install Calico CNI
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
-          kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
-          kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
-          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+      - name: Create kind cluster with Calico
+        run: bash kind/setup_kind_cluster.sh x86
 
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv

--- a/.github/workflows/problem-validation.yml
+++ b/.github/workflows/problem-validation.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          kind create cluster --config kind/kind-config-x86.yaml --wait 5m
+          kind create cluster --config kind/kind-config-x86.yaml
           kubectl cluster-info
           kubectl get nodes -o wide
 
@@ -296,6 +296,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
           kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
           kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
 
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv

--- a/.github/workflows/problem-validation.yml
+++ b/.github/workflows/problem-validation.yml
@@ -291,6 +291,12 @@ jobs:
           kubectl cluster-info
           kubectl get nodes -o wide
 
+      - name: Install Calico CNI
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
+          kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
+          kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -58,6 +58,12 @@ jobs:
           kubectl cluster-info
           kubectl get nodes -o wide
 
+      - name: Install Calico CNI
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
+          kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
+          kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          kind create cluster --config kind/kind-config-x86.yaml --wait 5m
+          kind create cluster --config kind/kind-config-x86.yaml
           kubectl cluster-info
           kubectl get nodes -o wide
 
@@ -63,6 +63,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
           kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
           kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
 
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,18 +52,8 @@ jobs:
       - name: Prepare /run/udev for OpenEBS NDM
         run: sudo mkdir -p /run/udev
 
-      - name: Create kind cluster
-        run: |
-          kind create cluster --config kind/kind-config-x86.yaml
-          kubectl cluster-info
-          kubectl get nodes -o wide
-
-      - name: Install Calico CNI
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
-          kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
-          kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
-          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+      - name: Create kind cluster with Calico
+        run: bash kind/setup_kind_cluster.sh x86
 
       # ── Python environment ────────────────────────────────────────────
       - name: Install uv

--- a/mcp_server/k8s/clusterrole.yaml
+++ b/mcp_server/k8s/clusterrole.yaml
@@ -97,3 +97,21 @@ rules:
     resources:
       - tidbclusters
     verbs: ["get", "list", "watch", "patch", "update"]
+
+  # Calico CRDs — allows diagnosing and fixing CNI/IPAM networking issues
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - ipamconfigs
+      - ipamblocks
+      - ipamhandles
+      - ipreservations
+      - blockaffinities
+      - felixconfigurations
+      - clusterinformations
+      - caliconodestatuses
+      - networkpolicies
+      - globalnetworkpolicies
+      - networksets
+      - globalnetworksets
+    verbs: ["get", "list", "watch", "patch", "update", "create", "delete"]


### PR DESCRIPTION
Follows up on #774 (Calico as the CNI for kind clusters instead of default kindnet).
   - Add Calico install step to smoke-test and problem-validation workflows
   - Add Calico CRD permissions to MCP server ClusterRole

---

We already shifted to Calico for our real clusters perviously. Calico has more features and will help us implement more complicated network faults. For example, the mentioned PR itself depends on Calico's IPPool feature.
 