### PR TITLE
Kill kubectl process group on timeout to prevent orphaned commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ uv run prek install
 Choose either a) or b) to set up your cluster and then proceed to the next steps.
 
 ### a) Kubernetes Cluster (Recommended)
-SREGym supports any kubernetes cluster that your `kubectl` context is set to, whether it's a cluster from a cloud provider or one you build yourself.
+SREGym runs on a self-managed Kubernetes cluster that you provision on Linux hosts you have SSH and root access to (e.g. [CloudLab](https://www.cloudlab.us/), bare-metal machines, or cloud VMs/VPS instances). We provide an Ansible playbook that builds the cluster for you. Follow this [README](./scripts/ansible/README.md) to set it up.
 
-We have an Ansible playbook to setup clusters on providers like [CloudLab](https://www.cloudlab.us/) and our own machines. Follow this [README](./scripts/ansible/README.md) to set up your own cluster.
+> [!NOTE]
+> A managed Kubernetes service won't work out of the box, since SREGym's setup needs SSH and root access to the nodes for OS-level cluster configuration. Instead, spin up a few plain VMs/VPS instances and add them to `inventory.yml`.
 
 ### b) Emulated cluster
 SREGym can be run on an emulated cluster using [kind](https://kind.sigs.k8s.io/) on your local machine. However, not all problems are supported.

--- a/mcp_server/kubectl_server_helper/kubectl.py
+++ b/mcp_server/kubectl_server_helper/kubectl.py
@@ -1,10 +1,12 @@
 """Interface to K8S controller service."""
 
+import contextlib
 import logging
 import os
 import re
 import shlex
-import subprocess  # nosec B404
+import signal
+import subprocess
 import time
 from enum import Enum
 
@@ -50,9 +52,8 @@ class KubeCtl:
         started = time.monotonic()
         try:
             logger.info("kubectl exec start timeout=%ss command=%r", timeout, command)
-            out = subprocess.run(  # nosec B602
+            out = _run_in_process_group(
                 command,
-                shell=True,
                 check=True,
                 capture_output=True,
                 input=input_data,
@@ -91,7 +92,7 @@ class KubeCtl:
             return f"Error executing kubectl command:\n{result.stderr}"
 
     @staticmethod
-    def extract_namespace_from_command(command: str) -> str:
+    def extract_namespace_from_command(command: str) -> str | None:
         """
         Returns the namespace.
         """
@@ -108,7 +109,7 @@ class KubeCtl:
         return namespace
 
     @staticmethod
-    def insert_flags(command: str, flags=str | list[str]) -> str:
+    def insert_flags(command: str, flags: str | list[str]) -> str:
         """
         Insert flags into a kubectl command.
         Args:
@@ -163,9 +164,8 @@ class KubeCtl:
         dry_run_command = KubeCtl.insert_flags(command, dry_run_arguments)
         timeout = _kubectl_dry_run_timeout_seconds()
         try:
-            dry_run_result = subprocess.run(  # nosec B602
+            dry_run_result = _run_in_process_group(
                 dry_run_command,
-                shell=True,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -240,3 +240,57 @@ def _decode_output(value: bytes | str | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+def _run_in_process_group(command, *, timeout, input=None, check=False, **kwargs) -> subprocess.CompletedProcess:
+    """Run a shell command in a new session so timeout kills the whole tree, not just /bin/sh.
+
+    Mirrors ``subprocess.run``: raises ``TimeoutExpired`` on timeout and ``CalledProcessError``
+    when ``check`` is set and the command fails.
+    """
+    if input is not None:
+        kwargs.setdefault("stdin", subprocess.PIPE)
+    if kwargs.pop("capture_output", False):
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
+    with subprocess.Popen(
+        command,
+        shell=True,
+        start_new_session=True,
+        **kwargs,
+    ) as proc:
+        try:
+            stdout, stderr = proc.communicate(input=input, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_process_group(proc)
+            stdout, stderr = _reap_after_kill(proc)
+            raise subprocess.TimeoutExpired(command, timeout, output=stdout, stderr=stderr) from None
+        except BaseException:
+            _kill_process_group(proc)
+            _reap_after_kill(proc)
+            raise
+        retcode = proc.wait()
+        if check and retcode:
+            raise subprocess.CalledProcessError(retcode, command, output=stdout, stderr=stderr)
+        return subprocess.CompletedProcess(command, retcode, stdout, stderr)
+
+
+def _reap_after_kill(proc: subprocess.Popen, timeout: float = 10.0) -> tuple:
+    """Bounded drain/reap so a process that escaped the group can't re-hang the cleanup."""
+    try:
+        return proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("kubectl reap timed out after %.0fs; abandoning pipe drain", timeout)
+        with contextlib.suppress(Exception):
+            proc.wait(timeout=timeout)
+        return None, None
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    """SIGKILL the whole process group led by ``proc``."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        # Can't signal the group; fall back to the child alone.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -2,6 +2,9 @@
 
 This is the instruction to use Ansible to build a remote cluster for SREGym. We currently use [CloudLab](https://www.cloudlab.us/) but we believe this will work on any servers you have access to.
 
+> [!NOTE]
+> This playbook needs SSH + root (sudo) access to each host for OS-level setup, so a managed Kubernetes service won't work. Instead, spin up a few plain VMs/VPS instances and add them to `inventory.yml`.
+
 
 ### 1) Modify the inventory file
 ```bash


### PR DESCRIPTION
## Problem
- `subprocess.run(shell=True, timeout=...)` only kills the `/bin/sh` wrapper on timeout, leaving the real `kubectl` (and piped/background children) running as orphans.
- Reproduced with `kubectl get pods --watch`: 2 live orphans left behind after the call "timed out."

## Fix
- Run commands in a new session (`start_new_session=True`) and SIGKILL the whole process group on timeout, so the entire command tree is cleaned up.
- Bound the post-kill pipe drain so a process that escaped the group can't re-introduce a hang during cleanup.
- Applied to both `exec_command` and `dry_run_json_output`; preserves existing `TimeoutExpired` / `CalledProcessError` semantics so callers are unchanged.

## Testing
- `kubectl get pods --watch`: 2 orphans pre-fix, 0 after. Verified locally and inside the live MCP pod.