### PR TITLE
(fix): modify ready check to account for Suceeded

### DIFF
--- a/sregym/service/kubectl.py
+++ b/sregym/service/kubectl.py
@@ -137,6 +137,19 @@ class KubeCtl:
         """Fetch the service configuration."""
         return client.CoreV1Api().read_namespaced_service(name=name, namespace=namespace)
 
+    @staticmethod
+    def _is_completed_job_pod(pod) -> bool:
+        """True if the pod is a successfully-completed Job pod.
+
+        Such pods (e.g. k3s's helm-install-* pods in kube-system) sit in phase
+        "Succeeded" with terminated containers forever, so a readiness wait must
+        not block on them. Restricted to Job-owned pods so unrelated Succeeded
+        pods aren't silently excused.
+        """
+        if pod.status.phase != "Succeeded":
+            return False
+        return any(owner.kind == "Job" for owner in (pod.metadata.owner_references or []))
+
     def wait_for_ready(
         self,
         namespace: str,
@@ -195,7 +208,13 @@ class KubeCtl:
                     ready_pods = [
                         pod
                         for pod in all_pods
-                        if pod.status.container_statuses and all(cs.ready for cs in pod.status.container_statuses)
+                        # Completed Job pods (e.g. k3s's helm-install-* pods in
+                        # kube-system) finish "Succeeded" with terminated, never-ready
+                        # containers — they're done, not pending — so don't block on
+                        # them. Scoped to Job-owned pods so a stray Succeeded pod (or
+                        # any Failed pod) still has to be accounted for.
+                        if self._is_completed_job_pod(pod)
+                        or (pod.status.container_statuses and all(cs.ready for cs in pod.status.container_statuses))
                     ]
 
                     if len(ready_pods) == len(all_pods):


### PR DESCRIPTION
we hit the 600s timeout without this change - the runs seem to come with a set of specific assumptions about the cluster

im using `k3s` right now - my kubeconfig happens to be a `k3s` config i.e NOT `kubeadm`  etc, but the prometheus pods failed to schedule bc `sregym/observer/prometheus/prometheus/values.yaml` assumes:
```
"node-role.kubernetes.io/control-plane": ""
```


`k3s` happens to label 
```
node-role.kubernetes.io/control-plane=true
``` 

i am moving to use my DO or EKS clusters - but, if all my nodes have any value set there, the cluster will auto fail due to scheduler stuck trying to find a valid node

