### PR TITLE
Restore the pre-injection kube-proxy image

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Download CodeQL CLI v2.23.5
+    - name: Download CodeQL CLI v2.26.3
       run: |
-        curl -L https://github.com/github/codeql-cli-binaries/releases/download/v2.23.5/codeql-linux64.zip -o codeql.zip
+        curl -L https://github.com/github/codeql-cli-binaries/releases/download/v2.26.3/codeql-linux64.zip -o codeql.zip
         unzip codeql.zip
         mv codeql /opt/codeql
         echo "/opt/codeql" >> $GITHUB_PATH

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -704,9 +704,7 @@ class Conductor:
         self.logger.info("[FIX] Imbalance leftover if any")
 
         injector = VirtualizationFaultInjector(namespace="kube-system")
-        injector.recover_daemon_set_image_replacement(
-            daemon_set_name="kube-proxy", original_image="registry.k8s.io/kube-proxy:v1.31.13"
-        )
+        injector.recover_daemon_set_image_replacement(daemon_set_name="kube-proxy")
 
         self.logger.info("[FIX] KubeletCrash leftover if any")
         injector = RemoteOSFaultInjector()

--- a/sregym/conductor/problems/workload_imbalance.py
+++ b/sregym/conductor/problems/workload_imbalance.py
@@ -51,9 +51,8 @@ class WorkloadImbalance(Problem):
     @mark_fault_injected
     def recover_fault(self):
         print("== Fault Recovery ==")
-        self.injector.inject_daemon_set_image_replacement(
-            daemon_set_name="kube-proxy", new_image="registry.k8s.io/kube-proxy:v1.31.13"
-        )
+        if not self.injector.recover_daemon_set_image_replacement(daemon_set_name="kube-proxy"):
+            raise RuntimeError("The saved kube-proxy image is missing")
         print(f"Service: {self.faulty_service[0]} | Namespace: {self.namespace}\n")
         self.injector_for_scale.scale_pods_to(replicas=1, microservices=self.faulty_service)
         self.kubectl.wait_for_ready(namespace=self.namespace)

--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -11,9 +11,11 @@ import yaml
 from kubernetes.client.rest import ApiException
 
 from sregym.generators.fault.base import FaultInjector
-from sregym.paths import TARGET_MICROSERVICES
+from sregym.paths import CACHE_DIR, TARGET_MICROSERVICES
 from sregym.service.helm import Helm
 from sregym.service.kubectl import KubeCtl
+
+DAEMON_SET_RECOVERY_STATE_DIR = CACHE_DIR / "daemon_set_recovery"
 
 
 class VirtualizationFaultInjector(FaultInjector):
@@ -2354,42 +2356,151 @@ class VirtualizationFaultInjector(FaultInjector):
         self.kubectl.exec_command(deployment_rollout_command)
         self.kubectl.wait_for_ready(self.namespace)
 
+    def _cluster_uid(self) -> str:
+        namespace = self.kubectl.core_v1_api.read_namespace("kube-system")
+        cluster_uid = str(namespace.metadata.uid or "")
+        if not cluster_uid:
+            raise RuntimeError("The kube-system namespace does not have a UID")
+        return cluster_uid
+
+    def _daemon_set_recovery_path(self, daemon_set_name: str, cluster_uid: str) -> Path:
+        filename = f"{cluster_uid}__{self.namespace}__{daemon_set_name}.json"
+        return DAEMON_SET_RECOVERY_STATE_DIR / filename
+
+    @staticmethod
+    def _daemon_set_images(daemon_set) -> dict[str, str]:
+        containers = daemon_set.spec.template.spec.containers or []
+        images = {container.name: container.image for container in containers if container.name and container.image}
+        if not images:
+            raise RuntimeError("The DaemonSet does not contain any named container images")
+        return images
+
+    def _write_daemon_set_recovery_state(self, path: Path, state: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.parent.chmod(0o700)
+        temporary_path = path.with_name(f".{path.name}.tmp")
+        temporary_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+        temporary_path.chmod(0o600)
+        temporary_path.replace(path)
+
+    def _capture_daemon_set_images(self, daemon_set_name: str, daemon_set, cluster_uid: str) -> dict:
+        path = self._daemon_set_recovery_path(daemon_set_name, cluster_uid)
+        daemon_set_uid = str(daemon_set.metadata.uid or "")
+        if not daemon_set_uid:
+            raise RuntimeError(f"DaemonSet '{self.namespace}/{daemon_set_name}' does not have a UID")
+
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RuntimeError(f"Invalid DaemonSet recovery state: {path}") from exc
+            if existing.get("daemon_set_uid") == daemon_set_uid:
+                expected = {
+                    "version": 1,
+                    "cluster_uid": cluster_uid,
+                    "namespace": self.namespace,
+                    "daemon_set": daemon_set_name,
+                }
+                if any(existing.get(key) != value for key, value in expected.items()):
+                    raise RuntimeError(f"DaemonSet recovery state does not match the current cluster resource: {path}")
+                if not isinstance(existing.get("images"), dict) or not existing["images"]:
+                    raise RuntimeError(f"DaemonSet recovery state does not contain images: {path}")
+                return existing
+
+        state = {
+            "version": 1,
+            "cluster_uid": cluster_uid,
+            "namespace": self.namespace,
+            "daemon_set": daemon_set_name,
+            "daemon_set_uid": daemon_set_uid,
+            "images": self._daemon_set_images(daemon_set),
+        }
+        self._write_daemon_set_recovery_state(path, state)
+        return state
+
+    def _load_daemon_set_recovery_state(self, daemon_set_name: str, cluster_uid: str) -> tuple[Path, dict] | None:
+        path = self._daemon_set_recovery_path(daemon_set_name, cluster_uid)
+        if not path.exists():
+            return None
+
+        try:
+            state = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Invalid DaemonSet recovery state: {path}") from exc
+
+        expected = {
+            "version": 1,
+            "cluster_uid": cluster_uid,
+            "namespace": self.namespace,
+            "daemon_set": daemon_set_name,
+        }
+        if any(state.get(key) != value for key, value in expected.items()):
+            raise RuntimeError(f"DaemonSet recovery state does not match the current cluster resource: {path}")
+        if not isinstance(state.get("images"), dict) or not state["images"]:
+            raise RuntimeError(f"DaemonSet recovery state does not contain images: {path}")
+        return path, state
+
+    def _patch_daemon_set_images(self, daemon_set_name: str, images: dict[str, str]) -> None:
+        body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {"name": container_name, "image": image} for container_name, image in images.items()
+                        ]
+                    }
+                }
+            }
+        }
+        self.kubectl.apps_v1_api.patch_namespaced_daemon_set(
+            name=daemon_set_name,
+            namespace=self.namespace,
+            body=body,
+        )
+
+    def _wait_for_daemon_set_rollout(self, daemon_set_name: str) -> None:
+        self.kubectl.exec_command_checked(
+            f"kubectl rollout status ds {daemon_set_name} -n {self.namespace} --timeout=120s",
+            timeout=130,
+        )
+
     def inject_daemon_set_image_replacement(self, daemon_set_name: str, new_image: str):
-        daemon_set_yaml = self._get_daemon_set_yaml(daemon_set_name)
-        if daemon_set_yaml is None:
-            raise RuntimeError(f"Failed to get daemonset '{daemon_set_name}'")
+        cluster_uid = self._cluster_uid()
+        daemon_set = self.kubectl.apps_v1_api.read_namespaced_daemon_set(daemon_set_name, self.namespace)
+        current_images = self._daemon_set_images(daemon_set)
+        self._capture_daemon_set_images(daemon_set_name, daemon_set, cluster_uid)
 
-        # Replace the image in all containers
-        if "spec" in daemon_set_yaml and "template" in daemon_set_yaml["spec"]:
-            template_spec = daemon_set_yaml["spec"]["template"]["spec"]
-            if "containers" in template_spec:
-                for container in template_spec["containers"]:
-                    if "image" in container:
-                        container["image"] = new_image
+        replacement_images = {container_name: new_image for container_name in current_images}
+        if current_images != replacement_images:
+            self._patch_daemon_set_images(daemon_set_name, replacement_images)
+        self._wait_for_daemon_set_rollout(daemon_set_name)
 
-        modified_yaml_path = self._write_yaml_to_file(daemon_set_name, daemon_set_yaml)  # backup the yaml
+    def recover_daemon_set_image_replacement(self, daemon_set_name: str) -> bool:
+        cluster_uid = self._cluster_uid()
+        saved = self._load_daemon_set_recovery_state(daemon_set_name, cluster_uid)
+        if saved is None:
+            return False
 
-        self.kubectl.exec_command(f"kubectl apply -f {modified_yaml_path}")
-        self.kubectl.exec_command(f"kubectl rollout restart ds {daemon_set_name} -n {self.namespace}")
-        self.kubectl.exec_command(f"kubectl rollout status ds {daemon_set_name} -n {self.namespace} --timeout=60s")
+        path, state = saved
+        daemon_set = self.kubectl.apps_v1_api.read_namespaced_daemon_set(daemon_set_name, self.namespace)
+        daemon_set_uid = str(daemon_set.metadata.uid or "")
+        if daemon_set_uid != state.get("daemon_set_uid"):
+            raise RuntimeError(
+                f"DaemonSet '{self.namespace}/{daemon_set_name}' was recreated after the recovery state was saved"
+            )
 
-    def recover_daemon_set_image_replacement(self, daemon_set_name: str, original_image: str):
-        daemon_set_yaml = self._get_daemon_set_yaml(daemon_set_name)
-        if daemon_set_yaml is None:
-            return
-        if "spec" in daemon_set_yaml and "template" in daemon_set_yaml["spec"]:
-            template_spec = daemon_set_yaml["spec"]["template"]["spec"]
-            if "containers" in template_spec:
-                for container in template_spec["containers"]:
-                    if "image" in container and container["image"] != original_image:
-                        container["image"] = original_image
-                        modified_yaml_path = self._write_yaml_to_file(daemon_set_name, daemon_set_yaml)
-                        self.kubectl.exec_command(f"kubectl apply -f {modified_yaml_path}")
-                        self.kubectl.exec_command(f"kubectl rollout restart ds {daemon_set_name} -n {self.namespace}")
-                        self.kubectl.exec_command(
-                            f"kubectl rollout status ds {daemon_set_name} -n {self.namespace} --timeout=60s"
-                        )
-                        return
+        current_images = self._daemon_set_images(daemon_set)
+        original_images = state["images"]
+        if set(current_images) != set(original_images):
+            raise RuntimeError(
+                f"DaemonSet '{self.namespace}/{daemon_set_name}' containers do not match the recovery state"
+            )
+        if current_images != original_images:
+            self._patch_daemon_set_images(daemon_set_name, original_images)
+        self._wait_for_daemon_set_rollout(daemon_set_name)
+
+        path.unlink()
+        return True
 
     def inject_rbac_misconfiguration(self, microservices: list[str]):
         for service in microservices:
@@ -3106,14 +3217,6 @@ class VirtualizationFaultInjector(FaultInjector):
     def _get_service_yaml(self, service_name: str):
         deployment_yaml = self.kubectl.exec_command(f"kubectl get service {service_name} -n {self.namespace} -o yaml")
         return yaml.safe_load(deployment_yaml)
-
-    def _get_daemon_set_yaml(self, daemon_set_name: str) -> dict | None:
-        daemon_set_yaml = self.kubectl.exec_command(f"kubectl get ds {daemon_set_name} -n {self.namespace} -o yaml")
-        parsed = yaml.safe_load(daemon_set_yaml)
-        if not isinstance(parsed, dict):
-            print(f"[inject_virtual] Failed to get daemonset '{daemon_set_name}': {daemon_set_yaml[:200]}")
-            return None
-        return parsed
 
     def _change_node_selector(self, deployment_yaml: dict, node_name: str):
         if "spec" in deployment_yaml and "template" in deployment_yaml["spec"]:

--- a/tests/conductor/test_calico_route_reflector_cleanup.py
+++ b/tests/conductor/test_calico_route_reflector_cleanup.py
@@ -220,7 +220,7 @@ def test_fix_kubernetes_keeps_kubelet_eviction_global_cleanup(monkeypatch):
         def __init__(self, namespace):
             self.namespace = namespace
 
-        def recover_daemon_set_image_replacement(self, daemon_set_name, original_image):
+        def recover_daemon_set_image_replacement(self, daemon_set_name):
             pass
 
         def recover_all_nxdomain_templates(self):

--- a/tests/generators/test_daemon_set_image_recovery.py
+++ b/tests/generators/test_daemon_set_image_recovery.py
@@ -1,0 +1,190 @@
+import json
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from sregym.generators.fault import inject_virtual
+from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
+
+
+def _daemon_set(uid="daemon-set-uid", images=None):
+    images = images or {"kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14"}
+    return SimpleNamespace(
+        metadata=SimpleNamespace(uid=uid),
+        spec=SimpleNamespace(
+            template=SimpleNamespace(
+                spec=SimpleNamespace(
+                    containers=[SimpleNamespace(name=name, image=image) for name, image in images.items()]
+                )
+            )
+        ),
+    )
+
+
+class _CoreApi:
+    def __init__(self, cluster_uid="cluster-uid"):
+        self.cluster_uid = cluster_uid
+
+    def read_namespace(self, name):
+        assert name == "kube-system"
+        return SimpleNamespace(metadata=SimpleNamespace(uid=self.cluster_uid))
+
+
+class _AppsApi:
+    def __init__(self, daemon_set):
+        self.daemon_set = daemon_set
+        self.patches = []
+
+    def read_namespaced_daemon_set(self, name, namespace):
+        assert name == "kube-proxy"
+        assert namespace == "kube-system"
+        return self.daemon_set
+
+    def patch_namespaced_daemon_set(self, name, namespace, body):
+        assert name == "kube-proxy"
+        assert namespace == "kube-system"
+        self.patches.append(body)
+        images = {container["name"]: container["image"] for container in body["spec"]["template"]["spec"]["containers"]}
+        for container in self.daemon_set.spec.template.spec.containers:
+            if container.name in images:
+                container.image = images[container.name]
+
+
+class _KubeCtl:
+    def __init__(self, daemon_set, cluster_uid="cluster-uid"):
+        self.core_v1_api = _CoreApi(cluster_uid)
+        self.apps_v1_api = _AppsApi(daemon_set)
+        self.commands = []
+        self.rollout_error = None
+
+    def exec_command_checked(self, command, timeout=None):
+        self.commands.append((command, timeout))
+        if self.rollout_error:
+            raise self.rollout_error
+        return ""
+
+
+@pytest.fixture
+def injector(monkeypatch, tmp_path):
+    monkeypatch.setattr(inject_virtual, "DAEMON_SET_RECOVERY_STATE_DIR", tmp_path)
+    instance = object.__new__(VirtualizationFaultInjector)
+    instance.namespace = "kube-system"
+    instance.kubectl = _KubeCtl(_daemon_set())
+    return instance
+
+
+def _state_path(injector):
+    return injector._daemon_set_recovery_path("kube-proxy", injector._cluster_uid())
+
+
+def test_injection_saves_the_real_images_before_replacement(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+
+    state = json.loads(_state_path(injector).read_text())
+    assert state["cluster_uid"] == "cluster-uid"
+    assert state["daemon_set_uid"] == "daemon-set-uid"
+    assert state["images"] == {"kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14"}
+    assert injector._daemon_set_images(injector.kubectl.apps_v1_api.daemon_set) == {
+        "kube-proxy": "example.invalid/kube-proxy:broken"
+    }
+
+
+def test_repeated_injection_keeps_the_first_snapshot(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken-again")
+
+    state = json.loads(_state_path(injector).read_text())
+    assert state["images"] == {"kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14"}
+
+
+def test_recovery_state_has_private_permissions(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+
+    path = _state_path(injector)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+
+def test_failed_injection_patch_keeps_state_for_cleanup(injector):
+    def fail_patch(*_args, **_kwargs):
+        raise RuntimeError("patch failed")
+
+    injector.kubectl.apps_v1_api.patch_namespaced_daemon_set = fail_patch
+
+    with pytest.raises(RuntimeError, match="patch failed"):
+        injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+
+    state = json.loads(_state_path(injector).read_text())
+    assert state["images"] == {"kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14"}
+
+
+def test_recovery_restores_each_original_image_and_removes_state(injector):
+    injector.kubectl.apps_v1_api.daemon_set = _daemon_set(
+        images={
+            "kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14",
+            "metrics": "example.invalid/metrics:v2",
+        }
+    )
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/broken:v1")
+
+    assert injector.recover_daemon_set_image_replacement("kube-proxy") is True
+    assert injector._daemon_set_images(injector.kubectl.apps_v1_api.daemon_set) == {
+        "kube-proxy": "registry.k8s.io/kube-proxy:v1.31.14",
+        "metrics": "example.invalid/metrics:v2",
+    }
+    assert not _state_path(injector).exists()
+
+
+def test_global_recovery_without_saved_state_does_not_change_the_daemon_set(injector):
+    assert injector.recover_daemon_set_image_replacement("kube-proxy") is False
+    assert injector.kubectl.apps_v1_api.patches == []
+    assert injector.kubectl.commands == []
+
+
+def test_recovery_rejects_a_recreated_daemon_set_and_keeps_state(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+    injector.kubectl.apps_v1_api.daemon_set.metadata.uid = "replacement-uid"
+
+    with pytest.raises(RuntimeError, match="was recreated"):
+        injector.recover_daemon_set_image_replacement("kube-proxy")
+
+    assert _state_path(injector).exists()
+
+
+def test_recovery_rejects_a_changed_container_set_and_keeps_state(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+    injector.kubectl.apps_v1_api.daemon_set.spec.template.spec.containers.append(
+        SimpleNamespace(name="new-sidecar", image="example.invalid/sidecar:v1")
+    )
+
+    with pytest.raises(RuntimeError, match="containers do not match"):
+        injector.recover_daemon_set_image_replacement("kube-proxy")
+
+    assert _state_path(injector).exists()
+
+
+def test_failed_recovery_rollout_keeps_state_for_the_next_run(injector):
+    injector.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+    injector.kubectl.rollout_error = RuntimeError("rollout timed out")
+
+    with pytest.raises(RuntimeError, match="rollout timed out"):
+        injector.recover_daemon_set_image_replacement("kube-proxy")
+
+    assert _state_path(injector).exists()
+
+
+def test_recovery_state_from_another_cluster_is_not_used(monkeypatch, tmp_path):
+    monkeypatch.setattr(inject_virtual, "DAEMON_SET_RECOVERY_STATE_DIR", tmp_path)
+    old = object.__new__(VirtualizationFaultInjector)
+    old.namespace = "kube-system"
+    old.kubectl = _KubeCtl(_daemon_set(), cluster_uid="old-cluster")
+    old.inject_daemon_set_image_replacement("kube-proxy", "example.invalid/kube-proxy:broken")
+
+    current = object.__new__(VirtualizationFaultInjector)
+    current.namespace = "kube-system"
+    current.kubectl = _KubeCtl(_daemon_set(), cluster_uid="new-cluster")
+
+    assert current.recover_daemon_set_image_replacement("kube-proxy") is False
+    assert current.kubectl.apps_v1_api.patches == []
+    assert old._daemon_set_recovery_path("kube-proxy", "old-cluster").exists()


### PR DESCRIPTION
Fixes #808

Save the current kube-proxy image before injecting the fault, then restore the same image during recovery.

Previously, recovery always changed kube-proxy to v1.31.13. This could downgrade a cluster using a newer Kubernetes patch version, even when no fault had been injected.

Recovery now uses the image saved during injection. The saved image is kept if recovery is interrupted or fails, allowing cleanup to retry later. If no image was saved, cleanup does not change kube-proxy.

/validate-problem workload_imbalance