### PR TITLE
fix(oracles): capture MitigationOracle baseline after the app is deployed

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -219,6 +219,13 @@ class Conductor:
     def _inject_fault(self):
         """Inject fault and prepare diagnosis checkpoint if available."""
         problem = self.current_problem
+
+        # Snapshot the healthy cluster before breaking it. The oracle is built
+        # in Problem.__init__, which runs before deploy_app(), so this is the
+        # first point at which the app actually exists.
+        if getattr(problem, "mitigation_oracle", None):
+            problem.mitigation_oracle.capture_baseline()
+
         problem.inject_fault()
         self.logger.info("[ENV] Injected fault")
         self.fault_injected = True

--- a/sregym/conductor/oracles/base.py
+++ b/sregym/conductor/oracles/base.py
@@ -7,6 +7,16 @@ class Oracle(ABC):
     def __init__(self, problem):
         self.problem = problem
 
+    def capture_baseline(self) -> None:
+        """Record the healthy pre-fault cluster state.
+
+        Called once the app is deployed and before the fault is injected.
+        Oracles cannot do this in __init__: the Problem is constructed before
+        deploy_app(), when the namespace does not exist yet. Defaults to a
+        no-op for oracles that need no baseline.
+        """
+        return
+
     @abstractmethod
     def evaluate(self, solution, trace, duration) -> dict:
         """Evaluate a solution."""

--- a/sregym/conductor/oracles/compound.py
+++ b/sregym/conductor/oracles/compound.py
@@ -18,6 +18,10 @@ class CompoundedOracle(Oracle):
                 raise ValueError(f"Duplicate oracle key: {key}")
             self.oracles[key] = oracle
 
+    def capture_baseline(self) -> None:
+        for oracle in self.oracles.values():
+            oracle.capture_baseline()
+
     def evaluate(self, *args, **kwargs):
         result = {
             "success": True,

--- a/sregym/conductor/oracles/mitigation.py
+++ b/sregym/conductor/oracles/mitigation.py
@@ -20,6 +20,12 @@ class MitigationOracle(Oracle):
         self.replica_count = {}
 
     def capture_baseline(self) -> None:
+        """Capture pre-injection Deployments in the problem namespace.
+
+        This is not a full resource baseline: Services and resources created by
+        inject_fault() are outside it. Faults that must preserve or validate
+        those resources need a custom mitigation oracle.
+        """
         deployments = self.problem.kubectl.list_deployments(self.problem.namespace)
         self.replica_count = {dep.metadata.name: dep.spec.replicas for dep in deployments.items}
 

--- a/sregym/conductor/oracles/mitigation.py
+++ b/sregym/conductor/oracles/mitigation.py
@@ -13,6 +13,13 @@ class MitigationOracle(Oracle):
 
     def __init__(self, problem):
         super().__init__(problem)
+        # Populated by capture_baseline() once the app is deployed. It cannot be
+        # filled in here: the Problem is built before deploy_app(), so the
+        # namespace is still empty and every replica check below would be
+        # skipped, letting "scale to 0" and "delete the deployment" pass.
+        self.replica_count = {}
+
+    def capture_baseline(self) -> None:
         deployments = self.problem.kubectl.list_deployments(self.problem.namespace)
         self.replica_count = {dep.metadata.name: dep.spec.replicas for dep in deployments.items}
 

--- a/tests/oracles/test_mitigation_oracle_baseline.py
+++ b/tests/oracles/test_mitigation_oracle_baseline.py
@@ -14,6 +14,7 @@ import pytest
 from sregym.conductor.conductor import Conductor
 from sregym.conductor.oracles import mitigation
 from sregym.conductor.oracles.base import Oracle
+from sregym.conductor.oracles.compound import CompoundedOracle
 from sregym.conductor.oracles.mitigation import MitigationOracle
 
 
@@ -205,6 +206,30 @@ def test_conductor_captures_baseline_before_injecting_the_fault():
 
     assert calls == ["baseline", "inject"]
     assert conductor.fault_injected is True
+
+
+def test_conductor_captures_baseline_through_nested_compounded_oracles(kubectl):
+    problem = _Problem(kubectl)
+    child_oracles = [MitigationOracle(problem), MitigationOracle(problem)]
+    inner_oracle = CompoundedOracle(problem, *child_oracles)
+    problem.mitigation_oracle = CompoundedOracle(problem, inner_oracle)
+    problem.inject_fault = lambda: None
+    problem.diagnosis_oracle = None
+    conductor = SimpleNamespace(
+        current_problem=problem,
+        logger=SimpleNamespace(info=lambda *a, **k: None),
+        fault_injected=False,
+    )
+    _deploy_two(kubectl)
+
+    Conductor._inject_fault(conductor)
+
+    assert all(oracle.replica_count == {"web-a": 1, "web-b": 1} for oracle in child_oracles)
+    kubectl.set_state(
+        [_deployment("web-a"), _deployment("web-b", replicas=0, ready=0, updated=0)],
+        [_pod("web-a-1")],
+    )
+    assert problem.mitigation_oracle.evaluate()["success"] is False
 
 
 def test_conductor_tolerates_a_problem_without_a_mitigation_oracle():

--- a/tests/oracles/test_mitigation_oracle_baseline.py
+++ b/tests/oracles/test_mitigation_oracle_baseline.py
@@ -1,0 +1,225 @@
+"""Baseline-capture behaviour of the generic MitigationOracle.
+
+The oracle compares the post-submission cluster against a pre-fault baseline to
+reject reward hacks (deleting a deployment, scaling it to 0). That baseline must
+be captured while the app is actually deployed. The Problem — and therefore the
+oracle — is constructed before `deploy_app()`, so capture cannot happen in
+`__init__`; it is driven by `capture_baseline()` from `Conductor._inject_fault`.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from sregym.conductor.conductor import Conductor
+from sregym.conductor.oracles import mitigation
+from sregym.conductor.oracles.base import Oracle
+from sregym.conductor.oracles.mitigation import MitigationOracle
+
+
+@pytest.fixture(autouse=True)
+def _fast_rollout_settle(monkeypatch):
+    """These tests exercise baseline logic, not rollout settling. Without this
+    an unsettled deployment burns the full 60s settle window."""
+    monkeypatch.setattr(mitigation, "_ROLLOUT_SETTLE_SECONDS", 0.05)
+    monkeypatch.setattr(mitigation, "_ROLLOUT_POLL_INTERVAL", 0.01)
+
+
+def _deployment(name, *, replicas=1, ready=None, updated=None, unavailable=0):
+    ready = replicas if ready is None else ready
+    updated = replicas if updated is None else updated
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name),
+        spec=SimpleNamespace(replicas=replicas),
+        status=SimpleNamespace(
+            updated_replicas=updated,
+            ready_replicas=ready,
+            unavailable_replicas=unavailable,
+        ),
+    )
+
+
+def _pod(name, *, phase="Running", ready=True):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name),
+        status=SimpleNamespace(
+            phase=phase,
+            container_statuses=[
+                SimpleNamespace(
+                    name="c",
+                    ready=ready,
+                    state=SimpleNamespace(waiting=None, terminated=None),
+                )
+            ],
+        ),
+    )
+
+
+class _KubeCtl:
+    """Mutable fake cluster: set_state() models deploy / hack transitions."""
+
+    def __init__(self, deployments=(), pods=()):
+        self.set_state(deployments, pods)
+
+    def set_state(self, deployments=(), pods=()):
+        self._deployments = list(deployments)
+        self._pods = list(pods)
+
+    def list_deployments(self, namespace):
+        return SimpleNamespace(items=list(self._deployments))
+
+    def list_pods(self, namespace):
+        return SimpleNamespace(items=list(self._pods))
+
+
+class _Problem:
+    def __init__(self, kubectl, namespace="demo-ns"):
+        self.kubectl = kubectl
+        self.namespace = namespace
+
+
+@pytest.fixture
+def kubectl():
+    # Namespace does not exist yet: this is the state at conductor.py's
+    # get_problem_instance(), which runs before undeploy_app()/deploy_app().
+    return _KubeCtl()
+
+
+@pytest.fixture
+def oracle(kubectl):
+    return MitigationOracle(_Problem(kubectl))
+
+
+def _deploy_two(kubectl):
+    kubectl.set_state(
+        [_deployment("web-a"), _deployment("web-b")],
+        [_pod("web-a-1"), _pod("web-b-1")],
+    )
+
+
+def test_construction_against_absent_namespace_does_not_raise(kubectl):
+    """The oracle is built before the namespace exists; that must not explode."""
+    assert MitigationOracle(_Problem(kubectl)).replica_count == {}
+
+
+def test_capture_baseline_records_replica_counts(oracle, kubectl):
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+    assert oracle.replica_count == {"web-a": 1, "web-b": 1}
+
+
+def test_capture_baseline_overwrites_a_stale_snapshot(oracle, kubectl):
+    """Leftovers from a previous run must not leak into this run's baseline."""
+    kubectl.set_state([_deployment("stale-dep", replicas=3)], [])
+    oracle.capture_baseline()
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+    assert oracle.replica_count == {"web-a": 1, "web-b": 1}
+
+
+def test_healthy_cluster_passes(oracle, kubectl):
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+    assert oracle.evaluate()["success"] is True
+
+
+def test_scaling_a_deployment_to_zero_is_rejected(oracle, kubectl):
+    """Reward hack: zero out one deployment. Other pods stay Running, so the
+    pod-liveness check alone would pass — only the baseline catches this."""
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+
+    kubectl.set_state(
+        [_deployment("web-a"), _deployment("web-b", replicas=0, ready=0, updated=0)],
+        [_pod("web-a-1")],
+    )
+
+    assert oracle.evaluate()["success"] is False
+
+
+def test_deleting_a_deployment_is_rejected(oracle, kubectl):
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+
+    kubectl.set_state([_deployment("web-a")], [_pod("web-a-1")])
+
+    assert oracle.evaluate()["success"] is False
+
+
+def test_under_replicated_deployment_is_rejected(oracle, kubectl):
+    _deploy_two(kubectl)
+    oracle.capture_baseline()
+
+    kubectl.set_state(
+        [_deployment("web-a"), _deployment("web-b", replicas=2, ready=1, updated=2)],
+        [_pod("web-a-1"), _pod("web-b-1")],
+    )
+
+    assert oracle.evaluate()["success"] is False
+
+
+def test_without_baseline_capture_the_hack_would_slip_through(kubectl):
+    """Regression guard for the original defect.
+
+    If the baseline is never captured, replica_count stays empty and every
+    replica check is skipped — a zeroed deployment then passes on the strength
+    of the surviving pods alone. This test pins that failure mode so the
+    capture_baseline() call site cannot be quietly dropped again.
+    """
+    oracle = MitigationOracle(_Problem(kubectl))
+    kubectl.set_state(
+        [_deployment("web-a"), _deployment("web-b", replicas=0, ready=0, updated=0)],
+        [_pod("web-a-1")],
+    )
+
+    assert oracle.replica_count == {}
+    assert oracle.evaluate()["success"] is True  # the bug, if capture is skipped
+
+
+def test_base_oracle_capture_baseline_is_a_noop():
+    """Oracles that need no baseline inherit a harmless default."""
+
+    class _Custom(Oracle):
+        def evaluate(self, solution=None, trace=None, duration=None):
+            return {"success": True}
+
+    _Custom(problem=object()).capture_baseline()
+
+
+def test_conductor_captures_baseline_before_injecting_the_fault():
+    """Ordering is the whole point: a baseline taken after injection would
+    record the broken state as healthy."""
+    calls = []
+    problem = SimpleNamespace(
+        mitigation_oracle=SimpleNamespace(capture_baseline=lambda: calls.append("baseline")),
+        inject_fault=lambda: calls.append("inject"),
+        diagnosis_oracle=None,
+    )
+    conductor = SimpleNamespace(
+        current_problem=problem,
+        logger=SimpleNamespace(info=lambda *a, **k: None),
+        fault_injected=False,
+    )
+
+    Conductor._inject_fault(conductor)
+
+    assert calls == ["baseline", "inject"]
+    assert conductor.fault_injected is True
+
+
+def test_conductor_tolerates_a_problem_without_a_mitigation_oracle():
+    calls = []
+    problem = SimpleNamespace(
+        mitigation_oracle=None,
+        inject_fault=lambda: calls.append("inject"),
+        diagnosis_oracle=None,
+    )
+    conductor = SimpleNamespace(
+        current_problem=problem,
+        logger=SimpleNamespace(info=lambda *a, **k: None),
+        fault_injected=False,
+    )
+
+    Conductor._inject_fault(conductor)
+
+    assert calls == ["inject"]


### PR DESCRIPTION
Fixes #941.

## What

`MitigationOracle` snapshotted per-deployment replica counts in `__init__`, which
runs before `deploy_app()`. The namespace didn't exist yet, so `replica_count`
stayed `{}` and the guards against "delete the deployment" and "scale to 0" never
fired.

Moves the snapshot into an explicit `capture_baseline()` hook, called from
`Conductor._inject_fault()` — the single choke point that runs after the app is
deployed and before the fault is injected. `Oracle` gets a no-op default, so
oracles needing no baseline are unaffected.

The snapshot logic itself is unchanged: the two lines that build `replica_count`
are byte-identical, just relocated. This is a timing change, not a rewrite of the
check.

## Verification

kind, k8s v1.35.0. Two healthy deployments, then
`kubectl scale deploy/web-b --replicas=0`:

```
before:  success = True     <- hack accepted
after:   success = False    <- "Deployment 'web-b' was scaled to 0"
```

11 new tests in `tests/oracles/test_mitigation_oracle_baseline.py`, run against
the unfixed code first to confirm they actually catch the defect (8 failed).
Three are load-bearing beyond coverage: two pin the conductor ordering (a
baseline captured *after* injection would record the broken state as healthy),
and one pins the original failure mode so the `capture_baseline()` call site
can't be quietly dropped again.

`tests/oracles/` + `tests/conductor/` (194) and `tests/problems/` (80) pass; ruff
clean.

## Reviewer notes

Two judgment calls I'd like a second opinion on:

1. `getattr(problem, "mitigation_oracle", None)` is defensive — the base
   `Problem` always sets the attribute, so a plain truthiness check would do.
   Happy to simplify.
2. The hook is only wired for `mitigation_oracle`. Detection and diagnosis
   oracles inherit the no-op and never get `capture_baseline()` called. Correct
   today since nothing else needs a baseline, but the asymmetry is deliberate
   rather than an oversight.

---

*AI assistance disclosure: this was found and drafted with Claude Code (Claude
Opus 4.8). The reproduction above was verified on a local kind cluster.*
