### PR TITLE
Add copilot cli agent

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -48,6 +48,12 @@ agents:
     install_script: null
     agent_version: null
     container_isolation: false
+  - name: copilot
+    kickoff_command: python -m clients.copilot.driver
+    kickoff_workdir: .
+    kickoff_env: null
+    install_script: install-copilot.sh
+    agent_version: null
   - name: demo
     kickoff_command: python -m clients.demo.driver
     kickoff_workdir: .

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -1,0 +1,254 @@
+"""
+GitHub Copilot CLI agent implementation for SREGym.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger("all.copilot.agent")
+
+
+class CopilotCliAgent:
+    """
+    The Copilot CLI agent uses GitHub's Copilot CLI tool to solve tasks.
+    """
+
+    _OUTPUT_FILENAME = "copilot-cli.txt"
+
+    @staticmethod
+    def check_installation() -> bool:
+        """Check if Copilot CLI is installed."""
+        return shutil.which("copilot") is not None
+
+    @staticmethod
+    def ensure_installed(auto_install: bool = True) -> None:
+        """
+        Ensure Copilot CLI is installed, optionally attempting installation.
+
+        Raises:
+            RuntimeError: If copilot is not installed and auto_install fails
+        """
+        if CopilotCliAgent.check_installation():
+            logger.info("Copilot CLI is already installed")
+            return
+
+        logger.warning("Copilot CLI not found in PATH")
+
+        if not auto_install:
+            raise RuntimeError(
+                "Copilot CLI is not installed. Please install it using:\n"
+                "  npm install -g @github/copilot\n"
+                "Or visit: https://docs.github.com/en/copilot/how-tos/copilot-cli"
+            )
+
+        logger.info("Attempting to install Copilot CLI via npm...")
+        try:
+            subprocess.check_call(
+                ["npm", "install", "-g", "@github/copilot"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            logger.info("Successfully installed Copilot CLI")
+
+            if not CopilotCliAgent.check_installation():
+                raise RuntimeError("Copilot CLI installation appeared to succeed but command is still not available")
+
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            error_msg = f"Failed to auto-install Copilot CLI: {e}\n"
+            if isinstance(e, FileNotFoundError):
+                error_msg += "npm is not installed. Please install Node.js and npm first.\n"
+            error_msg += (
+                "Please install Copilot CLI manually using:\n"
+                "  npm install -g @github/copilot\n"
+                "Or visit: https://docs.github.com/en/copilot/how-tos/copilot-cli"
+            )
+            raise RuntimeError(error_msg) from None
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        model_name: str,
+        copilot_home: Path | None = None,
+    ):
+        """
+        Initialize the Copilot CLI agent.
+
+        Args:
+            logs_dir: Directory to store logs and output
+            model_name: Model name to use (e.g., "gpt-4.1")
+            copilot_home: Directory for Copilot configuration (defaults to ~/.copilot)
+        """
+        self.logs_dir = Path(logs_dir)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+        self.model_name = model_name
+        self.copilot_home = Path(copilot_home) if copilot_home else Path.home() / ".copilot"
+
+        logger.info(f"Initialized Copilot CLI agent with model={model_name}")
+        logger.info(f"Logs dir: {self.logs_dir}")
+        logger.info(f"Copilot home: {self.copilot_home}")
+
+    @property
+    def output_path(self) -> Path:
+        """Path to Copilot CLI output file."""
+        return self.logs_dir / self._OUTPUT_FILENAME
+
+    @property
+    def otel_dir(self) -> Path:
+        """Path to OTel JSONL directory."""
+        return self.logs_dir / "otel"
+
+    @property
+    def transcript_path(self) -> Path:
+        """Path to session transcript markdown."""
+        return self.logs_dir / "copilot-session.md"
+
+    def get_usage_metrics(self) -> dict[str, int]:
+        """
+        Extract usage metrics from Copilot CLI OTel JSONL files.
+
+        Returns:
+            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
+        """
+        metrics = {
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0,
+        }
+
+        if not self.otel_dir.exists():
+            logger.debug("No OTel directory found for metrics")
+            return metrics
+
+        otel_files = list(self.otel_dir.glob("*.jsonl"))
+        if not otel_files:
+            logger.debug(f"No OTel JSONL files found in {self.otel_dir}")
+            return metrics
+
+        total_input = 0
+        total_output = 0
+        total_cached = 0
+
+        for otel_file in otel_files:
+            with open(otel_file) as handle:
+                for line in handle:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        event = json.loads(stripped)
+                        attrs = event.get("attributes", {})
+                        # OTel semantic conventions for GenAI
+                        total_input += attrs.get("gen_ai.usage.input_tokens", 0)
+                        total_output += attrs.get("gen_ai.usage.output_tokens", 0)
+                        total_cached += attrs.get("gen_ai.usage.cache_read_input_tokens", 0)
+                    except json.JSONDecodeError:
+                        continue
+
+        metrics["input_tokens"] = total_input
+        metrics["output_tokens"] = total_output
+        metrics["cached_input_tokens"] = total_cached
+
+        logger.info(f"Extracted usage metrics: {metrics}")
+        return metrics
+
+    def run(self, instruction: str) -> int:
+        """
+        Run the Copilot CLI agent with the given instruction.
+
+        Args:
+            instruction: The task instruction to pass to Copilot CLI
+
+        Returns:
+            Return code from Copilot CLI execution (0 for success)
+        """
+        model = self.model_name.split("/")[-1]
+
+        logger.info(f"Running Copilot CLI with model: {model}")
+
+        # Setup OTel directory for metrics capture
+        self.otel_dir.mkdir(parents=True, exist_ok=True)
+        otel_path = self.otel_dir / "copilot-otel.jsonl"
+
+        # Build environment variables
+        env = os.environ.copy()
+        env["COPILOT_HOME"] = str(self.copilot_home)
+        env["COPILOT_MODEL"] = model
+
+        # Enable OTel file export for token metrics
+        env["COPILOT_OTEL_ENABLED"] = "true"
+        env["COPILOT_OTEL_EXPORTER_TYPE"] = "file"
+        env["COPILOT_OTEL_FILE_EXPORTER_PATH"] = str(otel_path)
+
+        # Auth: BYOK mode (COPILOT_PROVIDER_BASE_URL) or GitHub-hosted
+        # (COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN)
+        byok_vars = ["COPILOT_PROVIDER_BASE_URL", "COPILOT_PROVIDER_API_KEY", "COPILOT_PROVIDER_TYPE"]
+        has_byok = bool(os.environ.get("COPILOT_PROVIDER_BASE_URL"))
+
+        token_vars = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+        has_github_auth = any(os.environ.get(v) for v in token_vars)
+
+        if not has_byok and not has_github_auth:
+            logger.error("=" * 80)
+            logger.error("ERROR: No authentication found for Copilot CLI")
+            logger.error("Option 1 - GitHub-hosted (set one of):")
+            logger.error("  - COPILOT_GITHUB_TOKEN (fine-grained PAT with Copilot Requests permission)")
+            logger.error("  - GH_TOKEN (GitHub CLI OAuth token)")
+            logger.error("  - GITHUB_TOKEN")
+            logger.error("Option 2 - BYOK (set all relevant):")
+            logger.error("  - COPILOT_PROVIDER_BASE_URL (required)")
+            logger.error("  - COPILOT_PROVIDER_API_KEY (required for remote providers)")
+            logger.error("  - COPILOT_PROVIDER_TYPE (openai|azure|anthropic, default: openai)")
+            logger.error("=" * 80)
+            return 1
+
+        # Pass through BYOK env vars if set
+        for var in byok_vars:
+            if os.environ.get(var):
+                env[var] = os.environ[var]
+
+        # Build command
+        command = [
+            "copilot",
+            "-p",
+            instruction,
+            "-s",
+            "--allow-all",
+            "--no-ask-user",
+            "--model",
+            model,
+            f"--share={self.transcript_path}",
+        ]
+
+        logger.info(f"Executing command: copilot -p <instruction> -s --allow-all --no-ask-user --model {model}")
+
+        try:
+            with open(self.output_path, "w") as out_file:
+                process = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    env=env,
+                    text=True,
+                    bufsize=1,
+                )
+
+                if process.stdout:
+                    for line in process.stdout:
+                        out_file.write(line)
+                        out_file.flush()
+                        print(line, end="", flush=True)
+
+                process.wait()
+
+            logger.info(f"Copilot CLI finished with return code: {process.returncode}")
+            return process.returncode
+
+        except Exception as e:
+            logger.error(f"Error running Copilot CLI: {e}")
+            raise

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -216,7 +216,6 @@ class CopilotCliAgent:
             "copilot",
             "-p",
             instruction,
-            "-s",
             "--allow-all",
             "--no-ask-user",
             "--model",
@@ -224,7 +223,7 @@ class CopilotCliAgent:
             f"--share={self.transcript_path}",
         ]
 
-        logger.info(f"Executing command: copilot -p <instruction> -s --allow-all --no-ask-user --model {model}")
+        logger.info(f"Executing command: copilot -p <instruction> --allow-all --no-ask-user --model {model}")
 
         try:
             with open(self.output_path, "w") as out_file:

--- a/clients/copilot/driver.py
+++ b/clients/copilot/driver.py
@@ -1,0 +1,301 @@
+"""
+GitHub Copilot CLI agent driver for SREGym.
+Entry point for running Copilot CLI agent on SREGym tasks.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+from clients.copilot.copilot_agent import CopilotCliAgent
+from clients.harness.problem_id import resolve_problem_id
+from logger import init_logger
+
+# Add SREGym root to path
+sregym_root = Path(__file__).resolve().parents[2]
+if str(sregym_root) not in sys.path:
+    sys.path.insert(0, str(sregym_root))
+
+
+init_logger()
+
+logger = logging.getLogger("all.copilot.driver")
+
+
+def run_preflight() -> None:
+    """Validate model + credentials by making a minimal Copilot CLI call."""
+    import subprocess
+
+    m = os.environ.get("AGENT_MODEL_ID", "gpt-4.1").split("/")[-1]
+
+    r = subprocess.run(
+        ["copilot", "-p", "say ok", "-s", "--model", m, "--no-ask-user"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if r.returncode:
+        print(r.stdout or r.stderr)
+    sys.exit(r.returncode)
+
+
+def get_api_base_url() -> str:
+    """Get the conductor API base URL."""
+    host = os.getenv("API_HOSTNAME", "localhost")
+    port = os.getenv("API_PORT", "8000")
+    return f"http://{host}:{port}"
+
+
+def get_app_info() -> dict:
+    """Get application info from conductor API."""
+    api_url = f"{get_api_base_url()}/get_app"
+    logger.info(f"Fetching app info from {api_url}")
+
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
+        app_info = response.json()
+        logger.info(f"App info: {app_info}")
+        return app_info
+    except Exception as e:
+        logger.error(f"Failed to get app info: {e}")
+        raise
+
+
+def wait_for_ready_stage(timeout: int = 300) -> str:
+    """
+    Wait for conductor to reach a submission-ready stage (diagnosis or mitigation).
+
+    Returns:
+        Current stage name
+
+    Raises:
+        TimeoutError: If timeout is reached before ready
+    """
+    import time
+
+    api_url = f"{get_api_base_url()}/status"
+    allowed_stages = {"diagnosis", "mitigation"}
+    start_time = time.time()
+
+    logger.info("Waiting for conductor to reach submission-ready stage...")
+
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(api_url)
+            response.raise_for_status()
+            status_data = response.json()
+            stage = status_data.get("stage")
+
+            if stage in allowed_stages:
+                logger.info(f"Conductor ready at stage: {stage}")
+                return stage
+            else:
+                logger.debug(f"Current stage: {stage}, waiting for {allowed_stages}...")
+                time.sleep(1)
+
+        except Exception as e:
+            logger.debug(f"Error checking status: {e}, retrying...")
+            time.sleep(1)
+
+    raise TimeoutError(f"Conductor did not reach ready stage within {timeout} seconds")
+
+
+def build_instruction(app_info: dict) -> str:
+    """
+    Build the instruction string for Copilot CLI.
+
+    Args:
+        app_info: Application information from conductor
+
+    Returns:
+        Instruction string to pass to Copilot CLI
+    """
+    app_name = app_info.get("app_name", "unknown")
+    namespace = app_info.get("namespace", "default")
+    namespaces = app_info.get("namespaces") or [namespace]
+    descriptions = app_info.get("descriptions", "")
+
+    if len(namespaces) > 1:
+        namespace_block = (
+            f"Namespaces: {', '.join(namespaces)}\n(This scenario spans multiple namespaces; investigate all of them.)"
+        )
+    else:
+        namespace_block = f"Namespace: {namespaces[0]}"
+
+    instruction = f"""You are an SRE agent tasked with diagnosing and fixing issues in a Kubernetes application.
+
+Application: {app_name}
+{namespace_block}
+
+{descriptions}
+
+CRITICAL: You are running in an AUTOMATED environment. Work autonomously and make all decisions yourself. DO NOT ask for user confirmation or approval. Proceed with the best solution based on your analysis.
+
+WORKFLOW: You will perform TWO tasks in sequence:
+
+TASK 1: DIAGNOSIS
+- Investigate the application to detect any anomalies or issues
+- Analyze metrics, logs, and traces
+- When ready, submit a natural language description of the issue you found
+- Your diagnosis is evaluated on whether you correctly identify the faulty components and root cause
+
+TASK 2: MITIGATION
+- Identify the root cause of the issue
+- Implement a fix to resolve the problem
+- When the fix is applied, submit to trigger validation
+- Your mitigation is evaluated on whether the application is healthy after your changes
+- Your fix is also evaluated on whether it addresses the root cause, not just the symptoms
+
+HOW TO SUBMIT:
+
+The submission endpoint is: {get_api_base_url()}/submit
+
+For DIAGNOSIS stage:
+- Submit with a natural language description of the issue
+- Example: POST {get_api_base_url()}/submit with JSON: {{"solution": "The frontend service is crashing due to missing environment variable"}}
+
+For MITIGATION stage:
+- Submit with an EMPTY STRING after you have applied the fix
+- POST {get_api_base_url()}/submit with JSON: {{"solution": ""}}
+
+Important:
+- You have access to kubectl commands to inspect and modify resources in namespace(s): {", ".join(namespaces)}
+- You can query metrics and traces through the available observability tools
+- The conductor API is available at {get_api_base_url()}
+"""
+
+    logger.info(f"Built instruction:\n{instruction}")
+    return instruction
+
+
+def save_results(
+    logs_dir: Path,
+    problem_id: str,
+    return_code: int,
+    usage_metrics: dict,
+) -> None:
+    """Save run results to JSON file."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    results_file = logs_dir / f"copilot_results_{problem_id}_{timestamp}.json"
+
+    results = {
+        "problem_id": problem_id,
+        "timestamp": timestamp,
+        "return_code": return_code,
+        "success": return_code == 0,
+        "usage_metrics": usage_metrics,
+    }
+
+    with open(results_file, "w") as f:
+        json.dump(results, f, indent=2)
+
+    logger.info(f"Saved results to {results_file}")
+
+
+def main():
+    """Main entry point for Copilot CLI agent driver."""
+    parser = argparse.ArgumentParser(description="Run Copilot CLI agent on SREGym tasks")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=os.getenv("AGENT_MODEL_ID", "gpt-4.1"),
+        help="Model to use for Copilot CLI (default: from AGENT_MODEL_ID env var or gpt-4.1)",
+    )
+    parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=os.environ.get("AGENT_LOGS_DIR", "./logs/copilot"),
+        help="Directory to store logs (default: ./logs/copilot)",
+    )
+    parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: SREGYM_PROBLEM_ID when launched via main.py)",
+    )
+    parser.add_argument(
+        "--copilot-home",
+        type=str,
+        default=None,
+        help="Copilot home directory (default: ~/.copilot)",
+    )
+    parser.add_argument(
+        "--no-auto-install",
+        action="store_true",
+        help="Disable auto-installation of Copilot CLI if not found",
+    )
+
+    args = parser.parse_args()
+
+    logger.info("=" * 80)
+    logger.info("Starting Copilot CLI agent for SREGym")
+    logger.info(f"Model: {args.model}")
+    logger.info(f"Logs directory: {args.logs_dir}")
+    logger.info("=" * 80)
+
+    # Check if Copilot CLI is installed
+    try:
+        CopilotCliAgent.ensure_installed(auto_install=not args.no_auto_install)
+    except RuntimeError as e:
+        logger.error(f"Copilot CLI installation check failed: {e}")
+        sys.exit(1)
+
+    # Wait for conductor to be ready
+    try:
+        stage = wait_for_ready_stage(timeout=300)
+        logger.info(f"Conductor is ready at stage: {stage}")
+    except TimeoutError as e:
+        logger.error(f"Timeout waiting for conductor: {e}")
+        sys.exit(1)
+
+    try:
+        app_info = get_app_info()
+    except Exception as e:
+        logger.error(f"Failed to get app info: {e}")
+        sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id)
+    logger.info(f"Problem ID (harness): {problem_id}")
+
+    # Build instruction
+    instruction = build_instruction(app_info)
+
+    # Initialize Copilot CLI agent
+    logs_dir = Path(args.logs_dir)
+    copilot_home = Path(args.copilot_home) if args.copilot_home else None
+
+    agent = CopilotCliAgent(
+        logs_dir=logs_dir,
+        model_name=args.model,
+        copilot_home=copilot_home,
+    )
+
+    # Run Copilot CLI
+    logger.info("Starting Copilot CLI execution...")
+    return_code = agent.run(instruction)
+
+    # Get usage metrics
+    usage_metrics = agent.get_usage_metrics()
+
+    # Save results
+    save_results(logs_dir, problem_id, return_code, usage_metrics)
+
+    # Log summary
+    logger.info("=" * 80)
+    logger.info("Copilot CLI execution completed")
+    logger.info(f"Return code: {return_code}")
+    logger.info(f"Usage metrics: {usage_metrics}")
+    logger.info("=" * 80)
+
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/agents/install-scripts/install-copilot.sh
+++ b/docker/agents/install-scripts/install-copilot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+VERSION="${AGENT_VERSION:-latest}"
+echo "[$(date -Iseconds)] Installing GitHub Copilot CLI (version: $VERSION)..."
+if [ "$VERSION" = "latest" ]; then
+    npm install -g @github/copilot
+else
+    npm install -g "@github/copilot@$VERSION"
+fi
+echo "[$(date -Iseconds)] Copilot CLI installed: $(copilot version)"

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ def run_preflight_check(
         "stratus": "clients.stratus.stratus_agent.driver.driver",
         "claudecode": "clients.claudecode.driver",
         "codex": "clients.codex.driver",
+        "copilot": "clients.copilot.driver",
     }
 
     module_path = agent_driver_modules.get(agent_name)

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -118,6 +118,11 @@ class ContainerRunner:
         "GLM_API_KEY",
         # Claude Code
         "CLAUDE_CODE_OAUTH_TOKEN",
+        # GitHub Copilot CLI
+        "COPILOT_GITHUB_TOKEN",
+        "COPILOT_PROVIDER_BASE_URL",
+        "COPILOT_PROVIDER_API_KEY",
+        "COPILOT_PROVIDER_TYPE",
         # SREGym internal
         "AGENT_MODEL_ID",
         "JUDGE_MODEL_ID",


### PR DESCRIPTION
Adds `copilot` as a new agent.

Supports both GitHub-hosted mode (via `COPILOT_GITHUB_TOKEN`) and BYOK mode (Anthropic, OpenAI, Azure, local models via `COPILOT_PROVIDER_*` env vars).

**Usage:**

*BYOK with Anthropic*
```bash
export COPILOT_PROVIDER_TYPE=anthropic
export COPILOT_PROVIDER_BASE_URL=https://api.anthropic.com
export COPILOT_PROVIDER_API_KEY=sk-ant-...

uv run main.py --agent copilot --model claude-sonnet-4-6 --problem <problem_id> --force-build
```
*Copilot subscription (did not test this!)*
```bash
export COPILOT_GITHUB_TOKEN=github_pat_...

uv run main.py --agent copilot --model claude-sonnet-4-6 --problem <problem_id> --force-build

```
---
@yimingsu01 I tested the byok version ([copilot-session.md](https://github.com/user-attachments/files/29104804/copilot-session.md)). As I don't have copilot sub need help testing that.