### PR TITLE
fix: bind MCP port-forward to 0.0.0.0 for Docker container reachability

### DIFF
--- a/sregym/service/mcp_server.py
+++ b/sregym/service/mcp_server.py
@@ -104,7 +104,9 @@ class MCPServer:
                 time.sleep(3)
                 continue
 
-            command = f"kubectl port-forward svc/{self.service_name} {self.port}:9954 -n {self.namespace}"
+            command = (
+                f"kubectl port-forward svc/{self.service_name} {self.port}:9954 -n {self.namespace} --address 0.0.0.0"
+            )
             self.port_forward_process = subprocess.Popen(
                 command,
                 shell=True,


### PR DESCRIPTION
On native Linux, `host-gateway` resolves to `172.17.0.1` (Docker bridge), not `127.0.0.1`. The agent container connects via `host.docker.internal` which resolves to the bridge IP, but `kubectl port-forward` defaults to binding on `127.0.0.1` only.

This caused `MCP client entered context but session is not connected` errors for stratus agent since PR #789.

Fix: add `--address 0.0.0.0` so port-forward listens on all interfaces, reachable from Docker containers on any platform.