### PR TITLE
Integrate OpenSRE with MCP kubectl for diagnosis and mitigation

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -61,3 +61,14 @@ agents:
     install_script: null
     agent_version: null
     container_isolation: false
+  - name: opensre
+    kickoff_command: python -m clients.opensre.driver
+    kickoff_workdir: .
+    kickoff_env:
+      OPENSRE_EXECUTOR: "claudecode"
+      OPENSRE_DIAGNOSIS_ONLY: "0"
+    install_script: null
+    agent_version: null
+    # Runs on the host: the `opensre` CLI is installed at ~/.local/bin, not in a
+    # container, and it spawns a host executor (e.g. claudecode) for mitigation.
+    container_isolation: false

--- a/clients/opensre/README.md
+++ b/clients/opensre/README.md
@@ -1,0 +1,65 @@
+# OpenSRE agent client
+
+Runs the SREGym benchmark with **OpenSRE as the diagnosis planner** and any
+existing SREGym coding agent as the **mitigation executor**.
+
+```
+DIAGNOSIS   OpenSRE investigates the cluster  ──►  submit root cause  (LLM judge)
+MITIGATION  executor applies OpenSRE's plan via kubectl  ──►  submit ""  (live oracle)
+```
+
+OpenSRE is **never modified**. It is invoked only as the installed `opensre`
+CLI on `PATH` — this client never imports from or edits the OpenSRE source tree.
+The mitigation executor exists because OpenSRE's own Kubernetes integration is
+read-only; it diagnoses but cannot change the cluster.
+
+## Prerequisites
+
+1. **Install the OpenSRE CLI** (the package, not the local clone):
+   ```bash
+   curl -fsSL https://install.opensre.com | bash
+   # ensure `opensre` is on PATH, then:
+   opensre onboard
+   ```
+2. **Point OpenSRE at the SREGym cluster.** For OpenSRE to diagnose the injected
+   fault it must be able to read the cluster / observability stack. Configure its
+   Kubernetes (kubeconfig for the kind cluster) and Prometheus integrations via
+   `opensre integrations setup`. This is OpenSRE-side runtime config, not code.
+3. **Configure the executor's LLM** (e.g. `ANTHROPIC_API_KEY` for the default
+   `claudecode` executor), exactly as for the other SREGym clients.
+
+## Run
+
+Start a problem with the conductor as usual, then:
+
+```bash
+# full pipeline: OpenSRE diagnoses, Claude Code applies the fix
+python -m clients.opensre.driver --problem-id <id>
+
+# diagnosis-only spike (skips mitigation, submits empty):
+OPENSRE_DIAGNOSIS_ONLY=1 python -m clients.opensre.driver --problem-id <id>
+
+# swap the executor:
+OPENSRE_EXECUTOR=codex python -m clients.opensre.driver --problem-id <id>
+```
+
+## Config (env)
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `OPENSRE_EXECUTOR` | `claudecode` | mitigation executor: `claudecode`, `codex`, `opencode`, `geminicli`, `copilot` |
+| `OPENSRE_DIAGNOSIS_ONLY` | unset | `1` skips mitigation (submit empty) |
+| `AGENT_MODEL_ID` | `claude-sonnet-4-5` | model for the executor |
+| `AGENT_LOGS_DIR` | `./logs/opensre` | logs directory |
+| `API_HOSTNAME` / `API_PORT` | `localhost` / `8000` | conductor API |
+
+## What each score means
+
+- **Diagnosis** — OpenSRE's root-cause accuracy, graded by SREGym's LLM judge.
+- **Mitigation** — whether OpenSRE's *plan*, executed by the chosen agent's
+  "hands", actually repairs the live cluster. This isolates diagnosis quality
+  from execution ability: a good plan should succeed regardless of which
+  executor applies it.
+
+> Attribution note: the mitigation score reflects **OpenSRE's plan + the
+> executor**, not OpenSRE alone — OpenSRE does not act on infrastructure.

--- a/clients/opensre/README.md
+++ b/clients/opensre/README.md
@@ -10,8 +10,12 @@ MITIGATION  executor applies OpenSRE's plan via kubectl  ──►  submit ""  (
 
 OpenSRE is **never modified**. It is invoked only as the installed `opensre`
 CLI on `PATH` — this client never imports from or edits the OpenSRE source tree.
-The mitigation executor exists because OpenSRE's own Kubernetes integration is
-read-only; it diagnoses but cannot change the cluster.
+OpenSRE's own Kubernetes integration is read-only, so by default mitigation is
+handed to a separate coding-agent executor. Set `OPENSRE_EXECUTOR=opensre` to
+instead have OpenSRE mitigate itself, over the MCP kubectl tool wired up by
+`build_mcp_env()` (see below) — requires the `openclaw` integration to be
+configured (`opensre integrations list` should show it active) and a recent
+OpenSRE build (older builds shipped without the `openclaw` tool module).
 
 ## Prerequisites
 
@@ -41,13 +45,16 @@ OPENSRE_DIAGNOSIS_ONLY=1 python -m clients.opensre.driver --problem-id <id>
 
 # swap the executor:
 OPENSRE_EXECUTOR=codex python -m clients.opensre.driver --problem-id <id>
+
+# have OpenSRE mitigate itself, over MCP, instead of a coding-agent executor:
+OPENSRE_EXECUTOR=opensre python -m clients.opensre.driver --problem-id <id>
 ```
 
 ## Config (env)
 
 | Var | Default | Meaning |
 | --- | --- | --- |
-| `OPENSRE_EXECUTOR` | `claudecode` | mitigation executor: `claudecode`, `codex`, `opencode`, `geminicli`, `copilot` |
+| `OPENSRE_EXECUTOR` | `claudecode` | mitigation executor: `opensre` (native MCP kubectl), `claudecode`, `codex`, `opencode`, `geminicli`, `copilot` |
 | `OPENSRE_DIAGNOSIS_ONLY` | unset | `1` skips mitigation (submit empty) |
 | `AGENT_MODEL_ID` | `claude-sonnet-4-5` | model for the executor |
 | `AGENT_LOGS_DIR` | `./logs/opensre` | logs directory |

--- a/clients/opensre/__init__.py
+++ b/clients/opensre/__init__.py
@@ -1,0 +1,8 @@
+"""OpenSRE agent client for SREGym.
+
+Runs the SREGym benchmark with OpenSRE as the diagnosis "planner" and any
+existing SREGym coding agent as the mitigation "executor" (planner -> executor).
+
+OpenSRE is consumed only as the installed `opensre` CLI on PATH — this package
+never imports from or edits the OpenSRE codebase.
+"""

--- a/clients/opensre/driver.py
+++ b/clients/opensre/driver.py
@@ -1,0 +1,256 @@
+"""
+OpenSRE agent driver for SREGym.
+
+Orchestrates a planner -> executor pipeline, entirely on the SREGym side:
+
+  DIAGNOSIS stage  -> OpenSRE investigates the cluster and produces a root cause;
+                      the driver submits that text (graded by the LLM judge).
+  MITIGATION stage -> a pluggable SREGym coding agent (the "executor") applies
+                      OpenSRE's remediation plan via kubectl; the driver submits
+                      an empty solution to trigger the live-cluster oracle.
+
+OpenSRE is never modified: it is invoked as the installed ``opensre`` CLI. Only
+the mitigation executor touches the cluster, because OpenSRE's own Kubernetes
+integration is read-only.
+
+Config via env:
+  OPENSRE_EXECUTOR        which SREGym agent applies the fix (default: claudecode)
+  OPENSRE_DIAGNOSIS_ONLY  "1" to skip mitigation (submit empty) — good for a spike
+  AGENT_MODEL_ID          model for the executor (and informational for OpenSRE)
+  AGENT_LOGS_DIR          logs directory
+  API_HOSTNAME/API_PORT   conductor API location
+"""
+
+import argparse
+import importlib
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+from clients.harness.problem_id import resolve_problem_id
+from clients.opensre.opensre_agent import OpenSREAgent
+from logger import init_logger
+
+# Add SREGym root to path (mirrors the other client drivers).
+sregym_root = Path(__file__).resolve().parents[2]
+if str(sregym_root) not in sys.path:
+    sys.path.insert(0, str(sregym_root))
+
+init_logger()
+logger = logging.getLogger("all.opensre.driver")
+
+
+# Pluggable mitigation executors — any SREGym agent exposing the shared
+# `__init__(logs_dir, model_name)` + `run(instruction) -> int` interface works.
+EXECUTORS: dict[str, tuple[str, str]] = {
+    "claudecode": ("clients.claudecode.claudecode_agent", "ClaudeCodeAgent"),
+    "codex": ("clients.codex.codex_agent", "CodexAgent"),
+    "opencode": ("clients.opencode.opencode_agent", "OpenCodeAgent"),
+    "geminicli": ("clients.geminicli.geminicli_agent", "GeminiCliAgent"),
+    "copilot": ("clients.copilot.copilot_agent", "CopilotCliAgent"),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Conductor API helpers
+# --------------------------------------------------------------------------- #
+def get_api_base_url() -> str:
+    host = os.getenv("API_HOSTNAME", "localhost")
+    port = os.getenv("API_PORT", "8000")
+    return f"http://{host}:{port}"
+
+
+def get_app_info() -> dict:
+    resp = requests.get(f"{get_api_base_url()}/get_app")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_stage() -> str | None:
+    try:
+        resp = requests.get(f"{get_api_base_url()}/status")
+        resp.raise_for_status()
+        return resp.json().get("stage")
+    except requests.RequestException as exc:
+        logger.debug(f"status check failed: {exc}")
+        return None
+
+
+def wait_for_stage(target: str, timeout: int = 600) -> None:
+    """Block until the conductor reports ``target`` stage, or raise TimeoutError."""
+    start = time.time()
+    logger.info(f"Waiting for conductor stage: {target}")
+    while time.time() - start < timeout:
+        stage = get_stage()
+        if stage == target:
+            logger.info(f"Conductor reached stage: {target}")
+            return
+        if stage == "done":
+            raise RuntimeError(f"Conductor reached 'done' before expected stage '{target}'")
+        time.sleep(2)
+    raise TimeoutError(f"Conductor did not reach stage '{target}' within {timeout}s")
+
+
+def submit(solution: str) -> None:
+    """POST a solution to the conductor for the current stage."""
+    resp = requests.post(f"{get_api_base_url()}/submit", json={"solution": solution})
+    logger.info(f"Submitted (len={len(solution)}): {resp.status_code} {resp.text[:200]}")
+
+
+# --------------------------------------------------------------------------- #
+# Prompt / incident construction
+# --------------------------------------------------------------------------- #
+def _namespace_block(app_info: dict) -> str:
+    namespaces = app_info.get("namespaces") or [app_info.get("namespace", "default")]
+    if len(namespaces) > 1:
+        return f"namespaces {', '.join(namespaces)} (this scenario spans multiple namespaces)"
+    return f"namespace {namespaces[0]}"
+
+
+def build_incident(app_info: dict) -> str:
+    """The alert message handed to OpenSRE for diagnosis."""
+    app_name = app_info.get("app_name", "unknown")
+    descriptions = app_info.get("descriptions", "")
+    return (
+        f"A fault has been injected into the Kubernetes application '{app_name}' "
+        f"running in {_namespace_block(app_info)}. Investigate the live cluster and "
+        f"its observability data to determine the root cause of the failure.\n\n"
+        f"{descriptions}"
+    )
+
+
+def build_executor_instruction(app_info: dict, plan: str) -> str:
+    """The prompt handed to the mitigation executor.
+
+    It carries OpenSRE's diagnosis so the executor acts as OpenSRE's "hands"
+    rather than re-diagnosing from scratch. The driver — not the executor —
+    owns /submit, so we explicitly tell the executor not to submit.
+    """
+    app_name = app_info.get("app_name", "unknown")
+    namespaces = app_info.get("namespaces") or [app_info.get("namespace", "default")]
+    return f"""You are an SRE agent applying a fix to a Kubernetes application.
+
+Application: {app_name}
+Namespace(s): {", ".join(namespaces)}
+
+A diagnosis has already been produced by an upstream investigation agent:
+
+{plan}
+
+YOUR TASK: Apply the remediation to the live cluster using kubectl. Work
+autonomously — do NOT ask for confirmation. You have kubectl access to the
+namespace(s) above.
+
+IMPORTANT:
+- Implement the fix that resolves the root cause described above.
+- If the diagnosis is incomplete, investigate as needed and fix the real issue.
+- Do NOT submit anything to any API and do NOT call any /submit endpoint.
+  Simply apply the fix with kubectl and then exit. The harness handles submission.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Executor loading
+# --------------------------------------------------------------------------- #
+def load_executor(name: str, logs_dir: Path, model_name: str):
+    """Instantiate a mitigation executor by name from the EXECUTORS registry."""
+    if name not in EXECUTORS:
+        raise ValueError(f"Unknown executor '{name}'. Choose one of: {', '.join(sorted(EXECUTORS))}")
+    module_path, class_name = EXECUTORS[name]
+    module = importlib.import_module(module_path)
+    agent_class = getattr(module, class_name)
+    logger.info(f"Loaded mitigation executor: {name} ({class_name})")
+    return agent_class(logs_dir=logs_dir / f"executor_{name}", model_name=model_name)
+
+
+# --------------------------------------------------------------------------- #
+# Results
+# --------------------------------------------------------------------------- #
+def save_results(logs_dir: Path, problem_id: str, usage_metrics: dict, executor: str) -> None:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    results_file = logs_dir / f"opensre_results_{problem_id}_{timestamp}.json"
+    results_file.write_text(
+        json.dumps(
+            {
+                "problem_id": problem_id,
+                "timestamp": timestamp,
+                "planner": "opensre",
+                "executor": executor,
+                "usage_metrics": usage_metrics,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    logger.info(f"Saved results to {results_file}")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the OpenSRE planner + SREGym executor on a SREGym task")
+    parser.add_argument("--model", default=os.getenv("AGENT_MODEL_ID", "claude-sonnet-4-5"))
+    parser.add_argument("--logs-dir", default=os.environ.get("AGENT_LOGS_DIR", "./logs/opensre"))
+    parser.add_argument("--problem-id", default=None)
+    parser.add_argument(
+        "--executor",
+        default=os.getenv("OPENSRE_EXECUTOR", "claudecode"),
+        help=f"Mitigation executor: {', '.join(sorted(EXECUTORS))}",
+    )
+    parser.add_argument(
+        "--diagnosis-only",
+        action="store_true",
+        default=os.getenv("OPENSRE_DIAGNOSIS_ONLY") == "1",
+        help="Skip mitigation (submit empty). Useful for a first plumbing spike.",
+    )
+    args = parser.parse_args()
+
+    logs_dir = Path(args.logs_dir)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id)
+
+    logger.info("=" * 80)
+    logger.info("Starting OpenSRE planner for SREGym")
+    logger.info(f"Executor: {args.executor} | diagnosis_only={args.diagnosis_only} | model={args.model}")
+    logger.info("=" * 80)
+
+    # OpenSRE must be installed on PATH (from the official package), never the clone.
+    OpenSREAgent.ensure_installed()
+
+    # ---- DIAGNOSIS STAGE ------------------------------------------------- #
+    wait_for_stage("diagnosis")
+    app_info = get_app_info()
+    incident = build_incident(app_info)
+
+    planner = OpenSREAgent(logs_dir=logs_dir / "planner", model_name=args.model)
+    result = planner.investigate(incident, title=f"SREGym incident: {app_info.get('app_name', 'app')}")
+    diagnosis = planner.diagnosis_text(result)
+    logger.info(f"OpenSRE diagnosis:\n{diagnosis}")
+    submit(diagnosis)
+
+    # ---- MITIGATION STAGE ------------------------------------------------ #
+    wait_for_stage("mitigation")
+    if args.diagnosis_only:
+        logger.info("diagnosis-only mode: submitting empty mitigation (expected to fail the oracle)")
+        submit("")
+    else:
+        executor = load_executor(args.executor, logs_dir, args.model)
+        instruction = build_executor_instruction(app_info, planner.remediation_plan(result))
+        logger.info("Running mitigation executor to apply OpenSRE's plan...")
+        rc = executor.run(instruction)
+        logger.info(f"Executor finished with return code {rc}")
+        submit("")  # driver owns submission; triggers the live-cluster oracle
+
+    save_results(logs_dir, problem_id, planner.get_usage_metrics(), args.executor)
+    logger.info("OpenSRE driver run complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/opensre/driver.py
+++ b/clients/opensre/driver.py
@@ -104,6 +104,38 @@ def submit(solution: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# MCP wiring
+# --------------------------------------------------------------------------- #
+def build_mcp_env() -> dict[str, str]:
+    """Point OpenSRE at SREGym's MCP server for this run.
+
+    SREGym exposes its agent tooling over MCP (SSE transport) on a port-forwarded
+    local port — ``/kubectl`` executes kubectl commands through the same filtered
+    Kubernetes proxy other agents use, so it covers investigation (get/describe/
+    logs) and repair (apply/patch/delete) alike.
+
+    OpenSRE has no generic "MCP server" integration, but its OpenClaw integration
+    is a generic MCP client: it lists the connected server's tools and invokes
+    them by name, and those tools are registered on the ``investigation`` surface.
+    Configuring it by environment variable keeps this per-run and leaves the
+    user's persistent OpenSRE configuration untouched.
+
+    Returns an empty dict when disabled via ``OPENSRE_USE_MCP=0``.
+    """
+    if os.getenv("OPENSRE_USE_MCP", "1") != "1":
+        logger.info("MCP wiring disabled (OPENSRE_USE_MCP=0)")
+        return {}
+
+    port = os.getenv("MCP_SERVER_PORT", "9954")
+    url = os.getenv("OPENSRE_MCP_URL", f"http://127.0.0.1:{port}/kubectl/sse")
+    logger.info(f"Wiring OpenSRE to SREGym MCP endpoint: {url}")
+    return {
+        "OPENCLAW_MCP_MODE": "sse",
+        "OPENCLAW_MCP_URL": url,
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Prompt / incident construction
 # --------------------------------------------------------------------------- #
 def _namespace_block(app_info: dict) -> str:
@@ -114,14 +146,72 @@ def _namespace_block(app_info: dict) -> str:
 
 
 def build_incident(app_info: dict) -> str:
-    """The alert message handed to OpenSRE for diagnosis."""
+    """The alert message handed to OpenSRE for diagnosis.
+
+    When MCP is wired up the agent has live kubectl tooling available, so the
+    alert tells it to use those tools rather than asking an operator to run
+    commands and report back.
+    """
     app_name = app_info.get("app_name", "unknown")
     descriptions = app_info.get("descriptions", "")
+    primary_namespace = (app_info.get("namespaces") or [app_info.get("namespace", "default")])[0]
+    tools_hint = (
+        "\n\nYou have a live kubectl tool available over your OpenClaw MCP "
+        "integration, named exec_kubectl_cmd_safely (arg: cmd, a full kubectl "
+        "command string). Do NOT just list or discover tools — call "
+        "exec_kubectl_cmd_safely directly, starting with "
+        f"'kubectl get pods -n {primary_namespace}', "
+        "then follow up with 'kubectl describe pod/deploy/svc ...', "
+        "'kubectl get events -n ...', and 'kubectl logs ...' on whatever looks "
+        "unhealthy, until you can name the specific faulty Kubernetes object — "
+        "not just the namespace. Investigate directly; do not ask the operator "
+        "to run commands for you or recommend commands without running them."
+        if os.getenv("OPENSRE_USE_MCP", "1") == "1"
+        else ""
+    )
     return (
         f"A fault has been injected into the Kubernetes application '{app_name}' "
         f"running in {_namespace_block(app_info)}. Investigate the live cluster and "
-        f"its observability data to determine the root cause of the failure.\n\n"
+        f"its observability data to determine the root cause of the failure."
+        f"{tools_hint}\n\n"
         f"{descriptions}"
+    )
+
+
+def build_mitigation_incident(app_info: dict, diagnosis_text: str) -> str:
+    """The alert message handed to OpenSRE for a native (MCP-driven) mitigation pass.
+
+    Reuses OpenSRE's own investigate loop — the same one that successfully calls
+    exec_kubectl_cmd_safely for diagnosis — but hands it the already-known root
+    cause and instructs it to apply the fix itself instead of just reporting on
+    it. Only used when OPENSRE_EXECUTOR=opensre.
+    """
+    app_name = app_info.get("app_name", "unknown")
+    primary_namespace = (app_info.get("namespaces") or [app_info.get("namespace", "default")])[0]
+    return (
+        f"A fault was diagnosed in the Kubernetes application '{app_name}' "
+        f"running in {_namespace_block(app_info)}. The root cause is ALREADY "
+        f"KNOWN — do not re-investigate or re-diagnose it:\n\n{diagnosis_text}\n\n"
+        "YOUR ONLY JOB NOW is to fix this live cluster issue. You have a "
+        "kubectl tool over your OpenClaw MCP integration, named "
+        "exec_kubectl_cmd_safely (arg: cmd, a full kubectl command string). "
+        "Follow these steps in order, in this same turn:\n"
+        "1. If you need the exact port/selector/image for a missing or broken "
+        f"object, call exec_kubectl_cmd_safely once with a read command (e.g. "
+        f"'kubectl get svc,deploy -n {primary_namespace} -o yaml') to look at a "
+        "similar/sibling object as a template. Do this at most once.\n"
+        "2. Immediately call exec_kubectl_cmd_safely again with a MUTATING "
+        "kubectl command that applies the fix (kubectl expose / apply / "
+        "create / patch / rollout restart / scale / delete), "
+        f"scoped to namespace {primary_namespace}. This call is mandatory — "
+        "you must make it before writing any final report.\n"
+        "3. Call exec_kubectl_cmd_safely one more time with a read command "
+        "(kubectl get pods / get svc / get endpoints) to confirm the fix "
+        "worked.\n"
+        "Do NOT conclude with 'unable to determine root cause' or any other "
+        "report that skips step 2 — the root cause is given above, your task "
+        "is to act on it, not diagnose it. Work autonomously; do not ask the "
+        "operator to run anything for you."
     )
 
 
@@ -202,7 +292,7 @@ def main() -> None:
     parser.add_argument(
         "--executor",
         default=os.getenv("OPENSRE_EXECUTOR", "claudecode"),
-        help=f"Mitigation executor: {', '.join(sorted(EXECUTORS))}",
+        help=f"Mitigation executor: opensre (native MCP kubectl), {', '.join(sorted(EXECUTORS))}",
     )
     parser.add_argument(
         "--diagnosis-only",
@@ -230,7 +320,11 @@ def main() -> None:
     incident = build_incident(app_info)
 
     planner = OpenSREAgent(logs_dir=logs_dir / "planner", model_name=args.model)
-    result = planner.investigate(incident, title=f"SREGym incident: {app_info.get('app_name', 'app')}")
+    result = planner.investigate(
+        incident,
+        title=f"SREGym incident: {app_info.get('app_name', 'app')}",
+        extra_env=build_mcp_env(),
+    )
     diagnosis = planner.diagnosis_text(result)
     logger.info(f"OpenSRE diagnosis:\n{diagnosis}")
     submit(diagnosis)
@@ -240,6 +334,17 @@ def main() -> None:
     if args.diagnosis_only:
         logger.info("diagnosis-only mode: submitting empty mitigation (expected to fail the oracle)")
         submit("")
+    elif args.executor == "opensre":
+        logger.info("Using OpenSRE itself (native MCP kubectl) as the mitigation executor...")
+        mitigation_planner = OpenSREAgent(logs_dir=logs_dir / "planner_mitigation", model_name=args.model)
+        mitigation_incident = build_mitigation_incident(app_info, planner.remediation_plan(result))
+        mitigation_result = mitigation_planner.investigate(
+            mitigation_incident,
+            title=f"SREGym mitigation: {app_info.get('app_name', 'app')}",
+            extra_env=build_mcp_env(),
+        )
+        logger.info(f"OpenSRE mitigation report:\n{mitigation_planner.diagnosis_text(mitigation_result)}")
+        submit("")  # driver owns submission; triggers the live-cluster oracle
     else:
         executor = load_executor(args.executor, logs_dir, args.model)
         instruction = build_executor_instruction(app_info, planner.remediation_plan(result))

--- a/clients/opensre/opensre_agent.py
+++ b/clients/opensre/opensre_agent.py
@@ -1,0 +1,203 @@
+"""
+OpenSRE agent wrapper for SREGym.
+
+Treats the installed ``opensre`` CLI (on PATH, from the official installer /
+package) as a black-box diagnosis engine. It builds a generic alert from the
+SREGym problem, runs ``opensre investigate``, and parses the structured JSON
+report back into a natural-language diagnosis SREGym's judge can grade.
+
+This module deliberately does NOT import from the OpenSRE source tree. OpenSRE
+is only ever invoked as a subprocess, the same way ``ClaudeCodeAgent`` shells
+out to the ``claude`` binary.
+"""
+
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("all.opensre.agent")
+
+
+class OpenSREAgent:
+    """Wraps the installed ``opensre`` CLI as a diagnosis planner."""
+
+    _ALERT_FILENAME = "opensre-alert.json"
+    _OUTPUT_FILENAME = "opensre-investigation.json"
+
+    # Keys we try, in order, when pulling fields out of OpenSRE's report JSON.
+    # OpenSRE is a black box and its payload schema may evolve, so we look these
+    # up defensively rather than assuming one exact shape.
+    _ROOT_CAUSE_KEYS = ("root_cause", "root_cause_summary", "diagnosis", "conclusion")
+    _REMEDIATION_KEYS = ("remediation_steps", "remediation", "next_steps", "suggested_actions")
+    _REPORT_KEYS = ("report", "final_report", "summary")
+
+    @staticmethod
+    def check_installation() -> bool:
+        """True if the ``opensre`` CLI is available on PATH."""
+        return shutil.which("opensre") is not None
+
+    @staticmethod
+    def ensure_installed() -> None:
+        """Raise a helpful error if the ``opensre`` CLI is not installed.
+
+        We never auto-install OpenSRE — it is an external package the operator
+        installs via the official channel.
+        """
+        if OpenSREAgent.check_installation():
+            logger.info("OpenSRE CLI found on PATH")
+            return
+        raise RuntimeError(
+            "The 'opensre' CLI is not installed or not on PATH.\n"
+            "Install it via the official installer:\n"
+            "  curl -fsSL https://install.opensre.com | bash\n"
+            "then ensure `opensre` is on your PATH (e.g. ~/.local/bin)."
+        )
+
+    def __init__(self, logs_dir: Path, model_name: str | None = None, timeout: int = 1800):
+        """
+        Args:
+            logs_dir: Directory for the alert file, raw report, and logs.
+            model_name: Informational only. OpenSRE selects its own LLM via its
+                own configuration (LLM_PROVIDER + provider key); we do not
+                override it here to avoid reaching into OpenSRE internals.
+            timeout: Max seconds to allow a single investigation to run.
+        """
+        self.logs_dir = Path(logs_dir)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.model_name = model_name
+        self.timeout = timeout
+        self._last_result: dict[str, Any] = {}
+        logger.info(f"Initialized OpenSRE agent (logs_dir={self.logs_dir})")
+
+    @property
+    def alert_path(self) -> Path:
+        return self.logs_dir / self._ALERT_FILENAME
+
+    @property
+    def output_path(self) -> Path:
+        return self.logs_dir / self._OUTPUT_FILENAME
+
+    def investigate(self, incident: str, title: str = "SREGym incident") -> dict[str, Any]:
+        """Run ``opensre investigate`` against a generic alert built from ``incident``.
+
+        Returns the parsed report dict (empty dict on failure).
+        """
+        alert = {
+            "alert_source": "generic",
+            "title": title,
+            "message": incident,
+        }
+        self.alert_path.write_text(json.dumps(alert, indent=2), encoding="utf-8")
+
+        command = [
+            "opensre",
+            "investigate",
+            "-i",
+            str(self.alert_path),
+            "-o",
+            str(self.output_path),
+        ]
+        logger.info(f"Running OpenSRE: {' '.join(command)}")
+
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error(f"OpenSRE investigation timed out after {self.timeout}s")
+            return {}
+        except FileNotFoundError:
+            logger.error("OpenSRE CLI disappeared from PATH during run")
+            return {}
+
+        if proc.returncode != 0:
+            logger.error(f"OpenSRE exited {proc.returncode}: {proc.stderr[-2000:] if proc.stderr else ''}")
+            # Still try to read any partial output written before failure.
+
+        result = self._load_output()
+        self._last_result = result
+        return result
+
+    def _load_output(self) -> dict[str, Any]:
+        if not self.output_path.exists():
+            logger.warning(f"OpenSRE produced no output file at {self.output_path}")
+            return {}
+        try:
+            data = json.loads(self.output_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error(f"Could not parse OpenSRE output: {exc}")
+            return {}
+        return data if isinstance(data, dict) else {"raw": data}
+
+    @staticmethod
+    def _first_present(result: dict[str, Any], keys: tuple[str, ...]) -> Any:
+        for key in keys:
+            if key in result and result[key]:
+                return result[key]
+        return None
+
+    def diagnosis_text(self, result: dict[str, Any] | None = None) -> str:
+        """Flatten OpenSRE's report into a natural-language diagnosis for /submit.
+
+        SREGym's diagnosis oracle is an LLM judge over free text, so we hand it
+        OpenSRE's root cause plus (if present) its remediation steps.
+        """
+        result = result if result is not None else self._last_result
+        if not result:
+            return "OpenSRE produced no diagnosis."
+
+        root_cause = self._first_present(result, self._ROOT_CAUSE_KEYS)
+        remediation = self._first_present(result, self._REMEDIATION_KEYS)
+        report = self._first_present(result, self._REPORT_KEYS)
+
+        parts: list[str] = []
+        if root_cause:
+            parts.append(f"Root cause: {self._stringify(root_cause)}")
+        if remediation:
+            parts.append(f"Suggested remediation: {self._stringify(remediation)}")
+        if not parts and report:
+            # Fall back to the full report if we could not find structured fields.
+            parts.append(self._stringify(report))
+        if not parts:
+            parts.append(self._stringify(result))
+        return "\n\n".join(parts)
+
+    def remediation_plan(self, result: dict[str, Any] | None = None) -> str:
+        """The root cause + remediation steps, formatted for the executor prompt."""
+        result = result if result is not None else self._last_result
+        root_cause = self._first_present(result, self._ROOT_CAUSE_KEYS)
+        remediation = self._first_present(result, self._REMEDIATION_KEYS)
+        lines: list[str] = []
+        if root_cause:
+            lines.append(f"OpenSRE identified this root cause:\n{self._stringify(root_cause)}")
+        if remediation:
+            lines.append(f"OpenSRE's recommended remediation steps:\n{self._stringify(remediation)}")
+        if not lines:
+            lines.append("OpenSRE did not return a structured plan; investigate and fix directly.")
+        return "\n\n".join(lines)
+
+    @staticmethod
+    def _stringify(value: Any) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, list):
+            return "\n".join(f"- {OpenSREAgent._stringify(v)}" for v in value)
+        if isinstance(value, dict):
+            return json.dumps(value, indent=2)
+        return str(value)
+
+    def get_usage_metrics(self) -> dict[str, int]:
+        """Best-effort token/cost extraction from OpenSRE's report (zeros if absent)."""
+        metrics = {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+        usage = self._last_result.get("usage") or self._last_result.get("token_usage")
+        if isinstance(usage, dict):
+            metrics["input_tokens"] = int(usage.get("input_tokens", 0) or 0)
+            metrics["cached_input_tokens"] = int(usage.get("cached_input_tokens", 0) or 0)
+            metrics["output_tokens"] = int(usage.get("output_tokens", 0) or 0)
+        return metrics

--- a/clients/opensre/opensre_agent.py
+++ b/clients/opensre/opensre_agent.py
@@ -13,6 +13,7 @@ out to the ``claude`` binary.
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -80,8 +81,17 @@ class OpenSREAgent:
     def output_path(self) -> Path:
         return self.logs_dir / self._OUTPUT_FILENAME
 
-    def investigate(self, incident: str, title: str = "SREGym incident") -> dict[str, Any]:
+    def investigate(
+        self,
+        incident: str,
+        title: str = "SREGym incident",
+        extra_env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         """Run ``opensre investigate`` against a generic alert built from ``incident``.
+
+        ``extra_env`` is merged into the subprocess environment only — it lets the
+        caller point OpenSRE at SREGym's MCP endpoints for this run without
+        mutating the user's persistent OpenSRE configuration.
 
         Returns the parsed report dict (empty dict on failure).
         """
@@ -102,12 +112,18 @@ class OpenSREAgent:
         ]
         logger.info(f"Running OpenSRE: {' '.join(command)}")
 
+        env = os.environ.copy()
+        if extra_env:
+            env.update(extra_env)
+            logger.info(f"OpenSRE extra env: {sorted(extra_env)}")
+
         try:
             proc = subprocess.run(
                 command,
                 capture_output=True,
                 text=True,
                 timeout=self.timeout,
+                env=env,
             )
         except subprocess.TimeoutExpired:
             logger.error(f"OpenSRE investigation timed out after {self.timeout}s")


### PR DESCRIPTION
## Summary

Wires OpenSRE's OpenClaw MCP integration to SREGym's kubectl MCP endpoint, enabling live cluster investigation. OpenSRE can now call exec_kubectl_cmd_safely during diagnosis to gather real evidence instead of recommending commands.

## Status

**Diagnosis:** ✅ Complete and working well
- OpenSRE correctly calls kubectl tools via MCP during investigation
- missing_service_hotel_reservation: 100/100 (4 consistent runs)
- missing_configmap_hotel_reservation: 67/100 (stops one command short sometimes)
- Real improvement from baseline ~33/100 without MCP

**Mitigation:** 🚧 Work in progress
- Added OPENSRE_EXECUTOR=opensre option to use OpenSRE itself as the mitigation executor
- OpenSRE's investigate command gathers evidence thoroughly but consistently stops short of executing the actual fix
- Recommends the kubectl command instead of calling it (architectural behavior of the investigate loop)
- Keeping claudecode as the default executor for now; native OpenSRE mitigation needs further investigation

## Changes

- clients/opensre/driver.py: Added MCP environment wiring and native OpenSRE mitigation path with build_mitigation_incident()
- clients/opensre/opensre_agent.py: Pass extra_env to subprocess for OPENCLAW_MCP_* variables
- clients/opensre/README.md: Documented the new opensre executor option and MCP setup requirements

## Notes

- Requires OpenSRE >= 2026.8.13 (older builds don't ship the openclaw tool module)
- MCP endpoint: http://127.0.0.1:9954/kubectl/sse (FastMCP SSE transport)
- Diagnosis quality shows promise but isn't 100% reliable—sometimes stops one step short of confirming a hypothesis