### PR TITLE
Agent internet access control via egress proxy

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from sregym.conductor.conductor_api import request_shutdown, run_api
 from sregym.conductor.constants import StartProblemResult
 from sregym.run_artifacts import ArtifactFinalizationError, RunArtifacts
 from sregym.service.container_runner import ContainerRunner, ExecInput
+from sregym.service.egress_proxy import DEFAULT_DENY_DOMAINS, EgressProxy
 
 LAUNCHER = AgentLauncher()
 logger = logging.getLogger(__name__)
@@ -493,6 +494,18 @@ def main(args):
 
     logger.info(f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}")
 
+    # Start egress proxy if internet access is restricted
+    internet_access = args.internet_access
+    egress_proxy = None
+    if internet_access != "on":
+        deny = list(DEFAULT_DENY_DOMAINS) if internet_access == "filtered" else []
+        egress_proxy = EgressProxy(mode=internet_access, deny_domains=deny)
+        port = egress_proxy.start()
+        LAUNCHER.set_proxy(f"http://host.docker.internal:{port}", ca_bundle=egress_proxy.ca_bundle_path)
+        logger.info(f"🛡️ Internet access: {internet_access} (proxy port {port})")
+    else:
+        logger.info("🌐 Internet access: unrestricted")
+
     # Only build/check agent container image if the agent requires it
     agent_reg = (
         get_agent(args.agent, path=Path(os.path.dirname(os.path.abspath(__file__))) / "agents.yaml")
@@ -510,7 +523,11 @@ def main(args):
         install_script=agent_reg.install_script if agent_reg else None,
     )
 
-    conductor_config = ConductorConfig(deploy_loki=not args.use_external_harness, enable_noise=args.noise)
+    conductor_config = ConductorConfig(
+        deploy_loki=not args.use_external_harness,
+        enable_noise=args.noise,
+        internet_access=internet_access,
+    )
     conductor = Conductor(config=conductor_config)
 
     # Start the driver in the background; it will call request_shutdown() when finished
@@ -553,6 +570,14 @@ def main(args):
 
         # Give driver a moment to finish setting results
         driver_thread.join(timeout=5)
+
+        # Log blocked requests (read from file while proxy is still up),
+        # then stop the process and clean up temp files.
+        if egress_proxy:
+            for req in egress_proxy.blocked_requests():
+                logger.info(f"🚫 {req}")
+            egress_proxy.stop()
+            egress_proxy.cleanup()
 
     # When API shuts down, collect results from driver
     results = _driver_results
@@ -640,6 +665,13 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Resume from a previous results CSV file. Problems already in the CSV will be skipped.",
+    )
+    parser.add_argument(
+        "--internet-access",
+        type=str,
+        choices=["on", "off", "filtered"],
+        default="filtered",
+        help="Agent internet access: 'on' (unrestricted), 'off' (cluster-only), 'filtered' (deny SREGym repo, default)",
     )
     args = parser.parse_args()
 

--- a/sregym/agent_launcher.py
+++ b/sregym/agent_launcher.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from clients.harness.problem_id import HARNESS_ARTIFACT_ID_ENV, HARNESS_PROBLEM_ID_ENV
 from sregym.service.container_runner import ContainerConfig, ContainerRunner, ExecInput
+from sregym.service.egress_proxy import CA_BUNDLE_ENV_VARS, NO_PROXY
 
 from .agent_registry import AgentRegistration
 
@@ -32,6 +33,8 @@ class AgentLauncher:
         self._agent_kubeconfig_path: str | None = None
         self._use_containers: bool = True
         self._container_runner: ContainerRunner | None = None
+        self._proxy_url: str | None = None
+        self._proxy_ca_bundle: Path | None = None
 
     def set_agent_kubeconfig(self, kubeconfig_path: str | None):
         """
@@ -39,6 +42,11 @@ class AgentLauncher:
         This is typically the filtered kubeconfig from the K8s proxy.
         """
         self._agent_kubeconfig_path = kubeconfig_path
+
+    def set_proxy(self, url: str | None, ca_bundle: Path | None = None):
+        """Set the egress proxy URL and CA bundle for agent containers."""
+        self._proxy_url = url
+        self._proxy_ca_bundle = ca_bundle
 
     def enable_container_isolation(self, force_build: bool = False):
         """Initialize the container runner and build/check the image."""
@@ -48,6 +56,8 @@ class AgentLauncher:
                 logs_path=Path("./logs"),
                 sregym_apps_path=Path("./SREGym-applications"),
                 sregym_app_subdirs=["socialNetwork/wrk2", "hotelReservation/wrk2"],
+                proxy_url=self._proxy_url,
+                proxy_ca_bundle=self._proxy_ca_bundle,
             )
             self._container_runner = ContainerRunner(config)
             if force_build:
@@ -79,6 +89,18 @@ class AgentLauncher:
         # Use filtered kubeconfig if set (hides chaos engineering namespaces)
         if self._agent_kubeconfig_path:
             env["KUBECONFIG"] = self._agent_kubeconfig_path
+
+        if self._proxy_url:
+            env["http_proxy"] = self._proxy_url
+            env["https_proxy"] = self._proxy_url
+            env["HTTP_PROXY"] = self._proxy_url
+            env["HTTPS_PROXY"] = self._proxy_url
+            env["no_proxy"] = NO_PROXY
+            env["NO_PROXY"] = NO_PROXY
+            if self._proxy_ca_bundle and self._proxy_ca_bundle.exists():
+                ca = str(self._proxy_ca_bundle)
+                for var in CA_BUNDLE_ENV_VARS:
+                    env[var] = ca
 
         proc = subprocess.Popen(
             reg.kickoff_command,

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -38,6 +38,7 @@ class ConductorConfig:
 
     deploy_loki: bool = True
     enable_noise: bool = False
+    internet_access: str = "filtered"
 
 
 class Conductor:
@@ -81,6 +82,7 @@ class Conductor:
 
         self.tasklist = None
         self.logger = logging.getLogger("all.sregym.conductor")
+        self.logger.info(f"Internet access mode: {self.config.internet_access}")
 
         self.stage_sequence: list[dict] = []
         self.current_stage_index: int = 0

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -7,6 +7,8 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from sregym.service.egress_proxy import CA_BUNDLE_ENV_VARS, NO_PROXY
+
 logger = logging.getLogger("all.sregym.container_runner")
 
 
@@ -32,6 +34,8 @@ class ContainerConfig:
     env_vars: dict = field(default_factory=dict)
     cpus: float = 4.0
     memory: str = "8g"
+    proxy_url: str | None = None
+    proxy_ca_bundle: Path | None = None
 
 
 class ContainerRunner:
@@ -167,6 +171,18 @@ class ContainerRunner:
             mcp_port = env_vars.get("MCP_SERVER_PORT", os.environ.get("MCP_SERVER_PORT", "9954"))
             env_vars["MCP_SERVER_URL"] = f"http://host.docker.internal:{mcp_port}"
 
+        if self.config.proxy_url:
+            env_vars["http_proxy"] = self.config.proxy_url
+            env_vars["https_proxy"] = self.config.proxy_url
+            env_vars["HTTP_PROXY"] = self.config.proxy_url
+            env_vars["HTTPS_PROXY"] = self.config.proxy_url
+            env_vars["no_proxy"] = NO_PROXY
+            env_vars["NO_PROXY"] = NO_PROXY
+            if self.config.proxy_ca_bundle:
+                ca_bundle_container = "/etc/ssl/certs/sregym-ca-bundle.pem"
+                for var in CA_BUNDLE_ENV_VARS:
+                    env_vars[var] = ca_bundle_container
+
         for key, value in env_vars.items():
             flags.extend(["-e", f"{key}={value}"])
         return flags
@@ -215,6 +231,10 @@ class ContainerRunner:
         codex_dir = Path.home() / ".codex"
         if codex_dir.is_dir():
             args.extend(["-v", f"{codex_dir.resolve()}:/root/.codex"])
+
+        # Mount combined CA bundle (system CAs + proxy CA) for MITM TLS
+        if self.config.proxy_ca_bundle and self.config.proxy_ca_bundle.exists():
+            args.extend(["-v", f"{self.config.proxy_ca_bundle.resolve()}:/etc/ssl/certs/sregym-ca-bundle.pem:ro"])
 
         # Mount workspace directory for agent output (logs, results, trajectories)
         if self.config.workspace_path:

--- a/sregym/service/egress_proxy.py
+++ b/sregym/service/egress_proxy.py
@@ -1,0 +1,285 @@
+"""HTTPS-capable egress proxy with path-level domain deny list.
+
+Uses ``mitmdump`` (from the ``mitmproxy`` package) as a subprocess so that
+HTTPS requests can be intercepted and inspected at the URL-path level — not
+just by hostname.  A small addon script is written to a temp file and loaded
+by ``mitmdump``; it checks every request against a configurable deny list and
+returns 403 for matches.
+
+The proxy generates a CA certificate on first run and stores it in a
+per-session temp directory.  The CA cert is **appended** to a copy of the
+system CA bundle so that the agent container trusts both the proxy and all
+real CAs (API providers, etc.).
+
+Requires ``mitmdump`` to be installed — e.g. ``uv tool install mitmproxy``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import signal
+import socket
+import ssl
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+NO_PROXY = "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,host.docker.internal,.svc,.cluster.local"
+
+CA_BUNDLE_ENV_VARS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE")
+
+DEFAULT_DENY_DOMAINS: list[str] = [
+    "github.com/SREGym",
+    "raw.githubusercontent.com/SREGym",
+    "api.github.com/repos/SREGym",
+    "codeload.github.com/SREGym",
+]
+
+# mitmproxy addon script loaded by mitmdump at runtime.
+_ADDON_SCRIPT = '''\
+"""mitmproxy addon — deny-list filter for SREGym egress proxy."""
+import json
+import os
+from mitmproxy import http
+
+DENY_LIST: list[str] = json.loads(os.environ.get("SREGYM_DENY_DOMAINS", "[]"))
+PROXY_MODE: str = os.environ.get("SREGYM_PROXY_MODE", "filtered")
+BLOCK_LOG_PATH: str = os.environ.get("SREGYM_BLOCK_LOG", "")
+
+
+def _is_denied(host: str, path: str) -> bool:
+    for entry in DENY_LIST:
+        if "/" in entry:
+            deny_host, deny_path = entry.split("/", 1)
+            if host == deny_host and path.lstrip("/").startswith(deny_path):
+                return True
+        else:
+            if host == entry:
+                return True
+    return False
+
+
+def request(flow: http.HTTPFlow) -> None:
+    host = flow.request.pretty_host
+    path = flow.request.path
+
+    if PROXY_MODE == "off" or _is_denied(host, path):
+        msg = f"Blocked by SREGym egress policy: {host}{path}"
+        flow.response = http.Response.make(403, msg, {"Content-Type": "text/plain"})
+        if BLOCK_LOG_PATH:
+            try:
+                with open(BLOCK_LOG_PATH, "a") as f:
+                    f.write(msg + "\\n")
+            except OSError:
+                pass
+'''
+
+
+def _find_mitmdump() -> str:
+    """Locate the ``mitmdump`` binary, preferring uv-tool-managed installs.
+
+    The uv-tool install (``~/.local/bin/mitmdump``) is checked first because
+    it runs in its own isolated virtualenv, avoiding dependency conflicts with
+    the project's pinned ``cryptography`` version.
+    """
+    # 1. Prefer uv tool install — isolated from project deps
+    uv_tool_path = Path.home() / ".local" / "bin" / "mitmdump"
+    if uv_tool_path.exists():
+        return str(uv_tool_path)
+
+    # 2. Fall back to PATH (may be a system or pipx install)
+    path = shutil.which("mitmdump")
+    if path:
+        return path
+
+    raise FileNotFoundError(
+        "mitmdump not found — required for --internet-access filtered|off.\n"
+        "Install it with:  uv tool install mitmproxy\n"
+        "Or:               pip install mitmproxy"
+    )
+
+
+def _build_combined_ca_bundle(proxy_ca_cert: Path, output_path: Path) -> None:
+    """Create a CA bundle containing the system CAs plus the proxy CA.
+
+    This avoids replacing the system trust store (which would break connections
+    to API providers like Anthropic, OpenAI, AWS Bedrock, etc.).
+
+    Note: uses the *host's* system CAs, not the container's.  The standard
+    Mozilla/CA root set is nearly identical across host and container, so this
+    works in practice.  If the container image ships a stripped CA bundle, this
+    may need revisiting.
+    """
+    # Get the system CA bundle path
+    system_ca = ssl.get_default_verify_paths().cafile
+    if system_ca and Path(system_ca).exists():
+        system_certs = Path(system_ca).read_text()
+    else:
+        # Fall back to certifi if available, else empty
+        try:
+            import certifi
+
+            system_certs = Path(certifi.where()).read_text()
+        except ImportError:
+            system_certs = ""
+
+    proxy_cert = proxy_ca_cert.read_text()
+    output_path.write_text(system_certs.rstrip("\n") + "\n" + proxy_cert)
+
+
+def _pick_free_port() -> int:
+    """Bind to port 0, record the OS-assigned port, then close the socket."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+class EgressProxy:
+    """Host-side MITM proxy enforcing a domain deny list with path-level
+    granularity for both HTTP and HTTPS.
+
+    Uses ``mitmdump`` as a subprocess.  Generates a CA certificate that must
+    be mounted into agent containers for HTTPS interception.
+
+    Usage::
+
+        proxy = EgressProxy(mode="filtered", deny_domains=[...])
+        port = proxy.start()
+        ca_bundle = proxy.ca_bundle_path  # mount this into the container
+        # … run agent containers with http_proxy / https_proxy / SSL_CERT_FILE
+        proxy.stop()
+        print(proxy.blocked_requests())
+    """
+
+    def __init__(
+        self,
+        mode: str = "filtered",
+        deny_domains: list[str] | None = None,
+    ):
+        if mode not in ("on", "off", "filtered"):
+            raise ValueError(f"Invalid mode: {mode!r} — expected 'on', 'off', or 'filtered'")
+        self.mode = mode
+        self.deny_domains = deny_domains or list(DEFAULT_DENY_DOMAINS)
+        self._proc: subprocess.Popen | None = None
+        self._tmpdir: str | None = None
+        self.port: int | None = None
+
+    @property
+    def ca_bundle_path(self) -> Path | None:
+        """Path to the combined CA bundle (system CAs + proxy CA) for containers."""
+        if self._tmpdir:
+            return Path(self._tmpdir) / "sregym-ca-bundle.pem"
+        return None
+
+    def start(self) -> int:
+        """Start the proxy on a free port and return the port number."""
+        if self.mode == "on":
+            raise RuntimeError("Proxy should not be started in 'on' mode")
+
+        mitmdump = _find_mitmdump()
+        self._tmpdir = tempfile.mkdtemp(prefix="sregym-egress-")
+        tmpdir = Path(self._tmpdir)
+
+        addon_path = tmpdir / "deny_addon.py"
+        addon_path.write_text(_ADDON_SCRIPT)
+
+        block_log = tmpdir / "blocked.log"
+
+        env = os.environ.copy()
+        env["SREGYM_DENY_DOMAINS"] = json.dumps(self.deny_domains)
+        env["SREGYM_PROXY_MODE"] = self.mode
+        env["SREGYM_BLOCK_LOG"] = str(block_log)
+
+        self.port = _pick_free_port()
+        cmd = [
+            mitmdump,
+            "-q",
+            "--set",
+            f"confdir={tmpdir}",
+            "-p",
+            str(self.port),
+            "--set",
+            "stream_large_bodies=1m",
+            "-s",
+            str(addon_path),
+        ]
+
+        self._proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+
+        self._wait_for_ready(tmpdir)
+
+        # Build combined CA bundle (system CAs + proxy CA) so that
+        # SSL_CERT_FILE doesn't replace the system trust store.
+        proxy_ca = tmpdir / "mitmproxy-ca-cert.pem"
+        _build_combined_ca_bundle(proxy_ca, tmpdir / "sregym-ca-bundle.pem")
+
+        logger.info(f"Egress proxy started on port {self.port} (mode={self.mode}, pid={self._proc.pid})")
+        return self.port
+
+    def stop(self):
+        """Stop the proxy subprocess. Temp files are kept until cleanup()."""
+        if self._proc:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGTERM)
+            self._proc.wait(timeout=5)
+            self._proc = None
+            logger.info("Egress proxy stopped")
+
+    def cleanup(self):
+        """Remove temp files (CA bundle, addon script, block log).
+
+        Call this only after all agent containers have exited — the CA bundle
+        is bind-mounted into containers, so removing it while they're running
+        breaks their HTTPS trust.
+        """
+        if self._tmpdir and Path(self._tmpdir).exists():
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            self._tmpdir = None
+
+    def blocked_requests(self) -> list[str]:
+        """Return the list of blocked requests (read from the log file)."""
+        if not self._tmpdir:
+            return []
+        log_path = Path(self._tmpdir) / "blocked.log"
+        if not log_path.exists():
+            return []
+        return [line.strip() for line in log_path.read_text().splitlines() if line.strip()]
+
+    def _wait_for_ready(self, confdir: Path, timeout: float = 15) -> None:
+        """Wait for mitmdump to start listening and generate its CA cert.
+
+        Polls with a TCP connect to the configured port and checks for the
+        CA certificate file on disk.
+        """
+        deadline = time.monotonic() + timeout
+        ca_cert = confdir / "mitmproxy-ca-cert.pem"
+
+        while time.monotonic() < deadline:
+            if self._proc and self._proc.poll() is not None:
+                remaining = self._proc.stderr.read() if self._proc.stderr else ""
+                raise RuntimeError(f"mitmdump exited with code {self._proc.returncode}: {remaining}")
+
+            port_up = False
+            with contextlib.suppress(OSError), socket.create_connection(("127.0.0.1", self.port), timeout=0.5):
+                port_up = True
+
+            if port_up and ca_cert.exists():
+                return
+
+            time.sleep(0.2)
+
+        raise TimeoutError(f"Egress proxy did not start within {timeout}s")

--- a/tests/service/test_egress_proxy.py
+++ b/tests/service/test_egress_proxy.py
@@ -1,0 +1,276 @@
+"""Tests for the egress proxy and proxy env-var injection."""
+
+import shutil
+import ssl
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sregym.service.container_runner import ContainerConfig, ContainerRunner
+from sregym.service.egress_proxy import (
+    CA_BUNDLE_ENV_VARS,
+    DEFAULT_DENY_DOMAINS,
+    NO_PROXY,
+    EgressProxy,
+    _build_combined_ca_bundle,
+    _pick_free_port,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — extract _is_denied from the addon script for isolated testing
+# ---------------------------------------------------------------------------
+
+
+def _load_is_denied(deny_list: list[str]):
+    """Return the addon's _is_denied function with a given deny list.
+
+    The addon script imports mitmproxy (not in the project venv), so we
+    stub the import and only extract the pure-Python _is_denied function.
+    """
+    import sys
+    import types
+
+    from sregym.service.egress_proxy import _ADDON_SCRIPT
+
+    fake_http = types.ModuleType("mitmproxy.http")
+    fake_http.HTTPFlow = type("HTTPFlow", (), {})
+    fake_http.Response = type("Response", (), {"make": staticmethod(lambda *a, **kw: None)})
+    fake_mitmproxy = types.ModuleType("mitmproxy")
+    fake_mitmproxy.http = fake_http
+
+    ns: dict = {}
+    saved = sys.modules.copy()
+    try:
+        sys.modules["mitmproxy"] = fake_mitmproxy
+        sys.modules["mitmproxy.http"] = fake_mitmproxy.http
+        exec(compile(_ADDON_SCRIPT, "<addon>", "exec"), ns)
+    finally:
+        sys.modules.update(saved)
+        for key in ["mitmproxy", "mitmproxy.http"]:
+            if key not in saved:
+                sys.modules.pop(key, None)
+
+    ns["DENY_LIST"] = deny_list
+    return ns["_is_denied"]
+
+
+# ===================================================================
+# Unit tests — EgressProxy class basics
+# ===================================================================
+
+
+class TestEgressProxyBasics:
+    def test_rejects_invalid_mode(self):
+        with pytest.raises(ValueError, match="invalid"):
+            EgressProxy(mode="invalid")
+
+    def test_start_raises_in_on_mode(self):
+        proxy = EgressProxy(mode="on")
+        with pytest.raises(RuntimeError, match="should not be started"):
+            proxy.start()
+
+    def test_default_deny_domains_cover_sregym(self):
+        expected = [
+            "github.com/SREGym",
+            "raw.githubusercontent.com/SREGym",
+            "api.github.com/repos/SREGym",
+            "codeload.github.com/SREGym",
+        ]
+        for domain in expected:
+            assert domain in DEFAULT_DENY_DOMAINS
+
+    def test_blocked_requests_empty_before_start(self):
+        proxy = EgressProxy(mode="filtered")
+        assert proxy.blocked_requests() == []
+
+    def test_cleanup_removes_tmpdir(self):
+        proxy = EgressProxy(mode="filtered")
+        proxy._tmpdir = tempfile.mkdtemp(prefix="sregym-test-")
+        assert Path(proxy._tmpdir).exists()
+        proxy.cleanup()
+        assert proxy._tmpdir is None
+
+
+# ===================================================================
+# Shared constants
+# ===================================================================
+
+
+class TestSharedConstants:
+    def test_no_proxy_covers_private_ranges(self):
+        for entry in [
+            "localhost",
+            "127.0.0.1",
+            "10.0.0.0/8",
+            "172.16.0.0/12",
+            "192.168.0.0/16",
+            "host.docker.internal",
+            ".svc",
+            ".cluster.local",
+        ]:
+            assert entry in NO_PROXY
+
+    def test_ca_bundle_env_vars(self):
+        expected = {"SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE"}
+        assert set(CA_BUNDLE_ENV_VARS) == expected
+
+
+# ===================================================================
+# Addon deny-list logic (tested in isolation)
+# ===================================================================
+
+
+class TestAddonDenyLogic:
+    def test_addon_denies_sregym_path(self):
+        is_denied = _load_is_denied(["github.com/SREGym"])
+        assert is_denied("github.com", "/SREGym/SREGym") is True
+        assert is_denied("github.com", "/SREGym/SREGym/tree/main") is True
+
+    def test_addon_allows_other_github_path(self):
+        is_denied = _load_is_denied(["github.com/SREGym"])
+        assert is_denied("github.com", "/kubernetes/kubernetes") is False
+
+    def test_addon_denies_bare_host(self):
+        is_denied = _load_is_denied(["evil.com"])
+        assert is_denied("evil.com", "/any/path") is True
+        assert is_denied("evil.com", "/") is True
+        assert is_denied("good.com", "/any/path") is False
+
+
+# ===================================================================
+# Helper functions
+# ===================================================================
+
+
+class TestHelpers:
+    def test_pick_free_port_returns_valid_port(self):
+        port = _pick_free_port()
+        assert isinstance(port, int)
+        assert 1024 <= port <= 65535
+
+    def test_build_combined_ca_bundle(self, tmp_path):
+        ca1 = tmp_path / "system.pem"
+        ca1.write_text("-----BEGIN CERTIFICATE-----\nSYSTEM\n-----END CERTIFICATE-----")
+        ca2 = tmp_path / "proxy.pem"
+        ca2.write_text("-----BEGIN CERTIFICATE-----\nPROXY\n-----END CERTIFICATE-----")
+        output = tmp_path / "combined.pem"
+
+        with patch.object(ssl, "get_default_verify_paths") as mock_paths:
+            mock_paths.return_value = type("P", (), {"cafile": str(ca1)})()
+            _build_combined_ca_bundle(ca2, output)
+
+        contents = output.read_text()
+        assert "SYSTEM" in contents
+        assert "PROXY" in contents
+
+    def test_find_mitmdump_not_found(self, monkeypatch):
+        from sregym.service import egress_proxy
+
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+        with pytest.raises(FileNotFoundError, match="mitmdump not found"):
+            egress_proxy._find_mitmdump()
+
+
+# ===================================================================
+# ContainerRunner proxy injection
+# ===================================================================
+
+
+class TestContainerRunnerProxy:
+    def test_proxy_env_vars_injected(self, tmp_path):
+        ca_bundle = tmp_path / "ca-bundle.pem"
+        ca_bundle.write_text("cert")
+        config = ContainerConfig(
+            proxy_url="http://host.docker.internal:18080",
+            proxy_ca_bundle=ca_bundle,
+        )
+        runner = ContainerRunner(config)
+        flags = runner._build_env_flags()
+        env = self._flags_to_dict(flags)
+
+        assert env["http_proxy"] == "http://host.docker.internal:18080"
+        assert env["HTTPS_PROXY"] == "http://host.docker.internal:18080"
+        assert env["no_proxy"] == NO_PROXY
+        assert env["SSL_CERT_FILE"] == "/etc/ssl/certs/sregym-ca-bundle.pem"
+        assert env["REQUESTS_CA_BUNDLE"] == "/etc/ssl/certs/sregym-ca-bundle.pem"
+
+    def test_no_proxy_vars_without_url(self):
+        config = ContainerConfig()
+        runner = ContainerRunner(config)
+        flags = runner._build_env_flags()
+        env = self._flags_to_dict(flags)
+
+        assert "http_proxy" not in env
+        assert "HTTPS_PROXY" not in env
+
+    def test_ca_bundle_mount(self, tmp_path):
+        ca_bundle = tmp_path / "ca-bundle.pem"
+        ca_bundle.write_text("cert")
+        config = ContainerConfig(
+            proxy_url="http://host.docker.internal:18080",
+            proxy_ca_bundle=ca_bundle,
+        )
+        runner = ContainerRunner(config)
+        args = runner._build_base_docker_args()
+
+        mount_args = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
+        ca_mounts = [m for m in mount_args if "sregym-ca-bundle.pem" in m]
+        assert len(ca_mounts) == 1
+        assert ca_mounts[0].endswith(":ro")
+
+    @staticmethod
+    def _flags_to_dict(flags: list[str]) -> dict[str, str]:
+        """Convert ['-e', 'K=V', '-e', 'K2=V2'] into {'K': 'V', 'K2': 'V2'}."""
+        env = {}
+        it = iter(flags)
+        for flag in it:
+            if flag == "-e":
+                kv = next(it)
+                k, v = kv.split("=", 1)
+                env[k] = v
+        return env
+
+
+# ===================================================================
+# Integration test — requires mitmdump
+# ===================================================================
+
+
+@pytest.mark.integration
+class TestEgressProxyIntegration:
+    def test_proxy_filtered_blocks_sregym(self):
+        proxy = EgressProxy(mode="filtered")
+        try:
+            port = proxy.start()
+            assert port > 0
+            assert proxy.ca_bundle_path is not None
+            assert proxy.ca_bundle_path.exists()
+
+            proxy_handler = urllib.request.ProxyHandler(
+                {
+                    "http": f"http://127.0.0.1:{port}",
+                    "https": f"http://127.0.0.1:{port}",
+                }
+            )
+            ctx = ssl.create_default_context(cafile=str(proxy.ca_bundle_path))
+            opener = urllib.request.build_opener(proxy_handler, urllib.request.HTTPSHandler(context=ctx))
+
+            # SREGym URL should be blocked
+            with pytest.raises(urllib.error.HTTPError, match="403"):
+                opener.open("https://github.com/SREGym/SREGym", timeout=10)
+
+            # Non-SREGym GitHub URL should be allowed
+            resp = opener.open("https://github.com/kubernetes/kubernetes", timeout=10)
+            assert resp.status == 200
+
+            blocked = proxy.blocked_requests()
+            assert any("SREGym" in req for req in blocked)
+        finally:
+            proxy.stop()
+            proxy.cleanup()


### PR DESCRIPTION
- Closes #911

## Problem

Opus 4.8 was observed querying the SREGym GitHub repo during benchmark runs, reading problem definitions and root cause strings — bypassing  all cluster-side isolation. Any agent with shell access can curl regardless of ALLOWED_TOOLS, so enforcement must happen at the network layer.

## Solution

Adds a --internet-access {on,off,filtered} CLI flag (default: filtered) that runs a MITM proxy (mitmdump) on the host. The proxy is injected  into agent containers via http_proxy/https_proxy env vars.

  - filtered (default): blocks requests to SREGym GitHub paths (github.com/SREGym, raw.githubusercontent.com/SREGym,
  api.github.com/repos/SREGym, codeload.github.com/SREGym) while allowing all other traffic
  - off: blocks all outbound internet traffic
  - on: no proxy, unrestricted access (previous behavior)

  Uses mitmdump as a subprocess to intercept HTTPS and inspect full URL paths — not just hostnames. A combined CA bundle (system CAs + proxy CA)  is mounted into the container so HTTPS interception works without breaking API provider connections (Anthropic, OpenAI, Bedrock, etc.).

  Proxy env vars are also injected into non-containerized agent subprocesses, so the policy applies regardless of container_isolation setting.

## Files

  | File | Change |
  |------|--------|
  | `sregym/service/egress_proxy.py` | New — mitmdump-based MITM proxy with path-level deny list |
  | `main.py` | `--internet-access` CLI flag, proxy lifecycle |
  | `sregym/agent_launcher.py` | Proxy env injection for both container and bare-process agents |
  | `sregym/service/container_runner.py` | Proxy env vars + CA bundle mount in containers |
  | `sregym/conductor/conductor.py` | `internet_access` field on `ConductorConfig` |
  | `tests/service/test_egress_proxy.py` | 16 unit tests + 1 integration test |
## Prerequisites

  mitmdump must be installed when using filtered or off mode:
```
  uv tool install mitmproxy
```
## Test plan

  - [x] Unit tests pass: uv run pytest tests/service/test_egress_proxy.py -k "not integration" (16 tests)
  - [x] Integration test passes: uv run pytest tests/service/test_egress_proxy.py -m integration (starts real proxy, verifies SREGym blocked /
  kubernetes allowed)
  - [ ] Full run with --internet-access filtered — verify agent can reach API providers but not SREGym repo
  - [ ] Full run with --internet-access on — verify no behavioral change from current main