### PR TITLE
Fix `k8s_proxy` hanging on parallel kubectl requests

### DIFF
--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -22,7 +22,7 @@ import os
 import ssl
 import tempfile
 import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 
 import urllib3
@@ -63,7 +63,7 @@ class KubernetesAPIProxy:
         self.hidden_namespaces: set[str] = hidden_namespaces if hidden_namespaces is not None else HIDDEN_NAMESPACES
         self.hidden_labels: dict[str, set[str]] = hidden_labels if hidden_labels is not None else HIDDEN_LABELS
         self.listen_port = listen_port
-        self.server: HTTPServer | None = None
+        self.server: ThreadingHTTPServer | None = None
         self.server_thread: threading.Thread | None = None
         self._temp_files: list = []
         self._bearer_token: str | None = None

--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -22,7 +22,7 @@ import os
 import ssl
 import tempfile
 import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from urllib.parse import urlparse
 
 import urllib3
@@ -391,7 +391,7 @@ class KubernetesAPIProxy:
                 self._proxy_request("HEAD")
 
         # Create and start server
-        self.server = HTTPServer(("127.0.0.1", self.listen_port), FilteringProxyHandler)
+        self.server = ThreadingHTTPServer(("127.0.0.1", self.listen_port), FilteringProxyHandler)
         self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.server_thread.start()
         logger.info(f"Kubernetes API filtering proxy started on port {self.listen_port}")


### PR DESCRIPTION
The k8s filtering proxy uses Python's `HTTPServer` which is single-threaded and processes one request at a time. When an agent fires multiple kubectl commands in parallel, requests queue up and eventually hang/timeout.

Replacing `HTTPServer` with `ThreadingHTTPServer` seems to be working.

Thanks to @selen0phile for reporting this!