### PR TITLE
fix(ci): bump Calico timeout to 300s and dump diagnostics on rollout failure

### DIFF
--- a/kind/setup_kind_cluster.sh
+++ b/kind/setup_kind_cluster.sh
@@ -29,8 +29,44 @@ echo "==> Step 2: Install Calico CNI"
 kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
 
 echo "==> Step 3: Wait for Calico to be ready"
-kubectl rollout status daemonset/calico-node -n kube-system --timeout=120s
-kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
+# 300s (vs 120s) accommodates first-time image pulls on slow CI runners,
+# where 1 of N calico-node pods routinely lags behind the others.
+CALICO_TIMEOUT="${CALICO_TIMEOUT:-300s}"
+
+dump_calico_diagnostics() {
+    echo ""
+    echo "❌ Calico did not reach Ready within ${CALICO_TIMEOUT}. Dumping diagnostics:"
+    echo "--- nodes ---"
+    kubectl get nodes -o wide || true
+    echo "--- calico pods ---"
+    kubectl -n kube-system get pods -l k8s-app=calico-node -o wide || true
+    echo "--- describe unready calico pods ---"
+    kubectl -n kube-system get pods -l k8s-app=calico-node \
+        --field-selector=status.phase!=Running -o name 2>/dev/null \
+        | xargs -r -I{} kubectl -n kube-system describe {} || true
+    echo "--- recent kube-system events ---"
+    kubectl -n kube-system get events --sort-by='.lastTimestamp' | tail -40 || true
+}
+
+if ! kubectl rollout status daemonset/calico-node -n kube-system --timeout="${CALICO_TIMEOUT}"; then
+    dump_calico_diagnostics
+    exit 1
+fi
+if ! kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout="${CALICO_TIMEOUT}"; then
+    dump_calico_diagnostics
+    exit 1
+fi
+
+echo "==> Step 3b: Confirm all nodes are Ready"
+# Calico rollout completing does not on its own guarantee nodes flip to Ready
+# (kubelet has its own debounce). Assert it explicitly so a stuck node fails
+# loudly here, not 10 minutes later inside wait_for_ready('kube-system').
+if ! kubectl wait --for=condition=Ready nodes --all --timeout=120s; then
+    echo "❌ Nodes did not reach Ready after Calico install."
+    kubectl get nodes -o wide || true
+    kubectl describe nodes || true
+    exit 1
+fi
 
 echo "==> Step 4: Delete SREGym cluster baseline cache"
 # SREGym caches the cluster baseline state after first deployment.


### PR DESCRIPTION
## What

The Calico rollout in `kind/setup_kind_cluster.sh` hit its 120s timeout in [run #26593443002](https://github.com/SREGym/SREGym/actions/runs/26593443002/job/78358025997) with **3 of 4 calico-node pods Ready** — the 4th calico-node pod simply needed longer to pull the image on a slow CI runner. The failure surfaced as a bare `error: timed out waiting for the condition` with no context, so it was indistinguishable from a real CNI breakage.

```
Waiting for daemon set "calico-node" rollout to finish: 3 of 4 updated pods are available...
error: timed out waiting for the condition
##[error]Process completed with exit code 1.
```

## Changes

- Bump Calico rollout/wait timeouts from **120s → 300s** (overridable via `CALICO_TIMEOUT` env var) to absorb cold-cache image pulls on shared runners.
- On rollout/wait timeout, dump `kubectl get nodes -o wide`, calico pod listing, `describe` of unready calico pods, and recent kube-system events **before** exiting non-zero. Turns a bare timeout into something actionable on the next flake.
- Add an explicit `kubectl wait --for=condition=Ready nodes --all --timeout=120s` step after Calico install. Calico rollout completing does not on its own guarantee kubelet flips nodes to Ready, and silently proceeding onto an unready cluster is what gave us the misleading 600s `kube-system` timeout tracked in #809 (this PR partially addresses #809 inside the kind-cluster setup).

## Out of scope

- Pre-loading the Calico image into the kind node via `kind load docker-image` would be a stronger fix for the image-pull root cause but adds maintenance burden (image tag tracking) — let's see if the timeout bump is enough before going there.
- Issue #808 (`fix_kubernetes()` kube-proxy downgrade) is unrelated and tracked separately.