### PR TITLE
Add metastable retry collapse to SREGym-Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SREGym has been used to simulate real-world cloud failures, such as:
 
 <h2 id="🚀SREGym-Lite">🚀🚀🚀 Start with SREGym-Lite</h2>
 
-[SREGym-Lite](./docs/SREGym-Lite.md) is a curated set of 20 representative problems with varied difficulty levels that are friendly to run. It is the recommended starting point for new users and can run easily on a [Kind](https://kind.sigs.k8s.io/) setup with 8 vCPU and 16 GB of memory.
+[SREGym-Lite](./docs/SREGym-Lite.md) is a curated set of 21 representative problems with varied difficulty levels that are friendly to run. It is the recommended starting point for new users and can run easily on a [Kind](https://kind.sigs.k8s.io/) setup with 8 vCPU and 16 GB of memory.
 
 
 <h2 id="📦installation">📦 Installation</h2>

--- a/docs/SREGym-Lite.md
+++ b/docs/SREGym-Lite.md
@@ -1,10 +1,10 @@
 # SREGym-Lite
 
-SREGym-Lite is a curated set of 20 well-tested problems with varied difficulty and failure mechanisms. The problems were selected to be easy and reliable to run, making Lite a practical starting point before running the full benchmark.
+SREGym-Lite is a curated set of 21 well-tested problems with varied difficulty and failure mechanisms. The problems were selected to be easy and reliable to run, making Lite a practical starting point before running the full benchmark.
 
 SREGym-Lite can run using SREGym's existing [KIND](https://kind.sigs.k8s.io/) setup on a machine with 8 vCPU and 16 GB of memory.
 
-To keep setup reliable and resource requirements manageable, the problem set excludes TrainTicket, hardware, metastable, and other faults that are difficult to run consistently on all machines.
+To keep setup reliable and resource requirements manageable, the problem set excludes TrainTicket, hardware, and other faults that are difficult to run consistently on all machines.
 
 ## Hardware requirements
 
@@ -80,3 +80,4 @@ The normal runner options, including `--judge-model`, `--reasoning-effort`, `--n
 - `wrong_dns_policy_astronomy_shop`
 - `wrong_service_selector_social_network`
 - `rolling_update_misconfigured_social_network`
+- `search_rate_retry_collapse_hotel_reservation`

--- a/sregym/conductor/problem_sets.py
+++ b/sregym/conductor/problem_sets.py
@@ -21,6 +21,7 @@ SREGYM_LITE_PROBLEMS = (
     "wrong_dns_policy_astronomy_shop",
     "wrong_service_selector_social_network",
     "rolling_update_misconfigured_social_network",
+    "search_rate_retry_collapse_hotel_reservation",
 )
 
 PROBLEM_SETS = {"sregym-lite": SREGYM_LITE_PROBLEMS}


### PR DESCRIPTION
Add the metastable `search_rate_retry_collapse_hotel_reservation` fault to SREGym-Lite.

From recent testing (#946), the fault is compatible to run in kind.