### PR TITLE
Remove /get_problem conductor endpoint (fixes #788)

### DIFF
--- a/clients/claudecode/driver.py
+++ b/clients/claudecode/driver.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import requests
 
 from clients.claudecode.claudecode_agent import ClaudeCodeAgent
+from clients.harness.problem_id import resolve_problem_id
 from logger import init_logger
 
 # Add SREGym root to path
@@ -72,23 +73,6 @@ def get_app_info() -> dict:
         return app_info
     except Exception as e:
         logger.error(f"Failed to get app info: {e}")
-        raise
-
-
-def get_problem_id() -> str:
-    """Get current problem ID from conductor API."""
-    api_url = f"{get_api_base_url()}/get_problem"
-    logger.info(f"Fetching problem ID from {api_url}")
-
-    try:
-        response = requests.get(api_url)
-        response.raise_for_status()
-        problem_data = response.json()
-        problem_id = problem_data.get("problem_id")
-        logger.info(f"Problem ID: {problem_id}")
-        return problem_id
-    except Exception as e:
-        logger.error(f"Failed to get problem ID: {e}")
         raise
 
 
@@ -251,6 +235,12 @@ def main():
         help="Directory to store logs (default: ./logs/claudecode)",
     )
     parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: derived from logs-dir / AGENT_LOGS_DIR)",
+    )
+    parser.add_argument(
         "--sessions-dir",
         type=str,
         default=None,
@@ -285,13 +275,15 @@ def main():
         logger.error(f"Timeout waiting for conductor: {e}")
         sys.exit(1)
 
-    # Get problem information
+    # Get app info for the agent prompt; problem_id is for harness artifacts only
     try:
         app_info = get_app_info()
-        problem_id = get_problem_id()
     except Exception as e:
-        logger.error(f"Failed to get problem information: {e}")
+        logger.error(f"Failed to get app info: {e}")
         sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id, logs_dir=args.logs_dir)
+    logger.info(f"Problem ID (harness): {problem_id}")
 
     # Build instruction
     instruction = build_instruction(app_info)

--- a/clients/codex/driver.py
+++ b/clients/codex/driver.py
@@ -23,6 +23,7 @@ from logger import init_logger  # noqa: E402
 init_logger()
 
 from clients.codex.codex_agent import CodexAgent  # noqa: E402
+from clients.harness.problem_id import resolve_problem_id  # noqa: E402
 
 logger = logging.getLogger("all.codex.driver")
 
@@ -89,23 +90,6 @@ def get_app_info() -> dict:
         return app_info
     except Exception as e:
         logger.error(f"Failed to get app info: {e}")
-        raise
-
-
-def get_problem_id() -> str:
-    """Get current problem ID from conductor API."""
-    api_url = f"{get_api_base_url()}/get_problem"
-    logger.info(f"Fetching problem ID from {api_url}")
-
-    try:
-        response = requests.get(api_url)
-        response.raise_for_status()
-        problem_data = response.json()
-        problem_id = problem_data.get("problem_id")
-        logger.info(f"Problem ID: {problem_id}")
-        return problem_id
-    except Exception as e:
-        logger.error(f"Failed to get problem ID: {e}")
         raise
 
 
@@ -262,6 +246,12 @@ def main():
         help="Directory to store logs (default: ./logs/codex)",
     )
     parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: derived from logs-dir / AGENT_LOGS_DIR)",
+    )
+    parser.add_argument(
         "--codex-home",
         type=str,
         default=None,
@@ -296,13 +286,14 @@ def main():
         logger.error(f"Timeout waiting for conductor: {e}")
         sys.exit(1)
 
-    # Get problem information
     try:
         app_info = get_app_info()
-        problem_id = get_problem_id()
     except Exception as e:
-        logger.error(f"Failed to get problem information: {e}")
+        logger.error(f"Failed to get app info: {e}")
         sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id, logs_dir=args.logs_dir)
+    logger.info(f"Problem ID (harness): {problem_id}")
 
     # Build instruction
     instruction = build_instruction(app_info)

--- a/clients/demo/driver.py
+++ b/clients/demo/driver.py
@@ -5,16 +5,15 @@ import os
 import sys
 import time
 import uuid
-from ast import literal_eval
 from datetime import datetime
 from pathlib import Path
 
-import requests
 from fastmcp import Client
 from fastmcp.client import SSETransport
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 
+from clients.harness.problem_id import resolve_problem_id
 from clients.stratus.configs.langgraph_tool_configs import LanggraphToolConfig
 from logger import init_logger
 
@@ -53,19 +52,6 @@ def get_current_datetime_formatted():
     now = datetime.now()
     formatted_datetime = now.strftime("%m%d_%H%M")
     return formatted_datetime
-
-
-def get_curr_problem():
-    ltc = LanggraphToolConfig()
-    url = ltc.benchmark_current_problem
-    try:
-        response = requests.get(url)
-        problem_str = str(response.text)
-        problem = literal_eval(problem_str)
-        return problem["problem_id"]
-    except Exception as e:
-        logger.error(f"[get_curr_problem] HTTP request failed: {e}")
-        return "error"
 
 
 async def manual_submit_tool(ans: str) -> str:
@@ -115,7 +101,7 @@ def save_trajectory(events, problem_id, output_dir=None):
 
 
 async def run_demo_agent():
-    problem_id = get_curr_problem()
+    problem_id = resolve_problem_id()
     logger.info(f"Starting Demo Agent for problem: {problem_id}")
 
     cmds_file = Path(__file__).parent / Path("kubectl_cmds.txt")

--- a/clients/geminicli/driver.py
+++ b/clients/geminicli/driver.py
@@ -23,6 +23,7 @@ from logger import init_logger  # noqa: E402
 init_logger()
 
 from clients.geminicli.geminicli_agent import GeminiCliAgent  # noqa: E402
+from clients.harness.problem_id import resolve_problem_id  # noqa: E402
 
 logger = logging.getLogger("all.geminicli.driver")
 
@@ -47,23 +48,6 @@ def get_app_info() -> dict:
         return app_info
     except Exception as e:
         logger.error(f"Failed to get app info: {e}")
-        raise
-
-
-def get_problem_id() -> str:
-    """Get current problem ID from conductor API."""
-    api_url = f"{get_api_base_url()}/get_problem"
-    logger.info(f"Fetching problem ID from {api_url}")
-
-    try:
-        response = requests.get(api_url)
-        response.raise_for_status()
-        problem_data = response.json()
-        problem_id = problem_data.get("problem_id")
-        logger.info(f"Problem ID: {problem_id}")
-        return problem_id
-    except Exception as e:
-        logger.error(f"Failed to get problem ID: {e}")
         raise
 
 
@@ -211,6 +195,12 @@ def main():
         help="Directory to store logs (default: ./logs/geminicli)",
     )
     parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: derived from logs-dir / AGENT_LOGS_DIR)",
+    )
+    parser.add_argument(
         "--gemini-home",
         type=str,
         default=None,
@@ -245,13 +235,14 @@ def main():
         logger.error(f"Timeout waiting for conductor: {e}")
         sys.exit(1)
 
-    # Get problem information
     try:
         app_info = get_app_info()
-        problem_id = get_problem_id()
     except Exception as e:
-        logger.error(f"Failed to get problem information: {e}")
+        logger.error(f"Failed to get app info: {e}")
         sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id, logs_dir=args.logs_dir)
+    logger.info(f"Problem ID (harness): {problem_id}")
 
     # Build instruction
     instruction = build_instruction(app_info)

--- a/clients/harness/__init__.py
+++ b/clients/harness/__init__.py
@@ -1,0 +1,3 @@
+from clients.harness.problem_id import resolve_problem_id
+
+__all__ = ["resolve_problem_id"]

--- a/clients/harness/problem_id.py
+++ b/clients/harness/problem_id.py
@@ -1,0 +1,41 @@
+"""Resolve benchmark problem_id for harness log/artifact naming (not exposed to eval agents)."""
+
+import logging
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_RUN_DIR = re.compile(r"^run_\d+$", re.IGNORECASE)
+
+
+def resolve_problem_id(
+    *,
+    cli_problem_id: str | None = None,
+    logs_dir: Path | str | None = None,
+) -> str:
+    """
+    Resolve problem_id for driver artifacts without calling the conductor API.
+
+    Resolution order:
+    1. cli_problem_id (--problem-id for standalone runs)
+    2. logs_dir or AGENT_LOGS_DIR (parent of run_<n> when using main.py layout)
+    3. "unknown" with a warning
+    """
+    if cli_problem_id:
+        return cli_problem_id
+
+    raw = logs_dir or os.environ.get("AGENT_LOGS_DIR")
+    if not raw:
+        logger.warning("Could not resolve problem_id; using 'unknown'")
+        return "unknown"
+
+    path = Path(raw).resolve()
+    if _RUN_DIR.match(path.name) and path.parent.name:
+        return path.parent.name
+    if path.name and path.name != "unknown":
+        return path.name
+
+    logger.warning("Could not resolve problem_id from %s; using 'unknown'", path)
+    return "unknown"

--- a/clients/opencode/driver.py
+++ b/clients/opencode/driver.py
@@ -23,6 +23,7 @@ from logger import init_logger  # noqa: E402
 init_logger()
 
 from clients.opencode.opencode_agent import OpenCodeAgent  # noqa: E402
+from clients.harness.problem_id import resolve_problem_id  # noqa: E402
 
 logger = logging.getLogger("all.opencode.driver")
 
@@ -47,23 +48,6 @@ def get_app_info() -> dict:
         return app_info
     except Exception as e:
         logger.error(f"Failed to get app info: {e}")
-        raise
-
-
-def get_problem_id() -> str:
-    """Get current problem ID from conductor API."""
-    api_url = f"{get_api_base_url()}/get_problem"
-    logger.info(f"Fetching problem ID from {api_url}")
-
-    try:
-        response = requests.get(api_url)
-        response.raise_for_status()
-        problem_data = response.json()
-        problem_id = problem_data.get("problem_id")
-        logger.info(f"Problem ID: {problem_id}")
-        return problem_id
-    except Exception as e:
-        logger.error(f"Failed to get problem ID: {e}")
         raise
 
 
@@ -211,6 +195,12 @@ def main():
         help="Directory to store logs (default: ./logs/opencode)",
     )
     parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: derived from logs-dir / AGENT_LOGS_DIR)",
+    )
+    parser.add_argument(
         "--no-auto-install",
         action="store_true",
         help="Disable auto-installation of OpenCode CLI if not found",
@@ -239,13 +229,14 @@ def main():
         logger.error(f"Timeout waiting for conductor: {e}")
         sys.exit(1)
 
-    # Get problem information
     try:
         app_info = get_app_info()
-        problem_id = get_problem_id()
     except Exception as e:
-        logger.error(f"Failed to get problem information: {e}")
+        logger.error(f"Failed to get app info: {e}")
         sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id, logs_dir=args.logs_dir)
+    logger.info(f"Problem ID (harness): {problem_id}")
 
     # Build instruction
     instruction = build_instruction(app_info)

--- a/clients/stratus/configs/langgraph_tool_configs.py
+++ b/clients/stratus/configs/langgraph_tool_configs.py
@@ -29,10 +29,6 @@ class LanggraphToolConfig(BaseModel):
         description="url for getting benchmark application information, default to http://localhost:8000/get_app",
         default=f"http://{os.getenv('API_HOSTNAME', 'localhost')}:{os.getenv('API_PORT', '8000')}/get_app",
     )
-    benchmark_current_problem: str = Field(
-        description="url for getting current benchmark problem, default to http://localhost:8000/get_problem",
-        default=f"http://{os.getenv('API_HOSTNAME', 'localhost')}:{os.getenv('API_PORT', '8000')}/get_problem",
-    )
     min_len_to_sum: int = Field(
         description="Minimum length of text that will be summarized first before being input to the main agent.",
         default=200,

--- a/clients/stratus/stratus_agent/driver/driver.py
+++ b/clients/stratus/stratus_agent/driver/driver.py
@@ -27,6 +27,7 @@ init_logger()
 
 import logging  # noqa: E402
 
+from clients.harness.problem_id import resolve_problem_id  # noqa: E402
 from clients.stratus.configs.langgraph_tool_configs import LanggraphToolConfig  # noqa: E402
 from clients.stratus.stratus_agent.diagnosis_agent import (  # noqa: E402
     single_run_with_predefined_prompts as diagnosis_single_run,
@@ -226,22 +227,6 @@ def get_app_info():
         return app_info
     except Exception as e:
         logger.error(f"[get_app_info] HTTP submission failed: {e}")
-        return "error"
-
-
-def get_curr_problem():
-    ltc = LanggraphToolConfig()
-    url = ltc.benchmark_current_problem
-    try:
-        response = requests.get(url)
-        logger.info(f"Response status: {response.status_code}, text: {response.text}")
-        problem_str = str(response.text)
-        logger.info(f"problem as str: {problem_str}")
-        problem = literal_eval(problem_str)
-        logger.info(f"problem info: {problem}")
-        return problem["problem_id"]
-    except Exception as e:
-        logger.error(f"[get_curr_problem] HTTP submission failed: {e}")
         return "error"
 
 
@@ -720,7 +705,8 @@ async def main():
     # run diagnosis agent 2 times
     # here, running the file's main function should suffice.
     # 1 for noop diagnosis
-    current_problem = get_curr_problem()
+    current_problem = resolve_problem_id()
+    logger.info(f"Problem ID (harness): {current_problem}")
 
     # logger.info("*" * 25 + f" Testing {current_problem} ! " + "*" * 25)
     # logger.info("*" * 25 + f" Testing {current_problem} ! " + "*" * 25)

--- a/clients/tierzero/driver.py
+++ b/clients/tierzero/driver.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import requests
 
+from clients.harness.problem_id import resolve_problem_id
+
 # Add SREGym root to path
 sregym_root = Path(__file__).resolve().parents[2]
 if str(sregym_root) not in sys.path:
@@ -164,15 +166,6 @@ def get_app_info(max_retries: int = 6, backoff: int = 5) -> dict:
                 raise
 
 
-def get_problem_id() -> str:
-    """Fetch current problem ID from conductor."""
-    resp = requests.get(f"{CONDUCTOR_URL}/get_problem", timeout=10)
-    resp.raise_for_status()
-    problem_id = resp.json().get("problem_id", "unknown")
-    logger.info(f"Problem ID: {problem_id}")
-    return problem_id
-
-
 def wait_for_stage(target_stages: set[str], timeout: int = 300) -> str:
     """Poll conductor until stage is in target_stages."""
     start = time.time()
@@ -279,7 +272,8 @@ def main():
 
     # ---- Get problem info ----
     app_info = get_app_info()
-    problem_id = get_problem_id()
+    problem_id = resolve_problem_id(logs_dir=logs_dir)
+    logger.info(f"Problem ID (harness): {problem_id}")
 
     params = {
         "app_name": app_info.get("app_name", "unknown"),

--- a/sregym/conductor/conductor_api.py
+++ b/sregym/conductor/conductor_api.py
@@ -174,16 +174,6 @@ async def get_app():
     }
 
 
-@app.get("/get_problem")
-async def get_problem():
-    if _conductor is None:
-        logger.error("No problem has been started")
-        raise HTTPException(status_code=400, detail="No problem has been started")
-    problem_id = _conductor.problem_id
-    logger.debug(f"API returns Problem ID: {problem_id}")
-    return {"problem_id": problem_id}
-
-
 def run_api(conductor):
     """
     Start the API server and block until request_shutdown() is called.


### PR DESCRIPTION
## Summary
- Removes `GET /get_problem` from the conductor HTTP API so eval agents cannot discover the canonical problem id via OpenAPI or direct requests.
- Adds `clients.harness.resolve_problem_id()` for driver log/artifact naming from `AGENT_LOGS_DIR` (`.../<problem_id>/run_<n>/`) or optional `--problem-id` on CLI drivers.
- Removes unused `benchmark_current_problem` from Stratus langgraph tool config.

## Test plan
- [x] `grep '/get_problem'` — no matches in `.py`
- [x] `resolve_problem_id` unit smoke (`.../node_foo/run_1` → `node_foo`)
- [ ] `curl .../get_problem` → 404; absent from `/openapi.json` (requires running conductor)
- [ ] `python main.py --agent debug --problem <id> --n-attempts 1` — run completes; artifacts under `.../<id>/run_1/`
- [ ] (Optional) `python -m clients.claudecode.driver --problem-id <id> --logs-dir /tmp/flat` for standalone naming

Closes #788

Made with [Cursor](https://cursor.com)