### PR TITLE
Apply LLM judge settings to requests

### DIFF
--- a/llm_backend/get_llm_backend.py
+++ b/llm_backend/get_llm_backend.py
@@ -30,10 +30,12 @@ class LiteLLMBackend:
         top_p: float = 0.95,
         temperature: float = 0.0,
         max_tokens: int | None = None,
+        provider: str | None = None,
     ):
         self.model_name = model_name
         self.api_key = api_key
         self.api_base = api_base
+        self.provider = provider
         self.temperature = temperature
         self.top_p = top_p
         self.max_tokens = max_tokens
@@ -93,6 +95,8 @@ class LiteLLMBackend:
             model_config["api_key"] = self.api_key
         if self.api_base is not None:
             model_config["api_base"] = self.api_base
+        if self.provider is not None:
+            model_config["custom_llm_provider"] = self.provider
         if self.max_tokens is not None:
             model_config["max_tokens"] = self.max_tokens
 

--- a/llm_backend/init_backend.py
+++ b/llm_backend/init_backend.py
@@ -7,11 +7,21 @@ def get_llm_backend(
     model_name: str,
     api_base: str | None = None,
     api_key: str | None = None,
+    provider: str | None = None,
+    temperature: float = 0.0,
+    max_tokens: int | None = None,
 ) -> LiteLLMBackend:
     """Initialize an LLM backend for the given litellm model string."""
     endpoint_status = "set" if api_base else "unset"
     print(f"🔧 Initializing LLM backend — model: {model_name}, api_base: {endpoint_status}")
-    return LiteLLMBackend(model_name=model_name, api_base=api_base, api_key=api_key)
+    return LiteLLMBackend(
+        model_name=model_name,
+        api_base=api_base,
+        api_key=api_key,
+        provider=provider,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
 
 
 def get_llm_backend_for_agent() -> LiteLLMBackend:
@@ -26,13 +36,24 @@ def get_llm_backend_for_agent() -> LiteLLMBackend:
     )
 
 
-def get_llm_backend_for_judge() -> LiteLLMBackend:
+def get_llm_backend_for_judge(
+    *,
+    provider: str | None = None,
+    model_name: str | None = None,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    temperature: float = 0.0,
+    max_tokens: int | None = None,
+) -> LiteLLMBackend:
     """Get LLM backend for the LLM-as-a-judge evaluator."""
-    model_id = os.environ.get("JUDGE_MODEL_ID")
+    model_id = model_name or os.environ.get("JUDGE_MODEL_ID")
     if not model_id:
-        raise ValueError("JUDGE_MODEL_ID environment variable is not set.")
+        raise ValueError("A judge model must be passed or set in JUDGE_MODEL_ID.")
     return get_llm_backend(
         model_id,
-        api_base=os.environ.get("JUDGE_API_BASE"),
-        api_key=os.environ.get("JUDGE_API_KEY"),
+        api_base=api_base if api_base is not None else os.environ.get("JUDGE_API_BASE"),
+        api_key=api_key if api_key is not None else os.environ.get("JUDGE_API_KEY"),
+        provider=provider,
+        temperature=temperature,
+        max_tokens=max_tokens,
     )

--- a/sregym/conductor/oracles/llm_as_a_judge/judge.py
+++ b/sregym/conductor/oracles/llm_as_a_judge/judge.py
@@ -7,6 +7,7 @@ root cause in natural language.
 from __future__ import annotations
 
 import json
+import os
 import re
 from enum import StrEnum
 from pathlib import Path
@@ -57,7 +58,14 @@ class LLMJudge:
         """Lazily initialize the LLM backend only when needed."""
         if self._backend is None:
             try:
-                self._backend = get_llm_backend_for_judge()
+                self._backend = get_llm_backend_for_judge(
+                    provider=self.provider,
+                    model_name=self.model_name,
+                    api_base=self.url,
+                    api_key=self.api_key,
+                    temperature=self.temperature,
+                    max_tokens=self.max_tokens,
+                )
             except (SystemExit, Exception) as e:
                 print(f"Warning: Failed to initialize LLM backend for judge: {e}")
                 print("Returning None - evaluation will be skipped")
@@ -263,7 +271,14 @@ fences, no preamble, no commentary.
         """Lazily initialize the LLM backend only when needed."""
         if self._backend is None:
             try:
-                self._backend = get_llm_backend_for_judge()
+                self._backend = get_llm_backend_for_judge(
+                    provider=self.provider,
+                    model_name=self.model_name or None,
+                    api_base=self.url,
+                    api_key=self.api_key,
+                    temperature=self.temperature,
+                    max_tokens=self.max_tokens,
+                )
             except (SystemExit, Exception) as e:
                 print(f"Warning: Failed to initialize LLM backend for judge: {e}")
                 print("Returning None - evaluation will be skipped")
@@ -314,7 +329,7 @@ fences, no preamble, no commentary.
                 reasoning=error_msg,
                 composite_score=0.0,
                 checklist_version=self._checklist_version,
-                evaluator_model=self.model_name,
+                evaluator_model=self._evaluator_model(),
             )
 
         # Handle empty / "I don't know" answers
@@ -380,7 +395,7 @@ fences, no preamble, no commentary.
             composite_score=composite,
             dimensions=dimensions,
             checklist_version=self._checklist_version,
-            evaluator_model=self.model_name,
+            evaluator_model=self._evaluator_model(),
         )
 
     # ------------------------------------------------------------------
@@ -538,8 +553,13 @@ fences, no preamble, no commentary.
             composite_score=0.0,
             dimensions=dimensions,
             checklist_version=self._checklist_version,
-            evaluator_model=self.model_name,
+            evaluator_model=self._evaluator_model(),
         )
+
+    def _evaluator_model(self) -> str:
+        """Return the model selected by the initialized backend."""
+        backend_model = getattr(self._backend, "model_name", None)
+        return backend_model or self.model_name or os.environ.get("JUDGE_MODEL_ID", "")
 
     @staticmethod
     def _build_reasoning(


### PR DESCRIPTION
Fixes #947

The LLM judge accepted a model, provider, endpoint, API key, temperature, and output-token limit. The backend ignored these values. 

This change passes these values to the backend. It also records the model that the backend uses. Agent LLM requests do not change.