### PR TITLE
Persist stratus token usage before completion

### DIFF
--- a/clients/stratus/stratus_agent/driver/driver.py
+++ b/clients/stratus/stratus_agent/driver/driver.py
@@ -22,6 +22,7 @@ import requests  # noqa: E402
 import yaml  # noqa: E402
 from langchain_core.messages import HumanMessage, SystemMessage  # noqa: E402
 
+from llm_backend.usage_log import USAGE_LOG_PATH_ENV, summarize_usage  # noqa: E402
 from logger import init_logger  # noqa: E402
 
 init_logger()
@@ -723,6 +724,14 @@ async def main():
     current_problem = resolve_problem_id()
     logger.info(f"Problem ID (harness): {current_problem}")
 
+    agent_logs_dir = os.environ.get("AGENT_LOGS_DIR")
+    if agent_logs_dir:
+        problem_dir = Path(agent_logs_dir)
+    else:
+        project_root = Path(__file__).resolve().parents[4]
+        problem_dir = project_root / "results" / timestamp / current_problem
+    os.environ[USAGE_LOG_PATH_ENV] = str(problem_dir / "stratus_usage.jsonl")
+
     # logger.info("*" * 25 + f" Testing {current_problem} ! " + "*" * 25)
     # logger.info("*" * 25 + f" Testing {current_problem} ! " + "*" * 25)
     # logger.info("*" * 25 + f" Testing {current_problem} ! " + "*" * 25)
@@ -856,14 +865,28 @@ async def main():
     agent_output_df["rollback_stack"] = agent_rollback_stack
     agent_output_df["oracle_results"] = agent_oracle_results
 
-    agent_logs_dir = os.environ.get("AGENT_LOGS_DIR")
-    if agent_logs_dir:
-        problem_dir = Path(agent_logs_dir)
-    else:
-        project_root = Path(__file__).resolve().parents[4]
-        problem_dir = project_root / "results" / timestamp / current_problem
-
     problem_dir.mkdir(parents=True, exist_ok=True)
+
+    # The callback-backed rows already include trace and nested tool calls. Only
+    # detached summary calls must be added to avoid counting other calls twice.
+    summary_usage = summarize_usage(Path(os.environ[USAGE_LOG_PATH_ENV]), usage_type="summary")
+    if summary_usage["requests"]:
+        summary_row = pd.DataFrame(
+            [
+                {
+                    "agent_name": "run_summary",
+                    "input_tokens": summary_usage["input_tokens"],
+                    "output_tokens": summary_usage["output_tokens"],
+                    "total_tokens": summary_usage["total_tokens"],
+                    "time": str(summary_usage["duration_seconds"]),
+                    "steps": summary_usage["requests"],
+                    "num_retry_attempts": "N/A",
+                    "rollback_stack": "N/A",
+                    "oracle_results": "N/A",
+                }
+            ]
+        )
+        agent_output_df = pd.concat([agent_output_df, summary_row], ignore_index=True)
 
     csv_path = problem_dir / f"{current_problem}_stratus_output.csv"
     agent_output_df.to_csv(csv_path, index=False, header=True)

--- a/clients/stratus/stratus_agent/mitigation_agent.py
+++ b/clients/stratus/stratus_agent/mitigation_agent.py
@@ -84,7 +84,7 @@ def generate_run_summary(last_state: StateSnapshot, summary_system_prompt) -> st
         SystemMessage(summary_system_prompt),
         HumanMessage(f"Here are the list of messages happened in the last conversation. \n\n {last_run_msgs}"),
     ]
-    res = llm.inference(summary_input_messages)
+    res = llm.inference(summary_input_messages, usage_type="summary")
     return res.content
 
 

--- a/clients/stratus/tools/jaeger_tools.py
+++ b/clients/stratus/tools/jaeger_tools.py
@@ -88,7 +88,7 @@ def _summarize_traces(traces):
         HumanMessage(content=traces),
     ]
 
-    traces_summary = llm.inference(messages=messages)
+    traces_summary = llm.inference(messages=messages, usage_type="tool")
     logger.info(f"Traces summary: {traces_summary}")
     return traces_summary
 
@@ -115,7 +115,7 @@ def _summarize_operations(operations):
         HumanMessage(content=operations),
     ]
 
-    operations_summary = llm.inference(messages=messages)
+    operations_summary = llm.inference(messages=messages, usage_type="tool")
     logger.info(f"Operations summary: {operations_summary}")
     return operations_summary
 

--- a/clients/stratus/tools/prometheus_tools.py
+++ b/clients/stratus/tools/prometheus_tools.py
@@ -117,7 +117,7 @@ If you do not have enough data to determine root cause, state 'Insufficient data
         HumanMessage(content=metrics.content[0].text),
     ]
 
-    metrics_summary = llm.inference(messages=messages)
+    metrics_summary = llm.inference(messages=messages, usage_type="tool")
     # metrics_summary = llm.inference(messages=metrics.content[0].text, system_prompt=system_prompt)
     logger.info(f"Metrics summary: {metrics_summary}")
     return metrics_summary

--- a/llm_backend/get_llm_backend.py
+++ b/llm_backend/get_llm_backend.py
@@ -12,6 +12,7 @@ from langchain_litellm import ChatLiteLLM
 from requests.exceptions import HTTPError
 
 from llm_backend.trim_util import trim_messages_conservative
+from llm_backend.usage_log import record_usage
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class LiteLLMBackend:
         messages: str | list[SystemMessage | HumanMessage | AIMessage],
         system_prompt: str | None = None,
         tools: list[any] | None = None,
+        usage_type: str = "trace",
     ):
         if isinstance(messages, str):
             if system_prompt is None:
@@ -118,7 +120,14 @@ class LiteLLMBackend:
                     new_prompt_messages, trim_sum = trim_messages_conservative(prompt_messages)
                     logger.info(f"Trimming the {trim_sum}/{len(prompt_messages)} messages")
                     prompt_messages = new_prompt_messages
+                request_start = time.perf_counter()
                 completion = llm.invoke(input=prompt_messages)
+                record_usage(
+                    completion,
+                    model=self.model_name,
+                    usage_type=usage_type,
+                    duration_seconds=time.perf_counter() - request_start,
+                )
                 return completion
             except openai.BadRequestError as e:
                 logger.error(f"Bad request error - request is malformed: {e}")

--- a/llm_backend/usage_log.py
+++ b/llm_backend/usage_log.py
@@ -1,0 +1,77 @@
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+USAGE_LOG_PATH_ENV = "LLM_USAGE_LOG_PATH"
+
+
+def record_usage(completion: Any, *, model: str, usage_type: str, duration_seconds: float) -> None:
+    """Persist one completed LLM request when usage logging is enabled."""
+    log_path = os.environ.get(USAGE_LOG_PATH_ENV)
+    if not log_path:
+        return
+
+    try:
+        usage = getattr(completion, "usage_metadata", None)
+        if not usage:
+            logger.warning("LLM response did not include usage metadata; usage was not recorded")
+            return
+
+        response_metadata = getattr(completion, "response_metadata", None) or {}
+        record = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "model": response_metadata.get("model_name") or model,
+            "usage_type": usage_type,
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "input_token_details": usage.get("input_token_details", {}),
+            "output_token_details": usage.get("output_token_details", {}),
+            "duration_seconds": duration_seconds,
+        }
+        payload = (json.dumps(record, default=str) + "\n").encode()
+
+        path = Path(log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except Exception as error:
+        # Usage reporting must not stop the benchmark agent.
+        logger.warning("Could not persist LLM usage to %s: %s", log_path, error)
+
+
+def summarize_usage(log_path: Path, *, usage_type: str | None = None) -> dict[str, int | float]:
+    """Return totals from complete records, ignoring a partial final line."""
+    totals: dict[str, int | float] = {
+        "requests": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "duration_seconds": 0.0,
+    }
+    if not log_path.exists():
+        return totals
+
+    with log_path.open(encoding="utf-8") as log_file:
+        for line in log_file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if usage_type is not None and record.get("usage_type") != usage_type:
+                continue
+            totals["requests"] += 1
+            totals["input_tokens"] += int(record.get("input_tokens", 0))
+            totals["output_tokens"] += int(record.get("output_tokens", 0))
+            totals["total_tokens"] += int(record.get("total_tokens", 0))
+            totals["duration_seconds"] += float(record.get("duration_seconds", 0.0))
+    return totals

--- a/tests/llm_backend/test_usage_log.py
+++ b/tests/llm_backend/test_usage_log.py
@@ -1,0 +1,90 @@
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+import llm_backend.get_llm_backend as backend_module
+from llm_backend.get_llm_backend import LiteLLMBackend
+from llm_backend.usage_log import USAGE_LOG_PATH_ENV, summarize_usage
+
+
+class FakeChatLiteLLM:
+    def __init__(self, **_kwargs):
+        pass
+
+    def invoke(self, input):
+        return AIMessage(
+            content="ok",
+            usage_metadata={
+                "input_tokens": 7,
+                "output_tokens": 3,
+                "total_tokens": 10,
+                "input_token_details": {"cache_read": 2},
+            },
+            response_metadata={"model_name": "provider-model"},
+        )
+
+
+class FailingChatLiteLLM(FakeChatLiteLLM):
+    def invoke(self, input):
+        raise RuntimeError("request failed")
+
+
+def test_inference_persists_each_completed_response(monkeypatch, tmp_path):
+    usage_log = tmp_path / "stratus_usage.jsonl"
+    monkeypatch.setenv(USAGE_LOG_PATH_ENV, str(usage_log))
+    monkeypatch.setattr(backend_module, "ChatLiteLLM", FakeChatLiteLLM)
+
+    backend = LiteLLMBackend("configured-model")
+    backend.inference("first", usage_type="summary")
+    backend.inference("second", usage_type="tool")
+
+    records = [json.loads(line) for line in usage_log.read_text().splitlines()]
+    assert [record["usage_type"] for record in records] == ["summary", "tool"]
+    assert records[0]["model"] == "provider-model"
+    assert records[0]["input_tokens"] == 7
+    assert records[0]["input_token_details"] == {"cache_read": 2}
+    assert summarize_usage(usage_log) == {
+        "requests": 2,
+        "input_tokens": 14,
+        "output_tokens": 6,
+        "total_tokens": 20,
+        "duration_seconds": pytest.approx(records[0]["duration_seconds"] + records[1]["duration_seconds"]),
+    }
+    assert summarize_usage(usage_log, usage_type="summary")["total_tokens"] == 10
+
+
+def test_failed_request_does_not_create_usage_record(monkeypatch, tmp_path):
+    usage_log = tmp_path / "stratus_usage.jsonl"
+    monkeypatch.setenv(USAGE_LOG_PATH_ENV, str(usage_log))
+    monkeypatch.setattr(backend_module, "ChatLiteLLM", FailingChatLiteLLM)
+
+    with pytest.raises(RuntimeError, match="request failed"):
+        LiteLLMBackend("configured-model").inference("fail")
+
+    assert not usage_log.exists()
+
+
+def test_summarize_usage_ignores_partial_final_line(tmp_path):
+    usage_log = tmp_path / "stratus_usage.jsonl"
+    usage_log.write_text(
+        json.dumps(
+            {
+                "usage_type": "trace",
+                "input_tokens": 4,
+                "output_tokens": 2,
+                "total_tokens": 6,
+                "duration_seconds": 0.5,
+            }
+        )
+        + "\n"
+        + '{"usage_type": "trace"'
+    )
+
+    assert summarize_usage(usage_log) == {
+        "requests": 1,
+        "input_tokens": 4,
+        "output_tokens": 2,
+        "total_tokens": 6,
+        "duration_seconds": 0.5,
+    }

--- a/tests/stratus/test_usage_reporting.py
+++ b/tests/stratus/test_usage_reporting.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+import os
+
+import pandas as pd
+
+from clients.stratus.stratus_agent.driver import driver
+from llm_backend.usage_log import USAGE_LOG_PATH_ENV
+
+
+def test_completed_run_adds_summary_usage_to_csv(monkeypatch, tmp_path):
+    problem_id = "test_problem"
+    monkeypatch.setenv("AGENT_LOGS_DIR", str(tmp_path))
+    monkeypatch.setattr(driver, "resolve_problem_id", lambda: problem_id)
+
+    async def fake_diagnosis_run():
+        usage_record = {
+            "usage_type": "summary",
+            "input_tokens": 11,
+            "output_tokens": 4,
+            "total_tokens": 15,
+            "duration_seconds": 0.25,
+        }
+        usage_log = os.environ[USAGE_LOG_PATH_ENV]
+        with open(usage_log, "w", encoding="utf-8") as log_file:
+            log_file.write(json.dumps(usage_record) + "\n")
+        stats = {
+            "input_tokens": 5,
+            "output_tokens": 1,
+            "total_tokens": 6,
+            "time": "0.1",
+            "steps": 1,
+            "num_retry_attempts": "N/A",
+            "rollback_stack": "N/A",
+            "oracle_results": "N/A",
+        }
+        return stats, object(), []
+
+    async def fake_stage_switch(**_kwargs):
+        return "done"
+
+    monkeypatch.setattr(driver, "diagnosis_with_localization_task_main", fake_diagnosis_run)
+    monkeypatch.setattr(driver, "generate_run_summary", lambda *_args: "summary")
+    monkeypatch.setattr(driver, "wait_for_stage_switch", fake_stage_switch)
+    monkeypatch.setattr(driver, "save_combined_trajectory", lambda *_args, **_kwargs: None)
+
+    asyncio.run(driver.main())
+
+    output = pd.read_csv(tmp_path / f"{problem_id}_stratus_output.csv")
+    assert output["agent_name"].tolist() == ["diagnosis_agent", "run_summary"]
+    assert output["total_tokens"].tolist() == [6, 15]


### PR DESCRIPTION
Fixes #934.

`stratus` currently reports token usage only after an agent attempt finishes. This loses usage from completed LLM requests when the process stops early. Summary requests are also missing because they run outside the agent callback.

Persist each successful `stratus` LLM response immediately in the run artifact directory. The records distinguish trace, tool, and summary usage. Completed runs add summary usage to the existing CSV without counting other requests twice. Interrupted runs keep all records written before the interruption.

Only the `stratus` driver enables this behavior. The judge, preflight process, and other agents remain unchanged. This is a targeted fix for `stratus` only. The records contain usage metadata.