### PR TITLE
Fix the mitigation oracle for `duplicate_pvc_mounts_social_network`

### DIFF
--- a/sregym/conductor/oracles/duplicate_pvc_mounts_mitigation.py
+++ b/sregym/conductor/oracles/duplicate_pvc_mounts_mitigation.py
@@ -8,7 +8,7 @@ from sregym.conductor.oracles.base import Oracle
 
 
 class DuplicatePVCMountsMitigationOracle(Oracle):
-    """Verify that the target Deployment and its Jaeger query endpoint recovered."""
+    """Verify that the target Deployment and its current Jaeger pod recovered."""
 
     importance = 1.0
     rollout_timeout_seconds = 120
@@ -31,6 +31,7 @@ class DuplicatePVCMountsMitigationOracle(Oracle):
         status = deployment.status
         return (
             (status.observed_generation or 0) >= generation
+            and (status.replicas or 0) == desired
             and (status.updated_replicas or 0) == desired
             and (status.ready_replicas or 0) == desired
             and (status.available_replicas or 0) == desired
@@ -58,7 +59,16 @@ class DuplicatePVCMountsMitigationOracle(Oracle):
             for owner in pod.metadata.owner_references or []
         )
 
-    def _has_current_ready_endpoint(self) -> bool:
+    @staticmethod
+    def _pod_ready(pod) -> bool:
+        container_statuses = pod.status.container_statuses or []
+        return (
+            pod.status.phase == "Running"
+            and bool(container_statuses)
+            and all(status.ready for status in container_statuses)
+        )
+
+    def _current_ready_pod_ip(self) -> str | None:
         namespace = self.problem.namespace
         service_name = self.problem.faulty_service
         replica_sets = self.problem.kubectl.get_matching_replicasets(namespace, service_name)
@@ -67,51 +77,28 @@ class DuplicatePVCMountsMitigationOracle(Oracle):
         }
         if not active_replica_sets:
             print(f"[FAIL] Deployment '{service_name}' has no active ReplicaSet")
-            return False
+            return None
 
-        current_pods = {
-            pod.metadata.name
+        ready_pods = [
+            pod
             for pod in self.problem.kubectl.list_pods(namespace).items
-            if pod.metadata.deletion_timestamp is None and self._owned_by_active_replica_set(pod, active_replica_sets)
-        }
-        if not current_pods:
-            print(f"[FAIL] Deployment '{service_name}' has no current pods")
-            return False
-
-        endpoints = self.problem.kubectl.core_v1_api.read_namespaced_endpoints(
-            name=service_name,
-            namespace=namespace,
-        )
-        ready_current_pods = {
-            address.target_ref.name
-            for subset in endpoints.subsets or []
-            for address in subset.addresses or []
-            if address.target_ref is not None
-            and address.target_ref.kind == "Pod"
-            and address.target_ref.name in current_pods
-        }
-        if not ready_current_pods:
-            print(f"[FAIL] Service '{service_name}' has no ready endpoint from its current ReplicaSet")
-            return False
-        return True
-
-    def _run_query_check(self) -> bool:
-        namespace = self.problem.namespace
-        service_name = self.problem.faulty_service
-        core_v1 = self.problem.kubectl.core_v1_api
-        service = core_v1.read_namespaced_service(name=service_name, namespace=namespace)
-        query_ports = [
-            port
-            for port in service.spec.ports or []
-            if port.port == self.query_port and (port.protocol or "TCP") == "TCP"
+            if pod.metadata.deletion_timestamp is None
+            and self._owned_by_active_replica_set(pod, active_replica_sets)
+            and self._pod_ready(pod)
+            and pod.status.pod_ip
         ]
-        if not query_ports:
-            print(f"[FAIL] Service '{service_name}' does not expose TCP port {self.query_port}")
-            return False
+        if not ready_pods:
+            print(f"[FAIL] Deployment '{service_name}' has no Ready pod from its active ReplicaSet")
+            return None
+
+        return ready_pods[0].status.pod_ip
+
+    def _run_query_check(self, target_ip: str) -> bool:
+        namespace = self.problem.namespace
+        core_v1 = self.problem.kubectl.core_v1_api
 
         pod_name = f"service-content-check-{time.time_ns()}"[:63]
-        target = f"{service_name}.{namespace}.svc.cluster.local"
-        url = f"http://{target}:{self.query_port}/api/services"
+        url = f"http://{target_ip}:{self.query_port}/api/services"
         script = (
             f"response=$(wget -q -T 10 -O - '{url}') && "
             "printf '%s' \"$response\" | grep -q '\"data\"' && "
@@ -179,15 +166,16 @@ class DuplicatePVCMountsMitigationOracle(Oracle):
                 print(f"[FAIL] Deployment '{service_name}' did not complete its current rollout")
                 return {"success": False}
 
-            if not self._has_current_ready_endpoint():
+            target_ip = self._current_ready_pod_ip()
+            if target_ip is None:
                 return {"success": False}
 
-            if not self._run_query_check():
-                print(f"[FAIL] Jaeger query endpoint for Service '{service_name}' did not respond correctly")
+            if not self._run_query_check(target_ip):
+                print(f"[FAIL] Current Jaeger pod for Deployment '{service_name}' did not respond correctly")
                 return {"success": False}
         except Exception as exc:
             print(f"[FAIL] Error checking storage recovery: {exc}")
             return {"success": False}
 
-        print(f"[PASS] Deployment '{service_name}' is fully ready and serving Jaeger queries")
+        print(f"[PASS] Deployment '{service_name}' is fully ready and its current pod is serving Jaeger queries")
         return {"success": True}

--- a/tests/oracles/test_duplicate_pvc_mounts_mitigation.py
+++ b/tests/oracles/test_duplicate_pvc_mounts_mitigation.py
@@ -6,6 +6,7 @@ from sregym.conductor.oracles.duplicate_pvc_mounts_mitigation import DuplicatePV
 def _deployment(
     *,
     replicas=1,
+    total=None,
     generation=2,
     observed_generation=2,
     updated=1,
@@ -18,6 +19,7 @@ def _deployment(
         spec=SimpleNamespace(replicas=replicas),
         status=SimpleNamespace(
             observed_generation=observed_generation,
+            replicas=replicas if total is None else total,
             updated_replicas=updated,
             ready_replicas=ready,
             available_replicas=available,
@@ -33,47 +35,46 @@ def _replica_set(name, replicas):
     )
 
 
-def _pod(name, replica_set, *, deleting=False):
+def _pod(
+    name,
+    replica_set,
+    *,
+    deleting=False,
+    phase="Running",
+    ready=True,
+    pod_ip="10.244.0.10",
+):
     return SimpleNamespace(
         metadata=SimpleNamespace(
             name=name,
             deletion_timestamp="now" if deleting else None,
             owner_references=[SimpleNamespace(kind="ReplicaSet", name=replica_set)],
-        )
+        ),
+        status=SimpleNamespace(
+            phase=phase,
+            container_statuses=[SimpleNamespace(ready=ready)],
+            pod_ip=pod_ip,
+        ),
     )
-
-
-def _endpoint(pod_name):
-    return SimpleNamespace(target_ref=SimpleNamespace(kind="Pod", name=pod_name))
 
 
 class _CoreV1:
     def __init__(
         self,
         *,
-        endpoint_pods=None,
-        query_port=True,
         check_phase="Succeeded",
         check_logs="SERVICE_OK\n",
     ):
-        endpoint_pods = ["jaeger-current"] if endpoint_pods is None else endpoint_pods
-        self.endpoints = SimpleNamespace(
-            subsets=[SimpleNamespace(addresses=[_endpoint(name) for name in endpoint_pods])]
-        )
-        self.query_port = query_port
         self.check_phase = check_phase
         self.check_logs = check_logs
         self.created_pods = []
         self.deleted_pods = []
 
     def read_namespaced_endpoints(self, name, namespace):
-        return self.endpoints
+        raise AssertionError("ExternalName services do not provide an Endpoints object")
 
     def read_namespaced_service(self, name, namespace):
-        ports = [SimpleNamespace(port=6831, protocol="UDP")]
-        if self.query_port:
-            ports.append(SimpleNamespace(port=16686, protocol="TCP"))
-        return SimpleNamespace(spec=SimpleNamespace(ports=ports))
+        raise AssertionError("The target pod probe must not depend on the ExternalName service")
 
     def create_namespaced_pod(self, namespace, body):
         self.created_pods.append((namespace, body))
@@ -146,7 +147,7 @@ def test_accepts_healthy_single_replica_and_ignores_obsolete_or_unrelated_pods()
     script = check.spec.containers[0].command[-1]
     assert check.metadata.name.startswith("service-content-check-")
     assert not any(word in check.metadata.name for word in ("sregym", "fault", "oracle", "mitigation"))
-    assert "http://jaeger.social-network.svc.cluster.local:16686/api/services" in script
+    assert "http://10.244.0.10:16686/api/services" in script
     assert len(core_v1.deleted_pods) == 1
 
 
@@ -189,10 +190,43 @@ def test_rejects_stale_generation_with_one_old_ready_replica():
     assert core_v1.created_pods == []
 
 
-def test_rejects_endpoint_owned_only_by_an_obsolete_replicaset():
-    core_v1 = _CoreV1(endpoint_pods=["jaeger-old"])
+def test_rejects_old_ready_pod_masking_unready_current_rollout():
+    core_v1 = _CoreV1()
+    deployment = _deployment(
+        replicas=1,
+        total=2,
+        updated=1,
+        ready=1,
+        available=1,
+        unavailable=0,
+    )
+    replica_sets = [
+        _replica_set("jaeger-current-rs", 1),
+        _replica_set("jaeger-old-rs", 1),
+    ]
     pods = [
-        _pod("jaeger-current", "jaeger-current-rs"),
+        _pod("jaeger-current", "jaeger-current-rs", ready=False),
+        _pod("jaeger-old", "jaeger-old-rs"),
+    ]
+
+    assert (
+        _oracle(
+            _KubeCtl(
+                deployment=deployment,
+                replica_sets=replica_sets,
+                pods=pods,
+                core_v1=core_v1,
+            )
+        ).evaluate()["success"]
+        is False
+    )
+    assert core_v1.created_pods == []
+
+
+def test_rejects_ready_pod_owned_only_by_an_obsolete_replicaset():
+    core_v1 = _CoreV1()
+    pods = [
+        _pod("jaeger-current", "jaeger-current-rs", ready=False),
         _pod("jaeger-old", "jaeger-old-rs"),
     ]
 
@@ -210,10 +244,19 @@ def test_rejects_replacement_without_an_active_target_replicaset():
     assert core_v1.created_pods == []
 
 
-def test_rejects_missing_query_port_without_starting_check():
-    core_v1 = _CoreV1(query_port=False)
+def test_rejects_current_pod_without_an_ip_without_starting_check():
+    core_v1 = _CoreV1()
+    pods = [_pod("jaeger-current", "jaeger-current-rs", pod_ip=None)]
 
-    assert _oracle(_KubeCtl(core_v1=core_v1)).evaluate()["success"] is False
+    assert _oracle(_KubeCtl(pods=pods, core_v1=core_v1)).evaluate()["success"] is False
+    assert core_v1.created_pods == []
+
+
+def test_rejects_current_pod_that_is_not_ready_without_starting_check():
+    core_v1 = _CoreV1()
+    pods = [_pod("jaeger-current", "jaeger-current-rs", ready=False)]
+
+    assert _oracle(_KubeCtl(pods=pods, core_v1=core_v1)).evaluate()["success"] is False
     assert core_v1.created_pods == []
 
 


### PR DESCRIPTION
### Bug

The observability setup changes the Jaeger Service to an ExternalName Service. Kubernetes does not create Endpoints for this type of Service. However, the old oracle required Jaeger Endpoints. As a result, the oracle rejected a correct mitigation even when the current Jaeger pod was Ready and served valid queries.

### Fix

The oracle now finds a Ready Jaeger pod that belongs to an active ReplicaSet. It sends the Jaeger query directly to the pod IP address.