### PR TITLE
Add readiness probe missing binary fault simulation

### DIFF
--- a/sregym/conductor/oracles/readiness_probe_missing_binary_mitigation.py
+++ b/sregym/conductor/oracles/readiness_probe_missing_binary_mitigation.py
@@ -1,0 +1,90 @@
+import logging
+from sregym.conductor.oracles.base import Oracle
+
+logger = logging.getLogger(__name__)
+
+class ReadinessProbeMissingBinaryMitigationOracle(Oracle):
+    """Mitigation oracle for the ReadinessProbeMissingBinary problem.
+
+    This oracle verifies that the `recommendation` deployment's readiness probe
+    no longer references the missing `/usr/local/bin/healthcheck` binary, and that
+    all pods in the application namespace are Running and Ready.
+    """
+
+    def evaluate(self) -> dict:
+        print("== Mitigation Evaluation (Missing Binary Readiness Probe) ==")
+
+        kubectl = self.problem.kubectl
+        namespace = self.problem.namespace
+        faulty_service = self.problem.faulty_service
+        results = {}
+
+        # 1. Fetch deployment details
+        try:
+            deployment = kubectl.apps_v1_api.read_namespaced_deployment(
+                name=faulty_service, namespace=namespace
+            )
+        except Exception as e:
+            print(f"❌ Failed to read deployment {faulty_service}: {e}")
+            results["success"] = False
+            return results
+
+        containers = deployment.spec.template.spec.containers
+        if not containers:
+            print("❌ No containers found in deployment spec")
+            results["success"] = False
+            return results
+
+        # 2. Check if the readiness probe has been fixed
+        probe_ok = True
+        for container in containers:
+            probe = container.readiness_probe
+            if not probe:
+                # If they deleted the probe, the pod might become Ready.
+                # However, they should ideally replace it with a valid probe.
+                # But we accept deletion or correction as mitigation.
+                continue
+
+            if probe.exec and probe.exec.command:
+                cmd = " ".join(probe.exec.command)
+                if "/usr/local/bin/healthcheck" in cmd:
+                    print(f"❌ Container {container.name} still uses the missing binary in its readiness probe: {cmd}")
+                    probe_ok = False
+                    break
+
+        if not probe_ok:
+            results["success"] = False
+            return results
+
+        # 3. Check if all pods in the namespace are Running and Ready
+        pod_list = kubectl.list_pods(namespace)
+        if not pod_list.items:
+            print("❌ No pods found in namespace")
+            results["success"] = False
+            return results
+
+        all_normal = True
+        for pod in pod_list.items:
+            if pod.status.phase != "Running":
+                print(f"❌ Pod {pod.metadata.name} is in phase: {pod.status.phase}")
+                all_normal = False
+                break
+
+            if pod.status.container_statuses:
+                for container_status in pod.status.container_statuses:
+                    if container_status.state.waiting and container_status.state.waiting.reason:
+                        print(f"❌ Container {container_status.name} is waiting: {container_status.state.waiting.reason}")
+                        all_normal = False
+                    elif container_status.state.terminated and container_status.state.terminated.reason != "Completed":
+                        print(f"❌ Container {container_status.name} terminated: {container_status.state.terminated.reason}")
+                        all_normal = False
+                    elif not container_status.ready:
+                        print(f"⚠️ Container {container_status.name} is not ready")
+                        all_normal = False
+
+            if not all_normal:
+                break
+
+        results["success"] = all_normal
+        print(f"Mitigation Result: {'Pass ✅' if all_normal else 'Fail ❌'}")
+        return results

--- a/sregym/conductor/problems/readiness_probe_missing_binary.py
+++ b/sregym/conductor/problems/readiness_probe_missing_binary.py
@@ -1,0 +1,55 @@
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.oracles.readiness_probe_missing_binary_mitigation import ReadinessProbeMissingBinaryMitigationOracle
+from sregym.conductor.problems.base import Problem
+from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+
+class ReadinessProbeMissingBinary(Problem):
+    """Problem where the recommendation service has a readiness probe executing a non-existent binary,
+    leaving the pod Running but unready (0/1 READY) because the binary is missing from the image.
+    """
+
+    def __init__(self, faulty_service: str = "recommendation"):
+        self.app = HotelReservation()
+        self.namespace = self.app.namespace
+        super().__init__(app=self.app, namespace=self.namespace)
+
+        self.kubectl = KubeCtl()
+        self.faulty_service = faulty_service
+
+        self.root_cause = self.build_structured_root_cause(
+            component=self.faulty_service,
+            namespace=self.namespace,
+            description=(
+                f"The deployment `{self.faulty_service}` has a misconfigured readiness probe that attempts to execute "
+                f"a non-existent binary `/usr/local/bin/healthcheck`, causing the readiness probe to fail with command-not-found "
+                f"errors. The pod remains in Running state but is never marked Ready, so the service excludes it from endpoints "
+                f"and callers experience connection failures or timeouts."
+            ),
+        )
+
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.app.create_workload()
+        self.mitigation_oracle = ReadinessProbeMissingBinaryMitigationOracle(problem=self)
+
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== Fault Injection: Readiness Probe Missing Binary ==")
+        self.injector = VirtualizationFaultInjector(namespace=self.namespace)
+        self.injector._inject(
+            fault_type="readiness_probe_missing_binary",
+            microservices=[self.faulty_service],
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== Fault Recovery: Readiness Probe Missing Binary ==")
+        self.injector._recover(
+            fault_type="readiness_probe_missing_binary",
+            microservices=[self.faulty_service],
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -69,6 +69,7 @@ from sregym.conductor.problems.product_catalog_failure import ProductCatalogServ
 from sregym.conductor.problems.pvc_claim_mismatch import PVCClaimMismatch
 from sregym.conductor.problems.rbac_misconfiguration import RBACMisconfiguration
 from sregym.conductor.problems.readiness_probe_misconfiguration import ReadinessProbeMisconfiguration
+from sregym.conductor.problems.readiness_probe_missing_binary import ReadinessProbeMissingBinary
 from sregym.conductor.problems.resource_request import ResourceRequestTooLarge, ResourceRequestTooSmall
 from sregym.conductor.problems.revoke_auth import MongoDBRevokeAuth
 from sregym.conductor.problems.rolling_update_misconfigured import RollingUpdateMisconfigured
@@ -135,6 +136,7 @@ class ProblemRegistry:
             "k8s_target_port-misconfig": lambda: K8STargetPortMisconfig(faulty_service="user-service"),
             "liveness_probe_misconfiguration_astronomy_shop": lambda: LivenessProbeMisconfiguration(app_name="astronomy_shop", faulty_service="frontend"),
             "liveness_probe_misconfiguration_hotel_reservation": lambda: LivenessProbeMisconfiguration(app_name="hotel_reservation", faulty_service="recommendation"),
+            "readiness_probe_missing_binary_hotel_reservation": lambda: ReadinessProbeMissingBinary(faulty_service="recommendation"),
             "liveness_probe_misconfiguration_social_network": lambda: LivenessProbeMisconfiguration(app_name="social_network", faulty_service="user-service"),
             "liveness_probe_too_aggressive_astronomy_shop": lambda: LivenessProbeTooAggressive(app_name="astronomy_shop"),
             "liveness_probe_too_aggressive_hotel_reservation": lambda: LivenessProbeTooAggressive(app_name="hotel_reservation"),

--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -1108,6 +1108,56 @@ class VirtualizationFaultInjector(FaultInjector):
 
             print(f"Recovered from readiness probe misconfiguration fault for service: {service}")
 
+    # V.14_b - Inject a readiness probe missing binary fault
+    def inject_readiness_probe_missing_binary(self, microservices: list[str]):
+        for service in microservices:
+            deployment_yaml = self._get_deployment_yaml(service)
+            original_deployment_yaml = copy.deepcopy(deployment_yaml)
+
+            containers = deployment_yaml["spec"]["template"]["spec"]["containers"]
+            initial_delay = 5
+
+            for container in containers:
+                container["readinessProbe"] = {
+                    "exec": {"command": ["/usr/local/bin/healthcheck", "-port", "8085"]},
+                    "initialDelaySeconds": initial_delay,
+                    "periodSeconds": 5,
+                    "failureThreshold": 1,
+                }
+
+            modified_yaml_path = self._write_yaml_to_file(service, deployment_yaml)
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {modified_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+            # Save the *original* deployment YAML for recovery
+            self._write_yaml_to_file(service, original_deployment_yaml)
+
+            print(f"Injected readiness probe missing binary fault for service: {service}")
+
+    def recover_readiness_probe_missing_binary(self, microservices: list[str]):
+        for service in microservices:
+            original_yaml_path = f"/tmp/{service}_modified.yaml"
+
+            delete_command = f"kubectl delete deployment {service} -n {self.namespace}"
+            apply_command = f"kubectl apply -f {original_yaml_path} -n {self.namespace}"
+
+            delete_result = self.kubectl.exec_command(delete_command)
+            print(f"Delete result for {service}: {delete_result}")
+
+            apply_result = self.kubectl.exec_command(apply_command)
+            print(f"Apply result for {service}: {apply_result}")
+
+            self.kubectl.wait_for_ready(self.namespace)
+
+            print(f"Recovered from readiness probe missing binary fault for service: {service}")
+
     # V.15 - Inject a liveness probe misconfiguration fault
     def inject_liveness_probe_misconfiguration(self, microservices: list[str]):
         for service in microservices:


### PR DESCRIPTION
### The real-world failure story
In modern cloud environments, developers optimize container images for size and security (using distroless or minimal base images). A common issue occurs when a Deployment is configured with a readiness probe that executes a shell command (such as `curl` or a custom health-check binary like `/usr/local/bin/healthcheck`), but that binary was not copied or is missing from the container image.
The pod is shown as Running by Kubernetes, but it never becomes Ready (0/1 READY). As a result, the Service excludes the pod from its Endpoints list, causing request failures/timeouts for upstream services.

### How you simulate the failure on SREGym
We simulated this scenario in the `hotel_reservation` application targeting the `recommendation` service.
- **Fault Injector**: Added `inject_readiness_probe_missing_binary` to patch the deployment's readiness probe to use `exec` with the non-existent `/usr/local/bin/healthcheck` binary on port 8085.
- **Mitigation Oracle**: Created `ReadinessProbeMissingBinaryMitigationOracle` to read the `recommendation` deployment and validate that the probe no longer references the missing `/usr/local/bin/healthcheck` binary, and that all pods in the application namespace are Running and Ready.
- **Registry**: Registered the new problem as `"readiness_probe_missing_binary_hotel_reservation"` in `registry.py`.