### PR TITLE
Add reasoning effort support for agent CLIs

### DIFF
--- a/clients/claudecode/claudecode_agent.py
+++ b/clients/claudecode/claudecode_agent.py
@@ -337,6 +337,7 @@ class ClaudeCodeAgent:
 
         # Set model name
         env["ANTHROPIC_MODEL"] = model
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
 
         # Pass through MAX_THINKING_TOKENS if set
         if "MAX_THINKING_TOKENS" in os.environ:
@@ -350,8 +351,10 @@ class ClaudeCodeAgent:
             "stream-json",
             "-p",
             instruction,
-            "--allowedTools",
-        ] + self.ALLOWED_TOOLS
+        ]
+        if reasoning_effort:
+            command.extend(["--effort", reasoning_effort])
+        command.extend(["--allowedTools", *self.ALLOWED_TOOLS])
 
         logger.info(f"Executing command: {' '.join(command)}")
 

--- a/clients/claudecode/driver.py
+++ b/clients/claudecode/driver.py
@@ -41,8 +41,13 @@ def run_preflight() -> None:
     if env.get("CLAUDE_CODE_OAUTH_TOKEN"):
         env.pop("ANTHROPIC_API_KEY", None)
 
+    command = ["claude", "-p", "say ok", "--model", m]
+    reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+    if reasoning_effort:
+        command.extend(["--effort", reasoning_effort])
+
     r = subprocess.run(
-        ["claude", "-p", "say ok", "--model", m, "--max-turns", "1"],
+        command,
         capture_output=True,
         text=True,
         timeout=60,

--- a/clients/codex/codex_agent.py
+++ b/clients/codex/codex_agent.py
@@ -278,6 +278,26 @@ class CodexAgent:
             logger.error(f"Trajectory conversion failed: {exc}")
             return None
 
+    def _build_command(self, instruction: str) -> list[str]:
+        """Build the Codex command, preserving the CLI's default effort when unset."""
+        model = self.model_name.split("/")[-1]
+        command = [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "--model",
+            model,
+            "--json",
+            "--enable",
+            "unified_exec",
+        ]
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+        if reasoning_effort:
+            command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
+        command.extend(["--", instruction])
+        return command
+
     def run(self, instruction: str) -> int:
         """
         Run the Codex agent with the given instruction.
@@ -290,30 +310,17 @@ class CodexAgent:
         """
         # Extract model name (remove provider prefix if present)
         model = self.model_name.split("/")[-1]
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
 
         logger.info(f"Running Codex with instruction: {instruction}")
         logger.info(f"Using model: {model}")
+        logger.info(f"Using reasoning effort: {reasoning_effort or 'Codex default'}")
 
         # Setup authentication
         using_api_key = self._setup_auth()
 
         try:
-            # Build Codex command
-            command = [
-                "codex",
-                "exec",
-                "--dangerously-bypass-approvals-and-sandbox",
-                "--skip-git-repo-check",
-                "--model",
-                model,
-                "--json",
-                "--enable",
-                "unified_exec",
-                "-c",
-                "model_reasoning_effort=high",
-                "--",  # end of flags
-                instruction,
-            ]
+            command = self._build_command(instruction)
 
             logger.info(f"Executing command: {' '.join(command)}")
 

--- a/clients/codex/driver.py
+++ b/clients/codex/driver.py
@@ -32,12 +32,12 @@ def run_preflight() -> None:
     """Validate model + credentials by making a minimal Codex CLI call."""
     import subprocess
 
-    home = Path("/root/.codex")
+    home = Path(os.environ.get("CODEX_HOME", "/root/.codex"))
     auth = home / "auth.json"
     key = os.environ.get("OPENAI_API_KEY", "")
 
     if not auth.exists() and not key:
-        print("missing ~/.codex/auth.json and OPENAI_API_KEY")
+        print(f"missing {auth} and OPENAI_API_KEY")
         sys.exit(1)
 
     if not auth.exists():
@@ -48,17 +48,21 @@ def run_preflight() -> None:
     env = dict(os.environ)
     env["CODEX_HOME"] = str(home)
 
+    command = [
+        "codex",
+        "exec",
+        "--model",
+        m,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+    ]
+    reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+    if reasoning_effort:
+        command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
+    command.extend(["--", "say ok"])
+
     r = subprocess.run(
-        [
-            "codex",
-            "exec",
-            "--model",
-            m,
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--skip-git-repo-check",
-            "--",
-            "say ok",
-        ],
+        command,
         capture_output=True,
         text=True,
         timeout=60,

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -162,6 +162,26 @@ class CopilotCliAgent:
         logger.info(f"Extracted usage metrics: {metrics}")
         return metrics
 
+    def _build_command(self, instruction: str) -> list[str]:
+        """Build the Copilot command, preserving the CLI's default effort when unset."""
+        model = self.model_name.split("/")[-1]
+        command = [
+            "copilot",
+            "-p",
+            instruction,
+            "--allow-all",
+            "--no-ask-user",
+            "--model",
+            model,
+            "--output-format",
+            "json",
+            f"--share={self.transcript_path}",
+        ]
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+        if reasoning_effort:
+            command.extend(["--reasoning-effort", reasoning_effort])
+        return command
+
     def run(self, instruction: str) -> int:
         """
         Run the Copilot CLI agent with the given instruction.
@@ -223,22 +243,13 @@ class CopilotCliAgent:
         # Harbor's converter. The structured stream is captured to
         # ``copilot-cli.jsonl``; a plain-text copy is kept in ``copilot-cli.txt``
         # for human debugging (Harbor keeps both the same way).
-        command = [
-            "copilot",
-            "-p",
-            instruction,
-            "--allow-all",
-            "--no-ask-user",
-            "--model",
-            model,
-            "--output-format",
-            "json",
-            f"--share={self.transcript_path}",
-        ]
+        command = self._build_command(instruction)
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
 
         logger.info(
             f"Executing command: copilot -p <instruction> --allow-all --no-ask-user "
             f"--model {model} --output-format json"
+            + (f" --reasoning-effort {reasoning_effort}" if reasoning_effort else "")
         )
 
         try:

--- a/clients/copilot/driver.py
+++ b/clients/copilot/driver.py
@@ -34,8 +34,13 @@ def run_preflight() -> None:
 
     m = os.environ.get("AGENT_MODEL_ID", "gpt-4.1").split("/")[-1]
 
+    command = ["copilot", "-p", "say ok", "-s", "--model", m, "--no-ask-user"]
+    reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+    if reasoning_effort:
+        command.extend(["--reasoning-effort", reasoning_effort])
+
     r = subprocess.run(
-        ["copilot", "-p", "say ok", "-s", "--model", m, "--no-ask-user"],
+        command,
         capture_output=True,
         text=True,
         timeout=60,

--- a/clients/opencode/driver.py
+++ b/clients/opencode/driver.py
@@ -36,15 +36,20 @@ def run_preflight() -> None:
     env = os.environ.copy()
     env["OPENCODE_FAKE_VCS"] = "git"
 
+    command = [
+        "opencode",
+        f"--model={m}",
+        "run",
+        "--format=json",
+        "--thinking",
+    ]
+    reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+    if reasoning_effort:
+        command.extend(["--variant", reasoning_effort])
+    command.append("say ok")
+
     r = subprocess.run(
-        [
-            "opencode",
-            f"--model={m}",
-            "run",
-            "--format=json",
-            "--thinking",
-            "say ok",
-        ],
+        command,
         capture_output=True,
         text=True,
         timeout=60,

--- a/clients/opencode/opencode_agent.py
+++ b/clients/opencode/opencode_agent.py
@@ -367,6 +367,16 @@ class OpenCodeAgent:
 
         return env
 
+    def _build_command(self, instruction: str) -> str:
+        """Build the OpenCode command, preserving the CLI's default variant when unset."""
+        escaped_instruction = shlex.quote(instruction)
+        reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
+        variant_arg = f" --variant {shlex.quote(reasoning_effort)}" if reasoning_effort else ""
+        return (
+            f"opencode --model={shlex.quote(self.model_name)} run --format=json --thinking"
+            f"{variant_arg} {escaped_instruction}"
+        )
+
     def run(self, instruction: str, export_session: bool = True) -> int:
         """
         Run the OpenCode agent with the given instruction.
@@ -383,9 +393,7 @@ class OpenCodeAgent:
 
         env = self._build_env()
 
-        # Build command
-        escaped_instruction = shlex.quote(instruction)
-        command = f"opencode --model={self.model_name} run --format=json --thinking {escaped_instruction}"
+        command = self._build_command(instruction)
 
         logger.info(f"Executing command: {command}")
 

--- a/main.py
+++ b/main.py
@@ -130,6 +130,7 @@ def _normalize_opencode_local_model_for_litellm(model: str) -> str:
 def _configure_model_environment(args) -> tuple[str, str]:
     agent_model = args.model
     raw_judge_model = args.judge_model or args.model
+    reasoning_effort = getattr(args, "reasoning_effort", None)
     normalizes_opencode_local_judge = _is_opencode_local_model(args.agent, raw_judge_model)
     judge_model = (
         _normalize_opencode_local_model_for_litellm(raw_judge_model)
@@ -139,6 +140,10 @@ def _configure_model_environment(args) -> tuple[str, str]:
 
     os.environ["AGENT_MODEL_ID"] = agent_model
     os.environ["JUDGE_MODEL_ID"] = judge_model
+    if reasoning_effort:
+        os.environ["AGENT_REASONING_EFFORT"] = reasoning_effort
+    else:
+        os.environ.pop("AGENT_REASONING_EFFORT", None)
 
     if not getattr(args, "judge_model", None) or normalizes_opencode_local_judge:
         if not os.environ.get("JUDGE_API_BASE") and os.environ.get("AGENT_API_BASE"):
@@ -564,6 +569,7 @@ def main(args):
 
     logger.info(
         f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}, "
+        f"reasoning_effort: {getattr(args, 'reasoning_effort', None) or 'agent default'}, "
         f"agent_api_base: {_env_status('AGENT_API_BASE')}, judge_api_base: {_env_status('JUDGE_API_BASE')}"
     )
 
@@ -686,6 +692,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Model for the LLM-as-a-judge evaluator (defaults to --model if not set)",
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+        default=None,
+        help="Reasoning effort for Codex, Copilot, OpenCode, and Claude Code (uses the agent default when omitted)",
     )
     parser.add_argument(
         "--use-external-harness", action="store_true", help="For use in external harnesses, deploy the fault and exit."

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -149,6 +149,7 @@ class ContainerRunner:
         "COPILOT_PROVIDER_TYPE",
         # SREGym internal
         "AGENT_MODEL_ID",
+        "AGENT_REASONING_EFFORT",
         "AGENT_API_BASE",
         "AGENT_API_KEY",
         "JUDGE_MODEL_ID",


### PR DESCRIPTION
Adds configurable reasoning effort for Codex, Copilot, OpenCode, and Claude Code via the `reasoning-effort` param.