### PR TITLE
Fix OpenEBS setup idempotency

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import shlex
 import shutil
 import time
 from dataclasses import dataclass
@@ -650,27 +651,14 @@ class Conductor:
             self.khaos.ensure_deployed()
 
         self.logger.info("[DEPLOY] Setting up OpenEBS…")
+        self._preflight_openebs_udev_mount()
         self.kubectl.exec_command("kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml")
         self.kubectl.exec_command(
             "kubectl patch storageclass openebs-hostpath "
             '-p \'{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}\''
         )
         self.kubectl.wait_for_ready("openebs")
-
-        print("Setting up OpenEBS LocalPV-Device…")
-        device_sc_yaml = """
-        apiVersion: storage.k8s.io/v1
-        kind: StorageClass
-        metadata:
-        name: openebs-device
-        annotations:
-            openebs.io/cas-type: local
-        provisioner: openebs.io/local
-        parameters:
-        localpvType: "device"
-        volumeBindingMode: WaitForFirstConsumer
-        """
-        self.kubectl.exec_command("kubectl apply -f - <<EOF\n" + device_sc_yaml + "\nEOF")
+        self._ensure_openebs_device_storageclass()
 
         self.logger.info("[DEPLOY] Deploying Prometheus…")
         self.prometheus.deploy()
@@ -722,6 +710,74 @@ class Conductor:
         """Teardown problem.app and, if no other apps running, OpenEBS/Prometheus."""
         if self.problem:
             self.problem.app.cleanup()
+
+    def _preflight_openebs_udev_mount(self) -> None:
+        if shutil.which("docker") is None:
+            self.logger.info("[DEPLOY] Docker is unavailable; skipping kind /run/udev preflight")
+            return
+
+        nodes_output = self.kubectl.exec_command(
+            "kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'"
+        )
+        missing_nodes: list[str] = []
+
+        for node in (line.strip() for line in nodes_output.splitlines()):
+            if not node or " " in node:
+                continue
+            quoted_node = shlex.quote(node)
+            result = self.kubectl.exec_command(
+                f"docker inspect {quoted_node} >/dev/null 2>&1 "
+                f"&& docker exec {quoted_node} sh -c 'test -d /run/udev && echo ok || echo missing' "
+                "|| echo not-a-docker-node"
+            ).strip()
+            if result == "missing":
+                missing_nodes.append(node)
+
+        if missing_nodes:
+            missing_list = ", ".join(missing_nodes)
+            raise RuntimeError(
+                "OpenEBS node-disk-manager requires /run/udev inside kind node containers. "
+                f"Missing /run/udev on: {missing_list}. Create /run/udev on the host before kind cluster "
+                "creation and mount hostPath /run/udev to containerPath /run/udev in the kind config."
+            )
+
+    def _ensure_openebs_device_storageclass(self) -> None:
+        self.logger.info("[DEPLOY] Ensuring OpenEBS LocalPV-Device StorageClass…")
+        existing = self.kubectl.exec_command(
+            "kubectl get storageclass openebs-device "
+            "-o jsonpath='{.provisioner}{\"\\n\"}{.volumeBindingMode}'"
+        )
+        if "not found" not in existing.lower() and "error from server" not in existing.lower():
+            provisioner, _, volume_binding_mode = existing.partition("\n")
+            if provisioner.strip() != "openebs.io/local":
+                raise RuntimeError(
+                    "StorageClass/openebs-device already exists with unexpected provisioner "
+                    f"{provisioner.strip()!r}; expected 'openebs.io/local'."
+                )
+            if volume_binding_mode.strip() != "WaitForFirstConsumer":
+                raise RuntimeError(
+                    "StorageClass/openebs-device already exists with unexpected volumeBindingMode "
+                    f"{volume_binding_mode.strip()!r}; expected 'WaitForFirstConsumer'."
+                )
+            self.logger.info("[DEPLOY] StorageClass/openebs-device already exists; leaving it unchanged")
+            return
+
+        device_sc_yaml = """apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-device
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      - name: StorageType
+        value: "device"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+"""
+        result = self.kubectl.exec_command("kubectl apply -f -", input_data=device_sc_yaml)
+        if "error from server" in result.lower() or "invalid" in result.lower():
+            raise RuntimeError(f"Failed to create StorageClass/openebs-device: {result.strip()}")
 
     def get_deployed_apps(self):
         deployed_apps = []


### PR DESCRIPTION
The current setup applies the upstream OpenEBS operator manifest, which already creates `StorageClass/openebs-device`. SREGym then applies a different inline `openebs-device` definition. Kubernetes rejects that because `StorageClass.parameters` are immutable after creation, causing benchmark runs to fail during deploy/setup before the agent can diagnose the injected fault.

https://github.com/SREGym/SREGym/issues/870 

- Checks if Sotrageclass already exists before creating it
- Verify the operator-provided version matches the setup