### PR TITLE
add: coredns_saturation_ndots problem

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -607,6 +607,22 @@ class Conductor:
         except Exception as e:
             self.logger.error(f"Failed to recover CoreDNS NXDOMAIN templates: {e}")
 
+        self.logger.info("[FIX] CoreDNS ndots saturation leftover if any")
+        try:
+            from kubernetes import client
+
+            from sregym.conductor.problems.coredns_saturation_ndots import _restore_coredns_from_annotation
+
+            # Delete analytics-collector stress workload in all namespaces.
+            self.kubectl.exec_command(
+                "kubectl delete deployment -l app=analytics-collector --all-namespaces --ignore-not-found --timeout=10s"
+            )
+
+            # Restore CoreDNS if the injection annotation is present.
+            _restore_coredns_from_annotation(client.AppsV1Api(), self.kubectl)
+        except Exception as e:
+            self.logger.warning(f"CoreDNS cleanup failed: {e}")
+
         self.logger.info("[FIX] Leftover dm-flakey infrastructure if any")
         try:
             self.dm_flakey_manager.teardown_openebs_dm_flakey_infrastructure()

--- a/sregym/conductor/oracles/coredns_saturation_mitigation.py
+++ b/sregym/conductor/oracles/coredns_saturation_mitigation.py
@@ -1,0 +1,418 @@
+"""Mitigation oracle for the CoreDNS ndots-saturation problem.
+
+Evaluates whether an agent has successfully mitigated CoreDNS saturation
+caused by ndots:5 DNS query amplification from the analytics-collector
+deployment in the problem's app namespace.
+
+Evaluation priority (all checks require DNS health as a gate):
+
+1. **DNS health** (required gate for any passing score):
+   Exec into a running pod and measure actual DNS resolution time for
+   ``kubernetes.default.svc.cluster.local``. 10 samples; median must be
+   under 50ms and no single sample may exceed 100ms.
+
+2. **ndots reduction** (primary fix, full credit):
+   ``analytics-collector`` deployment has ``dnsConfig.options`` with
+   ``ndots <= 2``. Also accepted cluster-wide (all deployments in the
+   namespace or via a mutating webhook).
+
+3. **Stress workload removed** (partial mitigation, lower credit):
+   ``analytics-collector`` is deleted or scaled to 0 replicas AND DNS
+   health passes. Stops the immediate flood but leaves the underlying
+   ndots vulnerability unaddressed.
+
+4. **CoreDNS health** (supporting check, not sufficient alone):
+   ``deployment/coredns`` in kube-system has at least 1 ready replica
+   and is not in CrashLoopBackOff.
+"""
+
+from __future__ import annotations
+
+from statistics import median
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from sregym.conductor.oracles.base import Oracle
+
+_DNS_SAMPLE_COUNT = 10
+_DNS_MEDIAN_THRESHOLD_MS = 50
+_DNS_MAX_SINGLE_SAMPLE_MS = 100
+_NDOTS_THRESHOLD = 2
+
+_STRESS_DEPLOYMENT_NAME = "analytics-collector"
+_COREDNS_DEPLOYMENT_NAME = "coredns"
+_COREDNS_NAMESPACE = "kube-system"
+
+# Preferred pods to exec into for the DNS timing probe, in priority order.
+_PREFERRED_EXEC_PODS = ["frontend"]
+
+
+class CoreDNSMitigationOracle(Oracle):
+    """Pass when CoreDNS saturation from ndots amplification is resolved."""
+
+    importance = 1.0
+
+    def __init__(self, problem):
+        super().__init__(problem)
+        self.core_v1 = client.CoreV1Api()
+        self.apps_v1 = client.AppsV1Api()
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def evaluate(self) -> dict:
+        print("== CoreDNS Saturation (ndots) Mitigation Evaluation ==")
+
+        namespace = self.problem.namespace
+
+        # --- Supporting check: CoreDNS health ---
+        coredns_healthy, coredns_detail = self._check_coredns_health()
+        print(coredns_detail)
+
+        # --- Gate: DNS health via in-pod measurement ---
+        dns_healthy, dns_detail = self._check_dns_health(namespace)
+        print(dns_detail)
+
+        if not dns_healthy:
+            return self._fail(f"DNS health check failed, CoreDNS is still saturated. {dns_detail}")
+
+        # --- Primary fix: ndots reduction ---
+        ndots_fixed, ndots_detail = self._check_ndots_reduction(namespace)
+        print(ndots_detail)
+
+        if ndots_fixed:
+            print(
+                "✅ Full pass: ndots reduced to ≤ 2 on analytics-collector (or cluster-wide) AND DNS health verified."
+            )
+            return {
+                "success": True,
+                "mitigation": "ndots_reduction",
+                "coredns_healthy": coredns_healthy,
+                "details": ndots_detail,
+            }
+
+        # --- Partial fix: stress workload removed ---
+        stress_removed, stress_detail = self._check_stress_workload_removed(namespace)
+        print(stress_detail)
+
+        if stress_removed:
+            print(
+                "⚠️ Partial pass: stress workload removed and DNS is healthy, "
+                "but root cause (ndots:5 amplification) is unaddressed. "
+                "A legitimate high-traffic service would re-trigger saturation."
+            )
+            return {
+                "success": True,
+                "mitigation": "stress_workload_removed",
+                "partial": True,
+                "coredns_healthy": coredns_healthy,
+                "details": (
+                    "Stress workload removed, DNS flood stopped. However the "
+                    "underlying ndots:5 amplification is still present. This is "
+                    "an acceptable but incomplete mitigation."
+                ),
+            }
+
+        # --- Neither fix applied ---
+        if coredns_healthy and not ndots_fixed and not stress_removed:
+            return self._fail(
+                "DNS health passes (possibly due to CoreDNS scaling) but neither "
+                "ndots was reduced nor the stress workload was removed. The "
+                "mitigation is insufficient: the cluster remains vulnerable to "
+                "ndots amplification."
+            )
+
+        return self._fail(
+            "No effective mitigation detected. ndots is still ≥ 5 on "
+            "analytics-collector and the stress workload is still running."
+        )
+
+    # ------------------------------------------------------------------
+    # 1. DNS health, in-pod timing measurement
+    # ------------------------------------------------------------------
+    def _check_dns_health(self, namespace: str) -> tuple[bool, str]:
+        """Exec into a running pod and measure DNS resolution times.
+
+        Returns (healthy, detail_message).
+        """
+        pod_name = self._find_exec_target_pod(namespace)
+        if pod_name is None:
+            return False, ("❌ No running pods available in the namespace to exec into for DNS health measurement.")
+
+        # Build a shell one-liner that resolves the name N times and prints
+        # each duration in milliseconds, followed by the exit status.
+        # It defines a function resolve_dns that tries nslookup, getent hosts,
+        # or python3 in order, returning 127 if none are found.
+        # We use `date +%s%N` for nanosecond timestamps where available,
+        # falling back to a Python one-liner if the pod has Python.
+        dns_target = "kubernetes.default.svc.cluster.local"
+        probe_script = (
+            "resolve_dns() {\n"
+            "  if command -v nslookup >/dev/null 2>&1; then\n"
+            '    nslookup "$1" >/dev/null 2>&1\n'
+            "    return $?\n"
+            "  elif command -v getent >/dev/null 2>&1; then\n"
+            '    getent hosts "$1" >/dev/null 2>&1\n'
+            "    return $?\n"
+            "  elif command -v python3 >/dev/null 2>&1; then\n"
+            "    python3 -c \"import socket; socket.gethostbyname('$1')\" >/dev/null 2>&1\n"
+            "    return $?\n"
+            "  else\n"
+            "    return 127\n"
+            "  fi\n"
+            "}\n"
+            f"for i in $(seq 1 {_DNS_SAMPLE_COUNT}); do "
+            f"START=$(date +%s%N 2>/dev/null || python3 -c "
+            f'"import time; print(int(time.time()*1e9))"); '
+            f"resolve_dns {dns_target}; "
+            f"STATUS=$?; "
+            f"END=$(date +%s%N 2>/dev/null || python3 -c "
+            f'"import time; print(int(time.time()*1e9))"); '
+            f'echo "$(( (END - START) / 1000000 )) $STATUS"; '
+            f"done"
+        )
+
+        container_name = self._get_first_container_name(pod_name, namespace)
+        cmd = (
+            f"kubectl exec {pod_name} -n {namespace}"
+            f"{f' -c {container_name}' if container_name else ''}"
+            f" -- sh -c '{probe_script}'"
+        )
+
+        output = self.problem.kubectl.exec_command(cmd)
+        return self._parse_dns_timing(output)
+
+    def _parse_dns_timing(self, output: str) -> tuple[bool, str]:
+        """Parse millisecond values and exit status from the probe output and evaluate."""
+        times_ms: list[float] = []
+        statuses: list[int] = []
+        for line in output.strip().splitlines():
+            line = line.strip()
+            # Accept lines that are "duration status".
+            parts = line.split()
+            if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                times_ms.append(float(parts[0]))
+                statuses.append(int(parts[1]))
+
+        if len(times_ms) < 1:
+            return False, f"❌ DNS timing probe returned no valid samples. Raw output: {output.strip()[:300]}"
+
+        # If all query options are missing, exit code is 127 for all runs.
+        if all(s == 127 for s in statuses):
+            return (
+                False,
+                f"❌ DNS timing probe failed: no query tool (nslookup, getent, python3) found in target container. Raw output: {output.strip()[:300]}",
+            )
+
+        # If DNS resolution failed, the query command exits with non-zero status.
+        if any(s != 0 for s in statuses):
+            return (
+                False,
+                f"❌ DNS timing probe failed: DNS resolution returned error status. Times: {times_ms}, Statuses: {statuses}",
+            )
+
+        median_ms = median(times_ms)
+        max_ms = max(times_ms)
+
+        detail = f"DNS timing: samples={times_ms}, median={median_ms:.0f}ms, max={max_ms:.0f}ms"
+
+        if max_ms > _DNS_MAX_SINGLE_SAMPLE_MS:
+            return False, f"❌ {detail}, single sample exceeds {_DNS_MAX_SINGLE_SAMPLE_MS}ms"
+
+        if median_ms > _DNS_MEDIAN_THRESHOLD_MS:
+            return False, f"❌ {detail}, median exceeds {_DNS_MEDIAN_THRESHOLD_MS}ms"
+
+        return True, f"✅ {detail}"
+
+    def _find_exec_target_pod(self, namespace: str) -> str | None:
+        """Find a running pod to exec into for DNS probing.
+
+        Tries preferred pods first (e.g. frontend), then falls back to any
+        ready pod in the namespace.
+        """
+        try:
+            pods = self.core_v1.list_namespaced_pod(namespace=namespace)
+        except ApiException:
+            return None
+
+        if not pods.items:
+            return None
+
+        running_pods = [
+            pod
+            for pod in pods.items
+            if pod.status.phase == "Running"
+            and pod.status.container_statuses
+            and any(cs.ready for cs in pod.status.container_statuses)
+        ]
+
+        if not running_pods:
+            return None
+
+        # Try preferred pods first.
+        for preferred in _PREFERRED_EXEC_PODS:
+            for pod in running_pods:
+                if pod.metadata.name.startswith(preferred):
+                    return pod.metadata.name
+
+        # Fall back to any running pod (excluding analytics-collector stress pods).
+        for pod in running_pods:
+            if not pod.metadata.name.startswith(_STRESS_DEPLOYMENT_NAME):
+                return pod.metadata.name
+
+        # Last resort: even a stress pod will do.
+        return running_pods[0].metadata.name
+
+    def _get_first_container_name(self, pod_name: str, namespace: str) -> str | None:
+        """Return the first container name for a pod, for use with kubectl exec -c."""
+        try:
+            pod = self.core_v1.read_namespaced_pod(pod_name, namespace)
+            containers = pod.spec.containers or []
+            if len(containers) > 1:
+                return containers[0].name
+        except ApiException:
+            pass
+        return None
+
+    # ------------------------------------------------------------------
+    # 2. ndots reduction check
+    # ------------------------------------------------------------------
+    def _check_ndots_reduction(self, namespace: str) -> tuple[bool, str]:
+        """Check whether ndots has been reduced on analytics-collector or cluster-wide.
+
+        Returns (fixed, detail_message).
+        """
+        # Check analytics-collector deployment spec directly.
+        ac_fixed, ac_detail = self._check_deployment_ndots(_STRESS_DEPLOYMENT_NAME, namespace)
+        if ac_fixed:
+            return True, f"✅ {ac_detail}"
+
+        # Check cluster-wide: if ALL deployments in the namespace have ndots ≤ threshold.
+        try:
+            deployments = self.apps_v1.list_namespaced_deployment(namespace=namespace)
+        except ApiException as exc:
+            return False, f"ℹ️ Could not list deployments: {exc}"
+
+        if not deployments.items:
+            return False, "ℹ️ No deployments found in namespace."
+
+        all_have_ndots = True
+        for dep in deployments.items:
+            ndots_val = self._extract_ndots_from_deployment(dep)
+            if ndots_val is None or ndots_val > _NDOTS_THRESHOLD:
+                all_have_ndots = False
+                break
+
+        if all_have_ndots and len(deployments.items) > 0:
+            return True, (
+                f"✅ All {len(deployments.items)} deployments in namespace "
+                f"have ndots ≤ {_NDOTS_THRESHOLD} (cluster-wide fix detected)."
+            )
+
+        return False, (
+            f"ℹ️ ndots not reduced on {_STRESS_DEPLOYMENT_NAME} and no cluster-wide ndots fix detected. {ac_detail}"
+        )
+
+    def _check_deployment_ndots(self, deployment_name: str, namespace: str) -> tuple[bool, str]:
+        """Check a single deployment's dnsConfig for ndots ≤ threshold."""
+        try:
+            dep = self.apps_v1.read_namespaced_deployment(deployment_name, namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False, f"Deployment '{deployment_name}' not found (deleted)."
+            return False, f"Error reading deployment '{deployment_name}': {exc}"
+
+        ndots_val = self._extract_ndots_from_deployment(dep)
+        if ndots_val is not None and ndots_val <= _NDOTS_THRESHOLD:
+            return True, (f"ndots={ndots_val} on deployment/{deployment_name} (≤ {_NDOTS_THRESHOLD} threshold).")
+
+        current = f"ndots={ndots_val}" if ndots_val is not None else "ndots not set"
+        return False, f"{current} on deployment/{deployment_name}."
+
+    @staticmethod
+    def _extract_ndots_from_deployment(deployment) -> int | None:
+        """Extract the ndots value from a deployment's pod template dnsConfig."""
+        pod_spec = deployment.spec.template.spec
+        dns_config = pod_spec.dns_config
+        if dns_config is None or dns_config.options is None:
+            return None
+        for option in dns_config.options:
+            if option.name == "ndots":
+                try:
+                    return int(option.value)
+                except (ValueError, TypeError):
+                    return None
+        return None
+
+    # ------------------------------------------------------------------
+    # 3. Stress workload removal check
+    # ------------------------------------------------------------------
+    def _check_stress_workload_removed(self, namespace: str) -> tuple[bool, str]:
+        """Check if analytics-collector is deleted or scaled to zero.
+
+        Returns (removed, detail_message).
+        """
+        try:
+            dep = self.apps_v1.read_namespaced_deployment(_STRESS_DEPLOYMENT_NAME, namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return True, (f"✅ Stress workload '{_STRESS_DEPLOYMENT_NAME}' has been deleted.")
+            return False, (f"ℹ️ Error checking stress workload: {exc}")
+
+        replicas = dep.spec.replicas or 0
+        if replicas == 0:
+            return True, (f"✅ Stress workload '{_STRESS_DEPLOYMENT_NAME}' has been scaled to 0 replicas.")
+
+        return False, (f"ℹ️ Stress workload '{_STRESS_DEPLOYMENT_NAME}' is still running with {replicas} replica(s).")
+
+    # ------------------------------------------------------------------
+    # 4. CoreDNS health (supporting check)
+    # ------------------------------------------------------------------
+    def _check_coredns_health(self) -> tuple[bool, str]:
+        """Verify CoreDNS deployment in kube-system is healthy.
+
+        Returns (healthy, detail_message).
+        """
+        try:
+            dep = self.apps_v1.read_namespaced_deployment(_COREDNS_DEPLOYMENT_NAME, _COREDNS_NAMESPACE)
+        except ApiException as exc:
+            return False, (f"❌ Could not read CoreDNS deployment: {exc}")
+
+        ready_replicas = dep.status.ready_replicas or 0
+        desired_replicas = dep.spec.replicas or 0
+
+        if ready_replicas < 1:
+            return False, (f"❌ CoreDNS has {ready_replicas}/{desired_replicas} ready replicas.")
+
+        # Check for CrashLoopBackOff on CoreDNS pods.
+        crashloop_detected = False
+        try:
+            pods = self.core_v1.list_namespaced_pod(
+                namespace=_COREDNS_NAMESPACE,
+                label_selector="k8s-app=kube-dns",
+            )
+            for pod in pods.items:
+                for cs in pod.status.container_statuses or []:
+                    if cs.state and cs.state.waiting and cs.state.waiting.reason == "CrashLoopBackOff":
+                        crashloop_detected = True
+                        break
+                if crashloop_detected:
+                    break
+        except ApiException:
+            pass
+
+        if crashloop_detected:
+            return False, (f"❌ CoreDNS has pods in CrashLoopBackOff ({ready_replicas}/{desired_replicas} ready).")
+
+        return True, (
+            f"✅ CoreDNS healthy: {ready_replicas}/{desired_replicas} replicas ready in {_COREDNS_NAMESPACE}."
+        )
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _fail(reason: str) -> dict:
+        print(f"❌ {reason}")
+        return {"success": False, "reason": reason}

--- a/sregym/conductor/problems/coredns_saturation_ndots.py
+++ b/sregym/conductor/problems/coredns_saturation_ndots.py
@@ -30,7 +30,7 @@ _STRESS_DEPLOYMENT = "analytics-collector"
 # Annotation key used to persist the original CoreDNS configuration on the
 # deployment itself.  This survives process crashes and avoids fragile temp
 # files or hardcoded defaults.
-_ORIGINAL_CONFIG_ANNOTATION = "sregym.io/coredns-original-config"
+_ORIGINAL_CONFIG_ANNOTATION = "original-config"
 
 
 class CoreDNSSaturationNdots(Problem):
@@ -279,6 +279,15 @@ def _restore_coredns_from_annotation(apps_v1, kubectl):
         return
 
     original = json.loads(raw)
+
+    resources = original.get("resources", {})
+    if "limits" not in resources:
+        resources["limits"] = {}
+
+    # Set to None if 'cpu' wasn't part of the original limits config
+    if "cpu" not in resources["limits"]:
+        resources["limits"]["cpu"] = None
+
     patch_body = {
         "metadata": {"annotations": {_ORIGINAL_CONFIG_ANNOTATION: None}},
         "spec": {
@@ -288,7 +297,7 @@ def _restore_coredns_from_annotation(apps_v1, kubectl):
                     "containers": [
                         {
                             "name": _COREDNS_DEPLOYMENT,
-                            "resources": original.get("resources", {}),
+                            "resources": resources,
                         }
                     ]
                 }

--- a/sregym/conductor/problems/coredns_saturation_ndots.py
+++ b/sregym/conductor/problems/coredns_saturation_ndots.py
@@ -1,0 +1,306 @@
+"""CoreDNS saturation caused by ndots:5 DNS query amplification.
+
+A stress workload (analytics-collector) generates high-volume DNS lookups whose
+names contain fewer dots than the Kubernetes default ndots:5.  This triggers
+search-path expansion, multiplying every query into several suffixed lookups and
+overwhelming the resource-constrained, single-replica CoreDNS pod.  The result
+is cluster-wide DNS latency and timeouts.
+
+Canonical fix: set ``dnsConfig.options: [{name: ndots, value: "2"}]`` on the
+offending deployment so search-path amplification stops.
+"""
+
+import json
+
+import yaml
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from sregym.conductor.oracles.coredns_saturation_mitigation import CoreDNSMitigationOracle
+from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsAJudgeOracle
+from sregym.conductor.problems.base import Problem
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.kubectl import KubeCtl
+from sregym.utils.decorators import mark_fault_injected
+
+_COREDNS_DEPLOYMENT = "coredns"
+_COREDNS_NAMESPACE = "kube-system"
+_STRESS_DEPLOYMENT = "analytics-collector"
+
+# Annotation key used to persist the original CoreDNS configuration on the
+# deployment itself.  This survives process crashes and avoids fragile temp
+# files or hardcoded defaults.
+_ORIGINAL_CONFIG_ANNOTATION = "sregym.io/coredns-original-config"
+
+
+class CoreDNSSaturationNdots(Problem):
+    """Inject CoreDNS saturation via ndots:5 query amplification."""
+
+    def __init__(self):
+        self.app = HotelReservation()
+        super().__init__(app=self.app, namespace=self.app.namespace)
+
+        self.kubectl = KubeCtl()
+        self.apps_v1 = client.AppsV1Api()
+        self.core_v1 = client.CoreV1Api()
+
+        self.root_cause = self.build_structured_root_cause(
+            component="deployment/coredns",
+            namespace="kube-system",
+            description=(
+                "CoreDNS is saturated due to DNS query amplification caused by Kubernetes default ndots:5 configuration. "
+                "A service generating high-volume external DNS requests causes excessive search path lookups, "
+                "overwhelming the resource-constrained CoreDNS pods and causing cluster-wide name resolution latency and timeouts."
+            ),
+        )
+
+        # === Attach evaluation oracles ===
+        self.diagnosis_oracle = LLMAsAJudgeOracle(problem=self, expected=self.root_cause)
+        self.mitigation_oracle = CoreDNSMitigationOracle(problem=self)
+
+        self.app.create_workload()
+
+    # ------------------------------------------------------------------
+    # Fault lifecycle
+    # ------------------------------------------------------------------
+    @mark_fault_injected
+    def inject_fault(self):
+        print("== CoreDNS Saturation Fault Injection ==")
+
+        # 1. Snapshot original CoreDNS config into an annotation on the
+        #    deployment.  If the annotation already exists (re-injection after
+        #    a crash), skip to avoid overwriting the true original.
+        self._save_coredns_original()
+
+        # 2. Constrain CoreDNS: 1 replica, tight resource limits.
+        patch_body = {
+            "spec": {
+                "replicas": 1,
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": _COREDNS_DEPLOYMENT,
+                                "resources": {
+                                    "limits": {"cpu": "150m", "memory": "128Mi"},
+                                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+        try:
+            self.apps_v1.patch_namespaced_deployment(_COREDNS_DEPLOYMENT, _COREDNS_NAMESPACE, patch_body)
+            print("Patched CoreDNS deployment limits and replicas.")
+            self.kubectl.exec_command(
+                f"kubectl rollout restart deployment {_COREDNS_DEPLOYMENT} -n {_COREDNS_NAMESPACE}"
+            )
+            self.kubectl.exec_command(
+                f"kubectl rollout status deployment {_COREDNS_DEPLOYMENT} -n {_COREDNS_NAMESPACE} --timeout=60s"
+            )
+        except Exception as e:
+            print(f"Error patching CoreDNS: {e}")
+
+        # 3. Deploy DNS stress workload in the app namespace.
+        stress_deployment = {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "name": _STRESS_DEPLOYMENT,
+                "namespace": self.namespace,
+                "labels": {"app": _STRESS_DEPLOYMENT},
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {"matchLabels": {"app": _STRESS_DEPLOYMENT}},
+                "template": {
+                    "metadata": {"labels": {"app": _STRESS_DEPLOYMENT}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "collector",
+                                "image": "python:3.12-slim",
+                                "command": [
+                                    "python",
+                                    "-c",
+                                    "import socket, struct, random, threading, time\n"
+                                    "\n"
+                                    "def parse_resolv_conf():\n"
+                                    "    nameserver = '10.96.0.10'\n"
+                                    "    search_paths = []\n"
+                                    "    ndots = 5\n"
+                                    "    try:\n"
+                                    "        with open('/etc/resolv.conf', 'r') as f:\n"
+                                    "            for line in f:\n"
+                                    "                parts = line.strip().split()\n"
+                                    "                if not parts or parts[0].startswith('#'):\n"
+                                    "                    continue\n"
+                                    "                if parts[0] == 'nameserver':\n"
+                                    "                    nameserver = parts[1]\n"
+                                    "                elif parts[0] == 'search':\n"
+                                    "                    search_paths = parts[1:]\n"
+                                    "                elif parts[0] == 'options':\n"
+                                    "                    for opt in parts[1:]:\n"
+                                    "                        if opt.startswith('ndots:'):\n"
+                                    "                            ndots = int(opt.split(':')[1])\n"
+                                    "    except Exception:\n"
+                                    "        pass\n"
+                                    "    return nameserver, search_paths, ndots\n"
+                                    "\n"
+                                    "def make_dns_query(domain, qtype=1):\n"
+                                    "    txid = random.randint(0, 65535)\n"
+                                    "    header = struct.pack('>HHHHHH', txid, 0x0100, 1, 0, 0, 0)\n"
+                                    "    parts = [p for p in domain.split('.') if p]\n"
+                                    "    qname = b''.join(bytes([len(p)]) + p.encode() for p in parts)\n"
+                                    "    qname += b'\\x00'\n"
+                                    "    qname += struct.pack('>HH', qtype, 1)\n"
+                                    "    return header + qname\n"
+                                    "\n"
+                                    "def flood(nameserver, search_paths, ndots):\n"
+                                    "    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+                                    "    while True:\n"
+                                    "        domain = f'analytics-sync-{random.randint(100000,999999)}.cluster.local'\n"
+                                    "        dot_count = domain.count('.')\n"
+                                    "        if dot_count < ndots:\n"
+                                    "            for suffix in search_paths:\n"
+                                    "                full_domain = f'{domain}.{suffix}'\n"
+                                    "                try:\n"
+                                    "                    sock.sendto(make_dns_query(full_domain, 1), (nameserver, 53))\n"
+                                    "                    sock.sendto(make_dns_query(full_domain, 28), (nameserver, 53))\n"
+                                    "                except Exception: pass\n"
+                                    "        try:\n"
+                                    "            sock.sendto(make_dns_query(domain, 1), (nameserver, 53))\n"
+                                    "            sock.sendto(make_dns_query(domain, 28), (nameserver, 53))\n"
+                                    "        except Exception: pass\n"
+                                    "        time.sleep(0.06)\n"
+                                    "\n"
+                                    "nameserver, search_paths, ndots = parse_resolv_conf()\n"
+                                    "threads = [threading.Thread(target=flood, args=(nameserver, search_paths, ndots), daemon=True) for _ in range(10)]\n"
+                                    "for t in threads: t.start()\n"
+                                    "for t in threads: t.join()\n",
+                                ],
+                                "resources": {
+                                    "limits": {"cpu": "100m", "memory": "64Mi"},
+                                    "requests": {"cpu": "50m", "memory": "32Mi"},
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        }
+
+        try:
+            stress_yaml = yaml.dump(stress_deployment)
+            self.kubectl.exec_command(f"kubectl apply -f - -n {self.namespace}", input_data=stress_yaml)
+            print("Deployed DNS stress deployment (analytics-collector).")
+        except Exception as e:
+            print(f"Error deploying stress workload: {e}")
+
+    @mark_fault_injected
+    def recover_fault(self):
+        print("== CoreDNS Saturation Fault Recovery ==")
+
+        # 1. Delete stress deployment.  Also cleaned up by namespace teardown,
+        #    but explicit delete stops the DNS flood immediately.
+        try:
+            self.apps_v1.delete_namespaced_deployment(_STRESS_DEPLOYMENT, self.namespace, grace_period_seconds=0)
+            print("Deleted DNS stress deployment.")
+        except ApiException as e:
+            if e.status == 404:
+                print("DNS stress deployment already absent.")
+            else:
+                print(f"Error deleting stress deployment: {e}")
+
+        # 2. Restore CoreDNS to its pre-injection state using the saved annotation.
+        _restore_coredns_from_annotation(self.apps_v1, self.kubectl)
+
+    # ------------------------------------------------------------------
+    # CoreDNS annotation helpers
+    # ------------------------------------------------------------------
+    def _save_coredns_original(self):
+        """Snapshot current CoreDNS config into an annotation on the deployment.
+
+        If the annotation already exists (e.g. re-injection after a crash),
+        the save is skipped to preserve the true original state.
+        """
+        try:
+            dep = self.apps_v1.read_namespaced_deployment(_COREDNS_DEPLOYMENT, _COREDNS_NAMESPACE)
+        except Exception as e:
+            print(f"Failed to read CoreDNS deployment: {e}")
+            return
+
+        annotations = dep.metadata.annotations or {}
+        if _ORIGINAL_CONFIG_ANNOTATION in annotations:
+            print("Original CoreDNS config annotation already exists; skipping save.")
+            return
+
+        original = {"replicas": dep.spec.replicas or 2, "resources": {}}
+        for container in dep.spec.template.spec.containers:
+            if container.name == _COREDNS_DEPLOYMENT:
+                res = container.resources
+                original["resources"] = {
+                    "limits": res.limits if res and res.limits else {},
+                    "requests": res.requests if res and res.requests else {},
+                }
+                break
+
+        annotations[_ORIGINAL_CONFIG_ANNOTATION] = json.dumps(original)
+        try:
+            self.apps_v1.patch_namespaced_deployment(
+                _COREDNS_DEPLOYMENT,
+                _COREDNS_NAMESPACE,
+                {"metadata": {"annotations": annotations}},
+            )
+            print("Saved original CoreDNS config as annotation on the deployment.")
+        except Exception as e:
+            print(f"Failed to save CoreDNS annotation: {e}")
+
+
+def _restore_coredns_from_annotation(apps_v1, kubectl):
+    """Restore CoreDNS to its pre-injection state using the saved annotation.
+
+    This is a module-level function so both the Problem class and the
+    conductor's ``fix_kubernetes`` safety net can call it without
+    instantiating a full Problem.
+    """
+    try:
+        dep = apps_v1.read_namespaced_deployment(_COREDNS_DEPLOYMENT, _COREDNS_NAMESPACE)
+    except Exception as e:
+        print(f"Could not read CoreDNS deployment: {e}")
+        return
+
+    annotations = dep.metadata.annotations or {}
+    raw = annotations.get(_ORIGINAL_CONFIG_ANNOTATION)
+    if not raw:
+        print("No original CoreDNS config annotation found; nothing to restore.")
+        return
+
+    original = json.loads(raw)
+    patch_body = {
+        "metadata": {"annotations": {_ORIGINAL_CONFIG_ANNOTATION: None}},
+        "spec": {
+            "replicas": original.get("replicas", 2),
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": _COREDNS_DEPLOYMENT,
+                            "resources": original.get("resources", {}),
+                        }
+                    ]
+                }
+            },
+        },
+    }
+    try:
+        apps_v1.patch_namespaced_deployment(_COREDNS_DEPLOYMENT, _COREDNS_NAMESPACE, patch_body)
+        kubectl.exec_command(f"kubectl rollout restart deployment {_COREDNS_DEPLOYMENT} -n {_COREDNS_NAMESPACE}")
+        kubectl.exec_command(
+            f"kubectl rollout status deployment {_COREDNS_DEPLOYMENT} -n {_COREDNS_NAMESPACE} --timeout=60s"
+        )
+        print("Restored CoreDNS to original configuration and removed annotation.")
+    except Exception as e:
+        print(f"Error restoring CoreDNS: {e}")

--- a/sregym/conductor/problems/registry.py
+++ b/sregym/conductor/problems/registry.py
@@ -13,10 +13,11 @@ from sregym.conductor.problems.auth_miss_mongodb import MongoDBAuthMissing
 from sregym.conductor.problems.capacity_decrease_rpc_retry_storm import CapacityDecreaseRPCRetryStorm
 from sregym.conductor.problems.cart_service_failure import CartServiceFailure
 from sregym.conductor.problems.configmap_drift import ConfigMapDrift
-from sregym.conductor.problems.dev_shm_exhaustion_hotel_reservation import DevShmExhaustionHotelReservation
+from sregym.conductor.problems.coredns_saturation_ndots import CoreDNSSaturationNdots
 from sregym.conductor.problems.cronjob_sidecar_blocks_completion import (
     CronJobSidecarBlocksCompletionHotelReservation,
 )
+from sregym.conductor.problems.dev_shm_exhaustion_hotel_reservation import DevShmExhaustionHotelReservation
 from sregym.conductor.problems.duplicate_pvc_mounts import DuplicatePVCMounts
 from sregym.conductor.problems.edge_request_filter_cpu_saturation import EdgeRequestFilterCPUSaturation
 from sregym.conductor.problems.env_variable_shadowing import EnvVariableShadowing
@@ -173,6 +174,7 @@ class ProblemRegistry:
             "service_port_conflict_social_network": lambda: ServicePortConflict(app_name="social_network", faulty_service="media-service"),
             "stale_coredns_config_astronomy_shop": lambda: StaleCoreDNSConfig(app_name="astronomy_shop"),
             "stale_coredns_config_social_network": lambda: StaleCoreDNSConfig(app_name="social_network"),
+            "coredns_saturation_ndots_hotel_reservation": CoreDNSSaturationNdots,
             "taint_no_toleration_social_network": lambda: TaintNoToleration(),
             # "top_of_rack_router_failure_hotel_reservation": lambda: TopOfRackRouterPartitionHotelReservation(app_name="hotel_reservation", faulty_service="frontend"),
             "wrong_bin_usage": WrongBinUsage,


### PR DESCRIPTION
### Problem description #811 

Simulates the real-world Kubernetes `ndots:5` DNS amplification issue. By default every pod gets `ndots:5` in its `/etc/resolv.conf`, meaning any domain with fewer than 5 dots (i.e., virtually every real domain like `api.stripe.com`) is treated as relative. The resolver appends each search domain (`default.svc.cluster.local`, `svc.cluster.local`, `cluster.local`) before trying the actual name, generating up to 10 DNS queries per lookup. At scale this silently saturates CoreDNS and causes intermittent latency spikes and timeouts across the entire cluster, while all pods remain Running/Ready.

This has bitten multiple companies in production, including Zalando (whose CoreDNS pods were OOMKilled by the DNS storm), Preply, and Airbnb.

References:
- [Kubernetes Failure Stories - Zalando - KubeCon Barcelona 2019](https://www.youtube.com/watch?v=6sDTB4eV4F8)
- [10 Ways to Shoot Yourself in the Foot with Kubernetes, #9 Will Surprise You - Datadog - KubeCon Barcelona 2019](https://www.youtube.com/watch?v=QKI-JRs2RIE)
- [Did Kubernetes Make My p95s Worse? - Airbnb - KubeCon NA 2019](https://www.youtube.com/watch?v=QXApVwRBeys)
- [DNS issues in Kubernetes. Public postmortem #1 - Preply - 2020](https://medium.com/preply-engineering/dns-postmortem-e169efd45afd)

### Fault injection mechanism

1. **Constrain CoreDNS**: Patch the `kube-system/coredns` deployment to 1 replica with resource limits (`cpu: 150m`, `memory: 128Mi`). Original config is saved as an annotation on the deployment itself for crash-safe recovery.
2. **Deploy DNS stress workload**: An `analytics-collector` deployment (2 replicas, 10 threads each) generates high-volume fire-and-forget raw UDP DNS queries while explicitly simulating the pod's configured ndots search-path expansion (ndots:5 by default), constructing all expanded queries per search domain, and sending A and AAAA packets independently, producing up to 8 queries per domain lookup and amplifying load on CoreDNS.
3. **Result**: CoreDNS becomes saturated, legitimate DNS queries time out, and the application experiences latency spikes or timeouts, while all pods remain in Running/Ready state or enter a CrashLoopBackOff state depending on the number of requests,.

### Recovery

- Delete the `analytics-collector` stress deployment
- Restore CoreDNS to pre-injection configuration from the saved annotation
- Rollout restart CoreDNS to apply restored limits

### Mitigation oracle

Custom `CoreDNSMitigationOracle` with tiered evaluation:

| Check | Type | Score |
|-------|------|-------|
| DNS health (in-pod timing, 10 samples, median < 50ms, max < 100ms) | **Gate** | Required |
| ndots ≤ 2 on analytics-collector or cluster-wide | **Full pass** | ✅ |
| Stress workload deleted/scaled to 0 + DNS healthy | **Partial pass** | ⚠️ |
| CoreDNS healthy (replicas ready, no CrashLoopBackOff) | Supporting | Informational |

The agent must look beyond `kubectl get pods` (all pods show Running/Ready) and trace the issue to DNS .

### Changes

- **New**: `sregym/conductor/problems/coredns_saturation_ndots.py` - Problem class
- **New**: `sregym/conductor/oracles/coredns_saturation_mitigation.py` - Mitigation oracle
- **Modified**: `sregym/conductor/conductor.py` - Added CoreDNS cleanup in `fix_kubernetes()`
- **Modified**: `sregym/conductor/problems/registry.py` -  Registered `coredns_saturation_ndots_hotel_reservation`

### Testing

- Validated fault injection: CoreDNS becomes resource-constrained and DNS queries time out
- Validated recovery: CoreDNS restored to original config from annotation
- Validated oracle: passes after ndots reduction, partial pass after stress removal, fails during active fault
- Validated conductor cleanup: `fix_kubernetes()` correctly restores CoreDNS on re-runs

/validate-problem coredns_saturation_ndots_hotel_reservation
