### PR TITLE
Hide Helm release secrets from the agent-facing API proxy

### DIFF
--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -41,7 +41,100 @@ HIDDEN_LABELS: dict[str, set[str]] = {
     "app": {"load-generator", "locust-fetcher"},
     "job": {"workload"},
     "opentelemetry.io/name": {"load-generator"},
+    # Helm stores the full pre-fault manifest of every release object in its
+    # release Secrets (owner=helm); hiding them stops agents from diffing the
+    # live cluster against Helm's stored copy to recover injected faults (#955).
+    "owner": {"helm"},
 }
+
+
+def has_hidden_label(metadata: dict, hidden_labels: dict[str, set[str]]) -> bool:
+    """Return whether a resource's metadata carries any hidden label."""
+    labels = metadata.get("labels") or {}
+    return any(labels.get(key) in values for key, values in hidden_labels.items())
+
+
+def filter_namespace_list(data: dict, hidden_namespaces: set[str]) -> dict:
+    """Filter hidden namespaces from a namespace list response."""
+    if "items" in data:
+        data["items"] = [
+            item for item in data["items"] if item.get("metadata", {}).get("name") not in hidden_namespaces
+        ]
+    # Handle Table format (kubectl's default)
+    if "rows" in data:
+        data["rows"] = [
+            row
+            for row in data["rows"]
+            if row.get("object", {}).get("metadata", {}).get("name") not in hidden_namespaces
+        ]
+    return data
+
+
+def filter_resource_list(data: dict, hidden_namespaces: set[str], hidden_labels: dict[str, set[str]]) -> dict:
+    """Filter resources in hidden namespaces or with hidden labels from list responses."""
+    if "items" in data:
+        data["items"] = [
+            item
+            for item in data["items"]
+            if item.get("metadata", {}).get("namespace") not in hidden_namespaces
+            and not has_hidden_label(item.get("metadata", {}), hidden_labels)
+        ]
+    # Handle Table format (kubectl's default)
+    if "rows" in data:
+        data["rows"] = [
+            row
+            for row in data["rows"]
+            if row.get("object", {}).get("metadata", {}).get("namespace") not in hidden_namespaces
+            and not has_hidden_label(row.get("object", {}).get("metadata", {}), hidden_labels)
+        ]
+    return data
+
+
+def should_filter_response(path: str) -> str | None:
+    """
+    Determine if a response should be filtered and return the filter type.
+    Returns: 'namespaces', 'resources', or None
+    """
+    clean_path = path.split("?", 1)[0].rstrip("/")
+
+    # Namespace list: /api/v1/namespaces
+    if clean_path == "/api/v1/namespaces":
+        return "namespaces"
+
+    parts = [part for part in clean_path.split("/") if part]
+    if "namespaces" in parts:
+        # Namespaced paths: /api/v1/namespaces/{ns}/{resource}[/{name}[/{sub}]]
+        # or /apis/{group}/{version}/namespaces/{ns}/{resource}[/{name}[/{sub}]]
+        # Exactly [ns, resource] after "namespaces" is a list; anything longer
+        # is a single resource or subresource, handled by the direct-access check.
+        tail = parts[parts.index("namespaces") + 1 :]
+        if len(tail) == 2:
+            return "resources"
+        return None
+
+    # Cluster-wide resource listings (not namespaced)
+    # e.g., /api/v1/pods, /api/v1/events, /apis/apps/v1/deployments
+    resource_patterns = [
+        "/api/v1/pods",
+        "/api/v1/services",
+        "/api/v1/events",
+        "/api/v1/configmaps",
+        "/api/v1/secrets",
+        "/api/v1/endpoints",
+        "/api/v1/persistentvolumeclaims",
+        "/apis/apps/v1/deployments",
+        "/apis/apps/v1/replicasets",
+        "/apis/apps/v1/statefulsets",
+        "/apis/apps/v1/daemonsets",
+        "/apis/batch/v1/jobs",
+        "/apis/batch/v1/cronjobs",
+    ]
+    for pattern in resource_patterns:
+        if clean_path.startswith(pattern):
+            return "resources"
+
+    return None
+
 
 # Disable SSL warnings for self-signed certs
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -223,78 +316,22 @@ class KubernetesAPIProxy:
 
             def _filter_namespace_list(self, data: dict) -> dict:
                 """Filter hidden namespaces from namespace list response."""
-                # Handle standard List format
-                if "items" in data:
-                    data["items"] = [
-                        item for item in data["items"] if item.get("metadata", {}).get("name") not in hidden_namespaces
-                    ]
-                # Handle Table format (kubectl's default)
-                if "rows" in data:
-                    data["rows"] = [
-                        row
-                        for row in data["rows"]
-                        if row.get("object", {}).get("metadata", {}).get("name") not in hidden_namespaces
-                    ]
-                return data
+                return filter_namespace_list(data, hidden_namespaces)
 
             def _has_hidden_label(self, metadata: dict) -> bool:
                 """Check if a resource's metadata contains any hidden labels."""
-                labels = metadata.get("labels") or {}
-                return any(labels.get(key) in values for key, values in hidden_labels.items())
+                return has_hidden_label(metadata, hidden_labels)
 
             def _filter_resource_list(self, data: dict) -> dict:
                 """Filter resources in hidden namespaces or with hidden labels from list responses."""
-                # Handle standard List format
-                if "items" in data:
-                    data["items"] = [
-                        item
-                        for item in data["items"]
-                        if item.get("metadata", {}).get("namespace") not in hidden_namespaces
-                        and not self._has_hidden_label(item.get("metadata", {}))
-                    ]
-                # Handle Table format (kubectl's default)
-                if "rows" in data:
-                    data["rows"] = [
-                        row
-                        for row in data["rows"]
-                        if row.get("object", {}).get("metadata", {}).get("namespace") not in hidden_namespaces
-                        and not self._has_hidden_label(row.get("object", {}).get("metadata", {}))
-                    ]
-                return data
+                return filter_resource_list(data, hidden_namespaces, hidden_labels)
 
             def _should_filter_response(self, path: str) -> str | None:
                 """
                 Determine if response should be filtered and return filter type.
                 Returns: 'namespaces', 'resources', or None
                 """
-                # Namespace list: /api/v1/namespaces
-                if path.rstrip("/") == "/api/v1/namespaces" or path.startswith("/api/v1/namespaces?"):
-                    return "namespaces"
-
-                # Cluster-wide resource listings (not namespaced)
-                # e.g., /api/v1/pods, /api/v1/events, /apis/apps/v1/deployments
-                if "/namespaces/" not in path:
-                    # Check if this is a list of namespaced resources
-                    resource_patterns = [
-                        "/api/v1/pods",
-                        "/api/v1/services",
-                        "/api/v1/events",
-                        "/api/v1/configmaps",
-                        "/api/v1/secrets",
-                        "/api/v1/endpoints",
-                        "/api/v1/persistentvolumeclaims",
-                        "/apis/apps/v1/deployments",
-                        "/apis/apps/v1/replicasets",
-                        "/apis/apps/v1/statefulsets",
-                        "/apis/apps/v1/daemonsets",
-                        "/apis/batch/v1/jobs",
-                        "/apis/batch/v1/cronjobs",
-                    ]
-                    for pattern in resource_patterns:
-                        if path.startswith(pattern):
-                            return "resources"
-
-                return None
+                return should_filter_response(path)
 
             def _proxy_request(self, method: str):
                 """Proxy request to upstream API and filter response."""

--- a/tests/service/test_k8s_proxy_filtering.py
+++ b/tests/service/test_k8s_proxy_filtering.py
@@ -1,0 +1,112 @@
+from sregym.service.k8s_proxy import (
+    HIDDEN_LABELS,
+    HIDDEN_NAMESPACES,
+    filter_resource_list,
+    has_hidden_label,
+    should_filter_response,
+)
+
+HELM_SECRET = {
+    "metadata": {
+        "name": "sh.helm.release.v1.astronomy-shop.v1",
+        "namespace": "astronomy-shop",
+        "labels": {"owner": "helm", "name": "astronomy-shop", "status": "deployed"},
+    },
+    "type": "helm.sh/release.v1",
+}
+
+APP_SECRET = {
+    "metadata": {
+        "name": "product-catalog-db-conn",
+        "namespace": "astronomy-shop",
+        "labels": {},
+    },
+    "type": "Opaque",
+}
+
+LOAD_GENERATOR_POD = {
+    "metadata": {
+        "name": "load-generator-abc",
+        "namespace": "astronomy-shop",
+        "labels": {"app": "load-generator"},
+    }
+}
+
+APP_POD = {
+    "metadata": {
+        "name": "frontend-abc",
+        "namespace": "astronomy-shop",
+        "labels": {"app": "frontend"},
+    }
+}
+
+
+def test_helm_release_secret_carries_hidden_label():
+    assert has_hidden_label(HELM_SECRET["metadata"], HIDDEN_LABELS) is True
+    assert has_hidden_label(APP_SECRET["metadata"], HIDDEN_LABELS) is False
+
+
+def test_namespaced_secret_list_is_filtered():
+    # kubectl get secrets -n astronomy-shop
+    assert should_filter_response("/api/v1/namespaces/astronomy-shop/secrets") == "resources"
+
+    data = {"items": [HELM_SECRET, APP_SECRET]}
+    filtered = filter_resource_list(data, HIDDEN_NAMESPACES, HIDDEN_LABELS)
+
+    assert [item["metadata"]["name"] for item in filtered["items"]] == ["product-catalog-db-conn"]
+
+
+def test_cluster_wide_secret_list_is_filtered():
+    # kubectl get secrets --all-namespaces
+    assert should_filter_response("/api/v1/secrets") == "resources"
+
+    data = {"items": [HELM_SECRET, APP_SECRET]}
+    filtered = filter_resource_list(data, HIDDEN_NAMESPACES, HIDDEN_LABELS)
+
+    assert [item["metadata"]["name"] for item in filtered["items"]] == ["product-catalog-db-conn"]
+
+
+def test_single_secret_get_is_left_to_direct_access_check():
+    # A trailing name segment means a single resource: the proxy handles these
+    # via the direct-access 403 path, driven by has_hidden_label on the object.
+    path = "/api/v1/namespaces/astronomy-shop/secrets/sh.helm.release.v1.astronomy-shop.v1"
+    assert should_filter_response(path) is None
+    assert has_hidden_label(HELM_SECRET["metadata"], HIDDEN_LABELS) is True
+
+
+def test_namespaced_pod_list_filters_hidden_labels():
+    assert should_filter_response("/api/v1/namespaces/astronomy-shop/pods") == "resources"
+
+    data = {"items": [LOAD_GENERATOR_POD, APP_POD]}
+    filtered = filter_resource_list(data, HIDDEN_NAMESPACES, HIDDEN_LABELS)
+
+    assert [item["metadata"]["name"] for item in filtered["items"]] == ["frontend-abc"]
+
+
+def test_table_format_rows_are_filtered():
+    data = {
+        "rows": [
+            {"object": HELM_SECRET, "cells": ["sh.helm.release.v1.astronomy-shop.v1"]},
+            {"object": APP_SECRET, "cells": ["product-catalog-db-conn"]},
+        ]
+    }
+    filtered = filter_resource_list(data, HIDDEN_NAMESPACES, HIDDEN_LABELS)
+
+    assert [row["object"]["metadata"]["name"] for row in filtered["rows"]] == ["product-catalog-db-conn"]
+
+
+def test_hidden_namespace_items_are_filtered_from_lists():
+    chaos_pod = {"metadata": {"name": "chaos-daemon-abc", "namespace": "chaos-mesh", "labels": {}}}
+    data = {"items": [chaos_pod, APP_POD]}
+    filtered = filter_resource_list(data, HIDDEN_NAMESPACES, HIDDEN_LABELS)
+
+    assert [item["metadata"]["name"] for item in filtered["items"]] == ["frontend-abc"]
+
+
+def test_subresource_and_query_paths():
+    assert should_filter_response("/api/v1/namespaces/astronomy-shop/pods/frontend-abc/log") is None
+    assert should_filter_response("/api/v1/namespaces/astronomy-shop/secrets?limit=500") == "resources"
+    assert should_filter_response("/api/v1/namespaces") == "namespaces"
+    assert should_filter_response("/api/v1/namespaces?limit=500") == "namespaces"
+    assert should_filter_response("/apis/apps/v1/namespaces/astronomy-shop/deployments") == "resources"
+    assert should_filter_response("/api/v1/namespaces/astronomy-shop") is None


### PR DESCRIPTION
Closes #955

## Problem

Agents can read the `sh.helm.release.v1.*` Secrets in the target namespace and recover the pre-fault manifest of every object in the application. For faults that change an existing field, diagnosis degenerates into a diff: compare the live object against Helm's stored copy and the injected change is the only difference.

## Fix

1. `owner=helm` added to `HIDDEN_LABELS` in `sregym/service/k8s_proxy.py` (the fix sketched in #955): Helm release Secrets are now filtered from list responses and direct GETs return 403 via the existing hidden-resource check.
2. While adding the test for it, I found the label filter only applied to **cluster-wide** list paths. Namespaced lists (`/api/v1/namespaces/{ns}/{resource}`, i.e. plain `kubectl get secrets -n astronomy-shop`) returned hidden-label resources unfiltered, which would have made the #955 fix ineffective for the most natural agent command, and also means load-generator pods were visible via namespaced `kubectl get pods`. `should_filter_response` now treats namespaced resource lists as filterable; a trailing name segment (single resource / subresource) is still handled by the direct-access 403 check.
3. The filtering helpers moved from the request-handler closure to module level so they can be unit-tested without a cluster: `tests/service/test_k8s_proxy_filtering.py` covers Helm secrets in namespaced/cluster-wide/table-format lists, direct-GET handling, load-generator filtering in namespaced pod lists, hidden-namespace items, and subresource/query-string paths. `uv run pytest tests/service/test_k8s_proxy_filtering.py` passes (8 tests); behavior is otherwise unchanged.

## Behavior change note

Agents (and the MCP kubectl tool, which routes through the same proxy) lose visibility of Helm release secrets and, newly, of hidden-label resources in namespaced lists. Both are the intended isolation semantics; conductor-side code uses the unproxied kubeconfig and is unaffected.

## Code changes

| File | Change |
| --- | --- |
| `sregym/service/k8s_proxy.py` | `owner=helm` hidden label; namespaced-list filtering; filtering helpers extracted to module level |
| `tests/service/test_k8s_proxy_filtering.py` | New unit tests for the filtering logic |

/validate-problem skip
