### PR TITLE
Support local LLM endpoints for Stratus and OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ Set the required environment variable for your provider before running:
 
 #### Local LLMs
 
-SREGym supports local models through Ollama and OpenAI-compatible servers such
-as vLLM and LM Studio. The examples below use Ollama.
+SREGym supports local models through Ollama and OpenAI-compatible servers such as vLLM and LM Studio. The examples below use Ollama.
+
+Set `AGENT_API_KEY` as well if the endpoint requires authentication.
 
 **Stratus with Ollama:**
 
@@ -152,45 +153,35 @@ export AGENT_API_BASE="http://127.0.0.1:11434"
 python main.py --agent stratus --model ollama_chat/qwen3-coder:30b
 ```
 
-Set `AGENT_API_KEY` as well if the endpoint requires authentication.
-
 **OpenCode with Ollama:**
 
 OpenCode uses the endpoint's OpenAI-compatible `/v1` API.
 
 ```bash
 export AGENT_API_BASE="http://127.0.0.1:11434/v1"
-export JUDGE_API_BASE="http://127.0.0.1:11434"
-
-python main.py \
-  --agent opencode \
-  --model local/qwen3-coder:30b \
-  --judge-model ollama_chat/qwen3-coder:30b
+python main.py --agent opencode --model local/qwen3-coder:30b
 ```
 
-When `--judge-model` is not set, SREGym reuses the agent model and endpoint for
-the judge. This works directly for Stratus because its model identifier is
-LiteLLM-compatible. OpenCode's `local/` provider is OpenCode-specific, so its
-judge must use a LiteLLM identifier such as `ollama_chat/qwen3-coder:30b`.
+When `--judge-model` is not set, SREGym reuses the agent model and endpoint for the judge. This works directly for Stratus because its model identifier is LiteLLM-compatible. For OpenCode, SREGym normalizes `local/<served-model>` to `openai/<served-model>` for the judge, because OpenCode's `local/` provider uses an OpenAI-compatible endpoint.
 
-For vLLM, LM Studio, or another OpenAI-compatible server, point
-`AGENT_API_BASE` to its `/v1` endpoint and use `openai/<served-model>` with
-Stratus or `local/<served-model>` with OpenCode.
+For vLLM, LM Studio, or another OpenAI-compatible server, point `AGENT_API_BASE` to its `/v1` endpoint and use `openai/<served-model>` with Stratus or `local/<served-model>` with OpenCode.
+
+To use a different LiteLLM judge provider, pass `--judge-model` explicitly:
+
+```bash
+export JUDGE_API_BASE="http://127.0.0.1:11434"
+python main.py --agent opencode --model local/qwen3-coder:30b --judge-model ollama_chat/qwen3-coder:30b
+```
 
 **Separate judge endpoint:**
 
-Set `JUDGE_API_BASE` and `JUDGE_API_KEY` when the judge uses a different
-endpoint or credential:
+Set `JUDGE_API_BASE` and `JUDGE_API_KEY` when the judge uses a different endpoint or credential:
 
 ```bash
 export JUDGE_API_BASE="https://example.test/v1"
 export JUDGE_API_KEY="..."
 python main.py --agent stratus --model ollama_chat/qwen3-coder:30b --judge-model gpt-5
 ```
-
-SREGym keeps loopback endpoints unchanged with native Linux host networking.
-On Docker Desktop for macOS or WSL, it automatically maps loopback endpoints to
-`host.docker.internal` for the agent container.
 
 <details>
 <summary><strong>Provider Examples</strong></summary>

--- a/README.md
+++ b/README.md
@@ -138,6 +138,36 @@ Set the required environment variable for your provider before running:
 | AWS Bedrock | `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `AWS_PROFILE`, `AWS_DEFAULT_REGION` |
 | Azure | `azure/gpt-4o` | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION` |
 
+#### Local LLMs
+
+Stratus can use local LLMs served through LiteLLM-compatible endpoints. Set the
+agent endpoint with environment variables before running SREGym:
+
+```bash
+export AGENT_API_BASE="http://127.0.0.1:11434"
+python main.py --agent stratus --model ollama_chat/qwen2.5:3b
+```
+
+Set `AGENT_API_KEY` as well if the endpoint requires authentication.
+
+If `--judge-model` is not set, the judge uses the same model as `--model` and
+inherits `AGENT_API_BASE` / `AGENT_API_KEY` when separate judge endpoint env
+vars are not provided.
+
+Set these only when the judge should use a different endpoint or credential:
+
+```bash
+export JUDGE_API_BASE="https://example.test/v1"
+export JUDGE_API_KEY="..."
+python main.py --agent stratus --model ollama_chat/qwen2.5:3b --judge-model gpt-5
+```
+
+On Linux host networking, `http://127.0.0.1:11434` can reach a local model
+server bound to loopback. On Docker Desktop for macOS or WSL, use
+`http://host.docker.internal:11434` if `127.0.0.1` resolves inside the agent
+container instead of the host. The local model server must listen on an address
+reachable from the Docker container.
+
 <details>
 <summary><strong>Provider Examples</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -188,11 +188,9 @@ export JUDGE_API_KEY="..."
 python main.py --agent stratus --model ollama_chat/qwen3-coder:30b --judge-model gpt-5
 ```
 
-On Linux host networking, `http://127.0.0.1:11434` can reach a local model
-server bound to loopback. On Docker Desktop for macOS or WSL, use
-`http://host.docker.internal:11434` if `127.0.0.1` resolves inside the agent
-container instead of the host. The local model server must listen on an address
-reachable from the Docker container.
+SREGym keeps loopback endpoints unchanged with native Linux host networking.
+On Docker Desktop for macOS or WSL, it automatically maps loopback endpoints to
+`host.docker.internal` for the agent container.
 
 <details>
 <summary><strong>Provider Examples</strong></summary>

--- a/README.md
+++ b/README.md
@@ -140,26 +140,52 @@ Set the required environment variable for your provider before running:
 
 #### Local LLMs
 
-Stratus can use local LLMs served through LiteLLM-compatible endpoints. Set the
-agent endpoint with environment variables before running SREGym:
+SREGym supports local models through Ollama and OpenAI-compatible servers such
+as vLLM and LM Studio. The examples below use Ollama.
+
+**Stratus with Ollama:**
 
 ```bash
+ollama pull qwen3-coder:30b
+
 export AGENT_API_BASE="http://127.0.0.1:11434"
-python main.py --agent stratus --model ollama_chat/qwen2.5:3b
+python main.py --agent stratus --model ollama_chat/qwen3-coder:30b
 ```
 
 Set `AGENT_API_KEY` as well if the endpoint requires authentication.
 
-If `--judge-model` is not set, the judge uses the same model as `--model` and
-inherits `AGENT_API_BASE` / `AGENT_API_KEY` when separate judge endpoint env
-vars are not provided.
+**OpenCode with Ollama:**
 
-Set these only when the judge should use a different endpoint or credential:
+OpenCode uses the endpoint's OpenAI-compatible `/v1` API.
+
+```bash
+export AGENT_API_BASE="http://127.0.0.1:11434/v1"
+export JUDGE_API_BASE="http://127.0.0.1:11434"
+
+python main.py \
+  --agent opencode \
+  --model local/qwen3-coder:30b \
+  --judge-model ollama_chat/qwen3-coder:30b
+```
+
+When `--judge-model` is not set, SREGym reuses the agent model and endpoint for
+the judge. This works directly for Stratus because its model identifier is
+LiteLLM-compatible. OpenCode's `local/` provider is OpenCode-specific, so its
+judge must use a LiteLLM identifier such as `ollama_chat/qwen3-coder:30b`.
+
+For vLLM, LM Studio, or another OpenAI-compatible server, point
+`AGENT_API_BASE` to its `/v1` endpoint and use `openai/<served-model>` with
+Stratus or `local/<served-model>` with OpenCode.
+
+**Separate judge endpoint:**
+
+Set `JUDGE_API_BASE` and `JUDGE_API_KEY` when the judge uses a different
+endpoint or credential:
 
 ```bash
 export JUDGE_API_BASE="https://example.test/v1"
 export JUDGE_API_KEY="..."
-python main.py --agent stratus --model ollama_chat/qwen2.5:3b --judge-model gpt-5
+python main.py --agent stratus --model ollama_chat/qwen3-coder:30b --judge-model gpt-5
 ```
 
 On Linux host networking, `http://127.0.0.1:11434` can reach a local model

--- a/clients/opencode/opencode_agent.py
+++ b/clients/opencode/opencode_agent.py
@@ -34,6 +34,7 @@ PROVIDER_ENV_VARS: dict[str, list[str]] = {
     "groq": ["GROQ_API_KEY"],
     "huggingface": ["HF_TOKEN"],
     "llama": ["LLAMA_API_KEY"],
+    "local": [],
     "mistral": ["MISTRAL_API_KEY"],
     "openai": ["OPENAI_API_KEY"],
     "xai": ["XAI_API_KEY"],
@@ -330,8 +331,36 @@ class OpenCodeAgent:
                 env[var] = os.environ[var]
                 has_auth = True
 
-        if not has_auth:
+        if env_vars and not has_auth:
             logger.warning(f"No authentication found for provider '{self.provider}'. Expected one of: {env_vars}")
+
+        if self.provider == "local":
+            if not env.get("AGENT_API_BASE"):
+                raise ValueError("AGENT_API_BASE is required for local OpenCode models")
+
+            model = self.model_name.split("/", 1)[1]
+            options = {"baseURL": "{env:AGENT_API_BASE}"}
+            if env.get("AGENT_API_KEY"):
+                options["apiKey"] = "{env:AGENT_API_KEY}"
+
+            config_path = self.logs_dir / "opencode.json"
+            with open(config_path, "w") as config_file:
+                json.dump(
+                    {
+                        "$schema": "https://opencode.ai/config.json",
+                        "provider": {
+                            "local": {
+                                "npm": "@ai-sdk/openai-compatible",
+                                "name": "Local",
+                                "options": options,
+                                "models": {model: {"name": model}},
+                            }
+                        },
+                    },
+                    config_file,
+                    indent=2,
+                )
+            env["OPENCODE_CONFIG"] = str(config_path)
 
         # Enable fake VCS for OpenCode (required for non-git directories)
         env["OPENCODE_FAKE_VCS"] = "git"

--- a/clients/stratus/stratus_agent/driver/driver.py
+++ b/clients/stratus/stratus_agent/driver/driver.py
@@ -53,19 +53,11 @@ logger.setLevel(logging.DEBUG)
 
 
 def run_preflight() -> None:
-    """Validate model + credentials by making a minimal litellm call."""
-    import litellm
+    """Validate model, endpoint, credentials, and tool calling."""
+    from clients.stratus.stratus_agent.driver.preflight import run_stratus_preflight
 
-    litellm.drop_params = True
-    litellm.modify_params = True
-    litellm.suppress_debug_info = True  # ty:ignore[invalid-assignment]
     try:
-        litellm.completion(
-            model=os.environ["AGENT_MODEL_ID"],
-            messages=[{"role": "user", "content": "say ok"}],
-            max_tokens=3,
-            num_retries=0,
-        )
+        run_stratus_preflight()
         print("ok")
     except Exception as e:
         print(f"preflight failed: {e}")

--- a/clients/stratus/stratus_agent/driver/preflight.py
+++ b/clients/stratus/stratus_agent/driver/preflight.py
@@ -1,0 +1,88 @@
+import contextlib
+import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import tool
+
+from llm_backend.init_backend import get_llm_backend_for_agent
+
+PREFLIGHT_TOOL_NAME = "preflight_echo"
+PREFLIGHT_TOOL_VALUE = "ok"
+
+
+@tool(PREFLIGHT_TOOL_NAME)
+def preflight_echo(value: str) -> str:
+    """Echo the provided value for validating model tool calling."""
+    return value
+
+
+def _tool_call_name(tool_call: Any) -> str | None:
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function")
+        if isinstance(function, dict) and function.get("name"):
+            return function["name"]
+        return tool_call.get("name")
+    return getattr(tool_call, "name", None)
+
+
+def _tool_call_args(tool_call: Any) -> dict[str, Any]:
+    if isinstance(tool_call, dict):
+        if isinstance(tool_call.get("args"), dict):
+            return tool_call["args"]
+        function = tool_call.get("function")
+        if isinstance(function, dict):
+            arguments = function.get("arguments")
+            if isinstance(arguments, dict):
+                return arguments
+            if isinstance(arguments, str):
+                with contextlib.suppress(json.JSONDecodeError):
+                    parsed = json.loads(arguments)
+                    if isinstance(parsed, dict):
+                        return parsed
+        return {}
+
+    args = getattr(tool_call, "args", None)
+    return args if isinstance(args, dict) else {}
+
+
+def validate_preflight_tool_call(ai_message: Any) -> None:
+    tool_calls = getattr(ai_message, "tool_calls", None)
+    if not tool_calls:
+        raise RuntimeError("model returned no tool calls during Stratus preflight")
+
+    seen_tool_names = []
+    for tool_call in tool_calls:
+        name = _tool_call_name(tool_call)
+        seen_tool_names.append(name or "<unknown>")
+        if name != PREFLIGHT_TOOL_NAME:
+            continue
+
+        args = _tool_call_args(tool_call)
+        value = args.get("value")
+        if isinstance(value, str) and value.lower() == PREFLIGHT_TOOL_VALUE:
+            return
+        raise RuntimeError(
+            f"model called {PREFLIGHT_TOOL_NAME!r}, but with invalid args {args!r}; "
+            f"expected value={PREFLIGHT_TOOL_VALUE!r}"
+        )
+
+    raise RuntimeError(
+        f"model returned tool calls {seen_tool_names!r}, but did not call required tool {PREFLIGHT_TOOL_NAME!r}"
+    )
+
+
+def run_stratus_preflight() -> None:
+    backend = get_llm_backend_for_agent()
+    backend.inference("say ok", system_prompt="Reply with exactly ok.")
+
+    ai_message = backend.inference(
+        messages=[
+            SystemMessage(
+                content=("This is a preflight check. You must call the provided tool; do not answer with normal text.")
+            ),
+            HumanMessage(content=f'Call {PREFLIGHT_TOOL_NAME} with value "{PREFLIGHT_TOOL_VALUE}".'),
+        ],
+        tools=[preflight_echo],
+    )
+    validate_preflight_tool_call(ai_message)

--- a/llm_backend/init_backend.py
+++ b/llm_backend/init_backend.py
@@ -3,10 +3,15 @@ import os
 from llm_backend.get_llm_backend import LiteLLMBackend
 
 
-def get_llm_backend(model_name: str) -> LiteLLMBackend:
+def get_llm_backend(
+    model_name: str,
+    api_base: str | None = None,
+    api_key: str | None = None,
+) -> LiteLLMBackend:
     """Initialize an LLM backend for the given litellm model string."""
-    print(f"🔧 Initializing LLM backend — model: {model_name}")
-    return LiteLLMBackend(model_name=model_name)
+    endpoint_status = "set" if api_base else "unset"
+    print(f"🔧 Initializing LLM backend — model: {model_name}, api_base: {endpoint_status}")
+    return LiteLLMBackend(model_name=model_name, api_base=api_base, api_key=api_key)
 
 
 def get_llm_backend_for_agent() -> LiteLLMBackend:
@@ -14,7 +19,11 @@ def get_llm_backend_for_agent() -> LiteLLMBackend:
     model_id = os.environ.get("AGENT_MODEL_ID")
     if not model_id:
         raise ValueError("AGENT_MODEL_ID environment variable is not set.")
-    return get_llm_backend(model_id)
+    return get_llm_backend(
+        model_id,
+        api_base=os.environ.get("AGENT_API_BASE"),
+        api_key=os.environ.get("AGENT_API_KEY"),
+    )
 
 
 def get_llm_backend_for_judge() -> LiteLLMBackend:
@@ -22,4 +31,8 @@ def get_llm_backend_for_judge() -> LiteLLMBackend:
     model_id = os.environ.get("JUDGE_MODEL_ID")
     if not model_id:
         raise ValueError("JUDGE_MODEL_ID environment variable is not set.")
-    return get_llm_backend(model_id)
+    return get_llm_backend(
+        model_id,
+        api_base=os.environ.get("JUDGE_API_BASE"),
+        api_key=os.environ.get("JUDGE_API_KEY"),
+    )

--- a/main.py
+++ b/main.py
@@ -94,6 +94,16 @@ def _restore_env_var(name: str, previous_value: str | None) -> None:
         os.environ[name] = previous_value
 
 
+def _set_optional_env(name: str, value: str | None) -> None:
+    """Set an env var from an explicit CLI value without clearing existing env config."""
+    if value:
+        os.environ[name] = value
+
+
+def _env_status(name: str) -> str:
+    return "set" if os.environ.get(name) else "unset"
+
+
 @contextlib.contextmanager
 def _artifact_environment(run: RunArtifacts):
     previous = {
@@ -486,12 +496,24 @@ def main(args):
     # Push to env so downstream code picks it up
     os.environ["AGENT_MODEL_ID"] = agent_model
     os.environ["JUDGE_MODEL_ID"] = judge_model
+    _set_optional_env("AGENT_API_BASE", getattr(args, "agent_api_base", None))
+    _set_optional_env("AGENT_API_KEY", getattr(args, "agent_api_key", None))
+    judge_api_base = getattr(args, "judge_api_base", None)
+    judge_api_key = getattr(args, "judge_api_key", None)
+    if not getattr(args, "judge_model", None):
+        judge_api_base = judge_api_base or os.environ.get("JUDGE_API_BASE") or os.environ.get("AGENT_API_BASE")
+        judge_api_key = judge_api_key or os.environ.get("JUDGE_API_KEY") or os.environ.get("AGENT_API_KEY")
+    _set_optional_env("JUDGE_API_BASE", judge_api_base)
+    _set_optional_env("JUDGE_API_KEY", judge_api_key)
     os.environ["API_HOSTNAME"] = "0.0.0.0"
     os.environ["API_PORT"] = "8000"
     os.environ["MCP_SERVER_PORT"] = "9954"
     os.environ["MCP_SERVER_URL"] = "http://127.0.0.1:9954"
 
-    logger.info(f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}")
+    logger.info(
+        f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}, "
+        f"agent_api_base: {_env_status('AGENT_API_BASE')}, judge_api_base: {_env_status('JUDGE_API_BASE')}"
+    )
 
     # Only build/check agent container image if the agent requires it
     agent_reg = (
@@ -609,6 +631,30 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Model for the LLM-as-a-judge evaluator (defaults to --model if not set)",
+    )
+    parser.add_argument(
+        "--agent-api-base",
+        type=str,
+        default=None,
+        help="Optional API base URL for the agent model endpoint (for example, local Ollama or vLLM)",
+    )
+    parser.add_argument(
+        "--agent-api-key",
+        type=str,
+        default=None,
+        help="Optional API key for the agent model endpoint; prefer AGENT_API_KEY env var for real secrets",
+    )
+    parser.add_argument(
+        "--judge-api-base",
+        type=str,
+        default=None,
+        help="Optional API base URL for the judge model endpoint",
+    )
+    parser.add_argument(
+        "--judge-api-key",
+        type=str,
+        default=None,
+        help="Optional API key for the judge model endpoint; prefer JUDGE_API_KEY env var for real secrets",
     )
     parser.add_argument(
         "--use-external-harness", action="store_true", help="For use in external harnesses, deploy the fault and exit."

--- a/main.py
+++ b/main.py
@@ -98,6 +98,42 @@ def _env_status(name: str) -> str:
     return "set" if os.environ.get(name) else "unset"
 
 
+def _is_opencode_local_model(agent: str | None, model: str) -> bool:
+    return agent == "opencode" and model.startswith("local/")
+
+
+def _normalize_opencode_local_model_for_litellm(model: str) -> str:
+    return f"openai/{model.split('/', 1)[1]}"
+
+
+def _configure_model_environment(args) -> tuple[str, str]:
+    agent_model = args.model
+    raw_judge_model = args.judge_model or args.model
+    normalizes_opencode_local_judge = _is_opencode_local_model(args.agent, raw_judge_model)
+    judge_model = (
+        _normalize_opencode_local_model_for_litellm(raw_judge_model)
+        if normalizes_opencode_local_judge
+        else raw_judge_model
+    )
+
+    os.environ["AGENT_MODEL_ID"] = agent_model
+    os.environ["JUDGE_MODEL_ID"] = judge_model
+
+    if not getattr(args, "judge_model", None) or normalizes_opencode_local_judge:
+        if not os.environ.get("JUDGE_API_BASE") and os.environ.get("AGENT_API_BASE"):
+            os.environ["JUDGE_API_BASE"] = os.environ["AGENT_API_BASE"]
+        if not os.environ.get("JUDGE_API_KEY") and os.environ.get("AGENT_API_KEY"):
+            os.environ["JUDGE_API_KEY"] = os.environ["AGENT_API_KEY"]
+
+    if normalizes_opencode_local_judge:
+        if not os.environ.get("JUDGE_API_BASE"):
+            raise ValueError("AGENT_API_BASE or JUDGE_API_BASE is required to use an OpenCode local model as the judge")
+        if not os.environ.get("JUDGE_API_KEY"):
+            os.environ["JUDGE_API_KEY"] = "dummy"
+
+    return agent_model, judge_model
+
+
 @contextlib.contextmanager
 def _artifact_environment(run: RunArtifacts):
     previous = {
@@ -481,20 +517,10 @@ def main(args):
     # set up the logger
     init_logger()
 
-    agent_model = args.model
-    judge_model = args.judge_model or args.model
+    agent_model, judge_model = _configure_model_environment(args)
 
     if args.noise:
         logger.info("Noise injection enabled.")
-
-    # Push to env so downstream code picks it up
-    os.environ["AGENT_MODEL_ID"] = agent_model
-    os.environ["JUDGE_MODEL_ID"] = judge_model
-    if not getattr(args, "judge_model", None):
-        if not os.environ.get("JUDGE_API_BASE") and os.environ.get("AGENT_API_BASE"):
-            os.environ["JUDGE_API_BASE"] = os.environ["AGENT_API_BASE"]
-        if not os.environ.get("JUDGE_API_KEY") and os.environ.get("AGENT_API_KEY"):
-            os.environ["JUDGE_API_KEY"] = os.environ["AGENT_API_KEY"]
     os.environ["API_HOSTNAME"] = "0.0.0.0"
     os.environ["API_PORT"] = "8000"
     os.environ["MCP_SERVER_PORT"] = "9954"

--- a/main.py
+++ b/main.py
@@ -94,12 +94,6 @@ def _restore_env_var(name: str, previous_value: str | None) -> None:
         os.environ[name] = previous_value
 
 
-def _set_optional_env(name: str, value: str | None) -> None:
-    """Set an env var from an explicit CLI value without clearing existing env config."""
-    if value:
-        os.environ[name] = value
-
-
 def _env_status(name: str) -> str:
     return "set" if os.environ.get(name) else "unset"
 
@@ -496,15 +490,11 @@ def main(args):
     # Push to env so downstream code picks it up
     os.environ["AGENT_MODEL_ID"] = agent_model
     os.environ["JUDGE_MODEL_ID"] = judge_model
-    _set_optional_env("AGENT_API_BASE", getattr(args, "agent_api_base", None))
-    _set_optional_env("AGENT_API_KEY", getattr(args, "agent_api_key", None))
-    judge_api_base = getattr(args, "judge_api_base", None)
-    judge_api_key = getattr(args, "judge_api_key", None)
     if not getattr(args, "judge_model", None):
-        judge_api_base = judge_api_base or os.environ.get("JUDGE_API_BASE") or os.environ.get("AGENT_API_BASE")
-        judge_api_key = judge_api_key or os.environ.get("JUDGE_API_KEY") or os.environ.get("AGENT_API_KEY")
-    _set_optional_env("JUDGE_API_BASE", judge_api_base)
-    _set_optional_env("JUDGE_API_KEY", judge_api_key)
+        if not os.environ.get("JUDGE_API_BASE") and os.environ.get("AGENT_API_BASE"):
+            os.environ["JUDGE_API_BASE"] = os.environ["AGENT_API_BASE"]
+        if not os.environ.get("JUDGE_API_KEY") and os.environ.get("AGENT_API_KEY"):
+            os.environ["JUDGE_API_KEY"] = os.environ["AGENT_API_KEY"]
     os.environ["API_HOSTNAME"] = "0.0.0.0"
     os.environ["API_PORT"] = "8000"
     os.environ["MCP_SERVER_PORT"] = "9954"
@@ -631,30 +621,6 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Model for the LLM-as-a-judge evaluator (defaults to --model if not set)",
-    )
-    parser.add_argument(
-        "--agent-api-base",
-        type=str,
-        default=None,
-        help="Optional API base URL for the agent model endpoint (for example, local Ollama or vLLM)",
-    )
-    parser.add_argument(
-        "--agent-api-key",
-        type=str,
-        default=None,
-        help="Optional API key for the agent model endpoint; prefer AGENT_API_KEY env var for real secrets",
-    )
-    parser.add_argument(
-        "--judge-api-base",
-        type=str,
-        default=None,
-        help="Optional API base URL for the judge model endpoint",
-    )
-    parser.add_argument(
-        "--judge-api-key",
-        type=str,
-        default=None,
-        help="Optional API key for the judge model endpoint; prefer JUDGE_API_KEY env var for real secrets",
     )
     parser.add_argument(
         "--use-external-harness", action="store_true", help="For use in external harnesses, deploy the fault and exit."

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -125,7 +125,11 @@ class ContainerRunner:
         "COPILOT_PROVIDER_TYPE",
         # SREGym internal
         "AGENT_MODEL_ID",
+        "AGENT_API_BASE",
+        "AGENT_API_KEY",
         "JUDGE_MODEL_ID",
+        "JUDGE_API_BASE",
+        "JUDGE_API_KEY",
         # Config vars
         "API_HOSTNAME",
         "API_PORT",

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -6,8 +6,28 @@ import subprocess
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger("all.sregym.container_runner")
+
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _docker_uses_separate_host() -> bool:
+    """Return whether Docker runs outside the host's network namespace."""
+    return platform.system() == "Darwin" or "microsoft" in platform.release().lower()
+
+
+def _replace_loopback_host(url: str) -> str:
+    parsed = urlsplit(url)
+    if parsed.hostname not in LOOPBACK_HOSTS:
+        return url
+
+    userinfo, separator, _ = parsed.netloc.rpartition("@")
+    netloc = f"{userinfo}{separator}host.docker.internal"
+    if parsed.port is not None:
+        netloc += f":{parsed.port}"
+    return urlunsplit(parsed._replace(netloc=netloc))
 
 
 @dataclass
@@ -158,6 +178,10 @@ class ContainerRunner:
 
         if extra_env:
             env_vars.update(extra_env)
+
+        # Docker Desktop containers cannot reach host loopback directly.
+        if _docker_uses_separate_host() and (api_base := env_vars.get("AGENT_API_BASE")):
+            env_vars["AGENT_API_BASE"] = _replace_loopback_host(api_base)
 
         # Agent containers use Docker's host alias to reach SREGym services
         # running on the host, including the MCP port-forward.

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -159,14 +159,9 @@ class ContainerRunner:
         if extra_env:
             env_vars.update(extra_env)
 
-        # On macOS, --network=host is a no-op so the container has its own
-        # network namespace. host.docker.internal routes to the Mac's loopback
-        # via Docker Desktop, so we must override the hostname.
-        # On Linux with --network=host the container shares the host's network
-        # stack directly, so localhost/127.0.0.1 already reaches host services.
-        # host.docker.internal resolves to the bridge IP (172.17.0.1) where
-        # kubectl port-forward is NOT listening, so we must NOT override.
-        if self.config.network_mode == "host" and platform.system() == "Darwin" or self.config.network_mode == "host":
+        # Agent containers use Docker's host alias to reach SREGym services
+        # running on the host, including the MCP port-forward.
+        if self.config.network_mode == "host":
             env_vars["API_HOSTNAME"] = "host.docker.internal"
             mcp_port = env_vars.get("MCP_SERVER_PORT", os.environ.get("MCP_SERVER_PORT", "9954"))
             env_vars["MCP_SERVER_URL"] = f"http://host.docker.internal:{mcp_port}"


### PR DESCRIPTION
## Summary

This is the first step toward local LLM support in SREGym (#915). This PR adds local endpoint support for Stratus and OpenCode, so models such as Qwen or DeepSeek served through Ollama or other compatible local runtimes can be used by passing an API base URL.

## Changes

- Add `AGENT_API_BASE` / `AGENT_API_KEY` for the agent model endpoint
- Add `JUDGE_API_BASE` / `JUDGE_API_KEY` for the judge model endpoint
- Forward generic agent/judge endpoint env vars into the SREGym Docker environment
- Pass endpoint config into the shared LiteLLM backend
- Add per-run OpenCode config for local OpenAI-compatible endpoints
- Automatically route loopback agent endpoints into Docker on macOS and WSL
- Update Stratus preflight to use the same backend path as the agent and verify tool calling support

## Why update Stratus preflight?

Stratus depends on tool calls during normal execution. The previous preflight only checked a minimal text completion, which can pass even if the configured local model cannot return tool calls in the shape Stratus needs. The updated preflight catches that early before starting a benchmark run.

I think it makes the local LLM support safer to use. But open to discussion about this.

## Validation

- Stratus preflight passed with `gpt-5`
- Stratus preflight passed with local `ollama_chat/qwen2.5:3b`
- End-to-end agent run with `ollama_chat/qwen2.5:3b` entered diagnosis and executed `get_services`, then hit the run timeout
- End-to-end agent run with `ollama_chat/qwen3-1.7b-fast` produced a diagnosis after multiple tool calls, then failed in mitigation due to the model context limit
- OpenCode local endpoint calls passed with `local/qwen2.5:3b`; an end-to-end run connected successfully and exported its session, but the model did not solve the task
- Ruff passed
- `git diff --check` passed
