### PR TITLE
Kubectl command timeout

### DIFF
--- a/mcp_server/kubectl_server_helper/kubectl.py
+++ b/mcp_server/kubectl_server_helper/kubectl.py
@@ -1,9 +1,11 @@
 """Interface to K8S controller service."""
 
 import logging
+import os
 import re
 import shlex
 import subprocess  # nosec B404
+import time
 from enum import Enum
 
 import bashlex
@@ -40,18 +42,43 @@ class KubeCtl:
         # self.apps_v1_api = client.AppsV1Api()
 
     @staticmethod
-    def exec_command(command: str, input_data=None):
-        """Execute an arbitrary kubectl command."""
+    def exec_command(command: str, input_data=None, timeout: float | None = None):
+        """Execute an arbitrary kubectl command with timeout protection."""
         if input_data is not None:
             input_data = input_data.encode("utf-8")
+        timeout = timeout if timeout is not None else _kubectl_timeout_seconds()
+        started = time.monotonic()
         try:
-            out = subprocess.run(command, shell=True, check=True, capture_output=True, input=input_data)  # nosec B602
-            out.stdout = out.stdout.decode("utf-8")
-            out.stderr = out.stderr.decode("utf-8")
+            logger.info("kubectl exec start timeout=%ss command=%r", timeout, command)
+            out = subprocess.run(  # nosec B602
+                command,
+                shell=True,
+                check=True,
+                capture_output=True,
+                input=input_data,
+                timeout=timeout,
+            )
+            out.stdout = _decode_output(out.stdout)
+            out.stderr = _decode_output(out.stderr)
+            logger.info("kubectl exec done elapsed=%.2fs command=%r", time.monotonic() - started, command)
             return out
         except subprocess.CalledProcessError as e:
-            e.stderr = e.stderr.decode("utf-8")
+            e.stdout = _decode_output(e.stdout)
+            e.stderr = _decode_output(e.stderr)
+            logger.warning(
+                "kubectl exec failed returncode=%s elapsed=%.2fs command=%r stderr=%s",
+                e.returncode,
+                time.monotonic() - started,
+                command,
+                e.stderr,
+            )
             return e
+        except subprocess.TimeoutExpired as e:
+            stdout = _decode_output(e.stdout)
+            stderr = _decode_output(e.stderr)
+            message = f"kubectl command timed out after {timeout:.0f}s: {command}"
+            logger.warning("%s elapsed=%.2fs", message, time.monotonic() - started)
+            return subprocess.CompletedProcess(command, 124, stdout=stdout, stderr=(stderr + "\n" + message).strip())
 
     @staticmethod
     def exec_command_result(command: str, input_data=None) -> str:
@@ -134,7 +161,21 @@ class KubeCtl:
             dry_run_arguments.extend(["-o", keylist])
 
         dry_run_command = KubeCtl.insert_flags(command, dry_run_arguments)
-        dry_run_result = subprocess.run(dry_run_command, shell=True, capture_output=True, text=True)  # nosec B602
+        timeout = _kubectl_dry_run_timeout_seconds()
+        try:
+            dry_run_result = subprocess.run(  # nosec B602
+                dry_run_command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return DryRunResult(
+                status=DryRunStatus.ERROR,
+                description=f"Dry-run timed out after {timeout:.0f}s.",
+                result=[],
+            )
 
         if dry_run_result.returncode == 0:
             if len(dry_run_result.stdout.strip()) == 0:
@@ -183,3 +224,19 @@ class KubeCtl:
                     description=f"Dry-run failed. Potentially it's an invalid command. stderr: {parse_text(dry_run_result.stderr, 200)}",
                     result=[],
                 )
+
+
+def _kubectl_timeout_seconds() -> float:
+    return float(os.getenv("SREGYM_KUBECTL_CMD_TIMEOUT_SECONDS", "300"))
+
+
+def _kubectl_dry_run_timeout_seconds() -> float:
+    return float(os.getenv("SREGYM_KUBECTL_DRY_RUN_TIMEOUT_SECONDS", "30"))
+
+
+def _decode_output(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value


### PR DESCRIPTION
Agent timeout of 1800s doesnt protect individual MCP tool calls, one call hang lead to full subprocesses hang. 

- **Returns exit code 124 on timeout instead of letting MCP requests hang indefinitely.**
- Adds configurable command timeout via SREGYM_KUBECTL_CMD_TIMEOUT_SECONDS defaulting to 300s.
- Adds dry-run timeout via SREGYM_KUBECTL_DRY_RUN_TIMEOUT_SECONDS defaulting to 30s. 
- Adds start/end/error/timeout logging with command duration.