### PR TITLE
Fix kind cluster detection

### DIFF
--- a/sregym/generators/fault/inject_remote_os.py
+++ b/sregym/generators/fault/inject_remote_os.py
@@ -1,5 +1,6 @@
 """Inject faults at the OS layer via SSH (remote clusters) or docker exec (Kind)."""
 
+import json
 import os
 import re
 import shlex
@@ -27,9 +28,19 @@ class RemoteOSFaultInjector(FaultInjector):
     def _check_is_kind(self):
         """Detect if the cluster is Kind-based."""
         if self._is_kind is None:
-            out = self.kubectl.exec_command("kubectl get nodes")
-            self._is_kind = "kind-worker" in out
+            self._is_kind = any(
+                (node.get("spec", {}).get("providerID") or "").startswith("kind://") for node in self._get_node_items()
+            )
         return self._is_kind
+
+    def _get_node_items(self):
+        """Return Kubernetes node objects from the current kubectl context."""
+        output = self.kubectl.exec_command("kubectl get nodes -o json")
+        return json.loads(output).get("items", [])
+
+    def _is_control_plane_node(self, node):
+        labels = node.get("metadata", {}).get("labels", {})
+        return "node-role.kubernetes.io/control-plane" in labels or "node-role.kubernetes.io/master" in labels
 
     def _check_remote_host(self):
         """Verify the remote cluster has an inventory file."""
@@ -99,16 +110,15 @@ class RemoteOSFaultInjector(FaultInjector):
         return result.stdout
 
     def _get_kind_worker_containers(self):
-        """Get Kind worker container names."""
-        result = subprocess.run(
-            ["docker", "ps", "--filter", "name=kind-worker", "--format", "{{.Names}}"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            print(f"Failed to list Kind containers: {result.stderr.strip()}")
-            return []
-        containers = [c.strip() for c in result.stdout.strip().splitlines() if c.strip()]
+        """Get Kind worker container names from the current kubectl context."""
+        containers = []
+        for node in self._get_node_items():
+            if self._is_control_plane_node(node):
+                continue
+            provider_id = node.get("spec", {}).get("providerID") or ""
+            if provider_id.startswith("kind://"):
+                containers.append(provider_id.rsplit("/", 1)[-1])
+
         if not containers:
             print("No Kind worker containers found.")
         return containers
@@ -308,7 +318,12 @@ class RemoteOSFaultInjector(FaultInjector):
 
     def recover_disk_pressure_all(self):
         """Strip the nodefs.available eviction threshold on every worker node."""
-        nodes = self._get_kind_worker_containers() if self._check_is_kind() else self._get_worker_node_names()
+        if self._check_is_kind():
+            nodes = self._get_kind_worker_containers()
+        else:
+            if not self._check_remote_host():
+                return
+            nodes = self._get_worker_node_names()
         for node_name in nodes:
             self.recover_disk_pressure(node_name)
 

--- a/sregym/generators/fault/inject_remote_os.py
+++ b/sregym/generators/fault/inject_remote_os.py
@@ -28,15 +28,20 @@ class RemoteOSFaultInjector(FaultInjector):
     def _check_is_kind(self):
         """Detect if the cluster is Kind-based."""
         if self._is_kind is None:
-            self._is_kind = any(
-                (node.get("spec", {}).get("providerID") or "").startswith("kind://") for node in self._get_node_items()
-            )
+            nodes = self._get_node_items()
+            if nodes is None:
+                return False
+            self._is_kind = any((node.get("spec", {}).get("providerID") or "").startswith("kind://") for node in nodes)
         return self._is_kind
 
     def _get_node_items(self):
         """Return Kubernetes node objects from the current kubectl context."""
         output = self.kubectl.exec_command("kubectl get nodes -o json")
-        return json.loads(output).get("items", [])
+        try:
+            return json.loads(output).get("items", [])
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            print("Failed to read Kubernetes node data from kubectl.")
+            return None
 
     def _is_control_plane_node(self, node):
         labels = node.get("metadata", {}).get("labels", {})
@@ -112,7 +117,10 @@ class RemoteOSFaultInjector(FaultInjector):
     def _get_kind_worker_containers(self):
         """Get Kind worker container names from the current kubectl context."""
         containers = []
-        for node in self._get_node_items():
+        nodes = self._get_node_items()
+        if nodes is None:
+            return containers
+        for node in nodes:
             if self._is_control_plane_node(node):
                 continue
             provider_id = node.get("spec", {}).get("providerID") or ""

--- a/tests/generators/test_inject_remote_os.py
+++ b/tests/generators/test_inject_remote_os.py
@@ -82,6 +82,21 @@ def test_check_is_kind_keeps_remote_clusters_on_remote_path():
     assert injector._check_is_kind() is False
 
 
+def test_check_is_kind_retries_after_invalid_kubectl_output():
+    injector = _injector([])
+    outputs = iter(
+        [
+            "Unable to connect to the server: connection refused",
+            json.dumps({"items": [_node("custom-worker", "kind://docker/custom/custom-worker")]}),
+        ]
+    )
+    injector.kubectl.exec_command = lambda command: next(outputs)
+
+    assert injector._check_is_kind() is False
+    assert injector._is_kind is None
+    assert injector._check_is_kind() is True
+
+
 def test_recover_disk_pressure_all_skips_remote_cluster_without_inventory():
     injector = object.__new__(RemoteOSFaultInjector)
     injector._check_is_kind = lambda: False

--- a/tests/generators/test_inject_remote_os.py
+++ b/tests/generators/test_inject_remote_os.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+
+from sregym.generators.fault.inject_remote_os import RemoteOSFaultInjector
+
+
+class FakeKubectl:
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def exec_command(self, command):
+        if command == "kubectl get nodes -o json":
+            return json.dumps({"items": self.nodes})
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def _node(name, provider_id="", labels=None):
+    return {
+        "metadata": {
+            "name": name,
+            "labels": labels or {},
+        },
+        "spec": {
+            "providerID": provider_id,
+        },
+    }
+
+
+def _injector(nodes):
+    injector = object.__new__(RemoteOSFaultInjector)
+    injector.kubectl = FakeKubectl(nodes)
+    injector.worker_info = None
+    injector._is_kind = None
+    return injector
+
+
+def test_check_is_kind_detects_custom_named_kind_cluster():
+    injector = _injector(
+        [
+            _node(
+                "sregym-copilot-20036-control-plane",
+                "kind://docker/sregym-copilot-20036/sregym-copilot-20036-control-plane",
+                {"node-role.kubernetes.io/control-plane": ""},
+            ),
+            _node(
+                "sregym-copilot-20036-worker",
+                "kind://docker/sregym-copilot-20036/sregym-copilot-20036-worker",
+            ),
+        ]
+    )
+
+    assert injector._check_is_kind() is True
+
+
+def test_get_kind_worker_containers_uses_current_context_provider_ids():
+    injector = _injector(
+        [
+            _node(
+                "sregym-copilot-20036-control-plane",
+                "kind://docker/sregym-copilot-20036/sregym-copilot-20036-control-plane",
+                {"node-role.kubernetes.io/control-plane": ""},
+            ),
+            _node(
+                "sregym-copilot-20036-worker",
+                "kind://docker/sregym-copilot-20036/sregym-copilot-20036-worker",
+            ),
+        ]
+    )
+
+    assert injector._get_kind_worker_containers() == ["sregym-copilot-20036-worker"]
+
+
+def test_check_is_kind_keeps_remote_clusters_on_remote_path():
+    injector = _injector(
+        [
+            _node("worker-1", "aws:///us-east-1a/i-1234567890abcdef0"),
+            _node("worker-2", ""),
+        ]
+    )
+
+    assert injector._check_is_kind() is False
+
+
+def test_recover_disk_pressure_all_skips_remote_cluster_without_inventory():
+    injector = object.__new__(RemoteOSFaultInjector)
+    injector._check_is_kind = lambda: False
+    injector._check_remote_host = lambda: False
+    injector._get_worker_node_names = lambda: pytest.fail("should not list workers without inventory")
+    injector.recover_disk_pressure = lambda node_name: pytest.fail("should not recover without inventory")
+
+    injector.recover_disk_pressure_all()


### PR DESCRIPTION
## Fix custom-named kind clusters being incorrectly treated as remote clusters

- Detect kind using node providerID
- Resolve workers from the current cluster's provider IDs
- Safely handle failed kubectl output and missing remote inventory

Fixes #895 