### PR TITLE
Restrict agent access to the SREGym repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ SREGym supports local models through Ollama and OpenAI-compatible servers such a
 
 Set `AGENT_API_KEY` as well if the endpoint requires authentication.
 
+> [!CAUTION]
+> When you use `--internet-access filtered`, the agent runs on an isolated Docker network. It cannot reach a local model server that listens only on `127.0.0.1` or `localhost`. Configure the server to listen on a host-reachable interface, such as `0.0.0.0`, and use `http://host.docker.internal:<port>` as the API base. Protect the exposed port with authentication or a firewall. This requirement is the same for Kind and external Kubernetes clusters because the connection is between the agent container and the machine running SREGym.
+
 **Stratus with Ollama:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Use `--force-build` to rebuild the container image after updating dependencies o
 uv run main.py --agent codex --model gpt-5 --force-build
 ```
 
+Containerized agents can use the public internet by default, but direct access to the benchmark's GitHub source is
+blocked. Use `--internet-access open` only when you intentionally need the previous unrestricted network behavior.
+
 ### Model Selection
 
 SREGym uses [LiteLLM](https://docs.litellm.ai/docs/providers) model strings directly (no config file needed). Just pass any supported model string via `--model`:

--- a/clients/claudecode/claudecode_agent.py
+++ b/clients/claudecode/claudecode_agent.py
@@ -103,6 +103,13 @@ class ClaudeCodeAgent:
         "WebSearch",
     ]
 
+    @classmethod
+    def allowed_tools(cls) -> list[str]:
+        tools = list(cls.ALLOWED_TOOLS)
+        if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
+            tools.remove("WebSearch")
+        return tools
+
     def __init__(
         self,
         logs_dir: Path,
@@ -354,7 +361,7 @@ class ClaudeCodeAgent:
         ]
         if reasoning_effort:
             command.extend(["--effort", reasoning_effort])
-        command.extend(["--allowedTools", *self.ALLOWED_TOOLS])
+        command.extend(["--allowedTools", *self.allowed_tools()])
 
         logger.info(f"Executing command: {' '.join(command)}")
 

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -180,6 +180,10 @@ class CopilotCliAgent:
         reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
         if reasoning_effort:
             command.extend(["--reasoning-effort", reasoning_effort])
+        if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
+            # Shell network calls still pass through the egress proxy. Remove
+            # web tools that can perform provider-side requests outside it.
+            command.extend(["--excluded-tools", "web_fetch,web_search"])
         return command
 
     def run(self, instruction: str) -> int:

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -182,8 +182,10 @@ class CopilotCliAgent:
             command.extend(["--reasoning-effort", reasoning_effort])
         if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
             # Shell network calls still pass through the egress proxy. Remove
-            # web tools that can perform provider-side requests outside it.
+            # web tools and the built-in GitHub MCP, which can perform
+            # provider-side requests outside the container.
             command.extend(["--excluded-tools", "web_fetch,web_search"])
+            command.extend(["--disable-mcp-server", "github-mcp-server"])
         return command
 
     def run(self, instruction: str) -> int:

--- a/clients/geminicli/geminicli_agent.py
+++ b/clients/geminicli/geminicli_agent.py
@@ -200,6 +200,16 @@ class GeminiCliAgent:
         logger.info(f"Extracted usage metrics: {metrics}")
         return metrics
 
+    def _build_command(self, instruction: str) -> str:
+        model = self.model_name.split("/")[-1]
+        escaped_instruction = shlex.quote(instruction)
+        excluded_tools = ""
+        if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
+            # These tools can fetch content outside the container, where the
+            # network proxy cannot enforce the source deny list.
+            excluded_tools = " --exclude-tools google_web_search,web_fetch,browser_agent"
+        return f"gemini -p {escaped_instruction} -y -m {model}{excluded_tools}"
+
     def run(self, instruction: str) -> int:
         """
         Run the Gemini CLI agent with the given instruction.
@@ -250,9 +260,7 @@ class GeminiCliAgent:
             logger.error("=" * 80)
             return 1
 
-        # Build command
-        escaped_instruction = shlex.quote(instruction)
-        command = f"gemini -p {escaped_instruction} -y -m {model}"
+        command = self._build_command(instruction)
 
         logger.info(f"Executing command: {command}")
 

--- a/clients/geminicli/geminicli_agent.py
+++ b/clients/geminicli/geminicli_agent.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -203,12 +204,26 @@ class GeminiCliAgent:
     def _build_command(self, instruction: str) -> str:
         model = self.model_name.split("/")[-1]
         escaped_instruction = shlex.quote(instruction)
-        excluded_tools = ""
-        if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
-            # These tools can fetch content outside the container, where the
-            # network proxy cannot enforce the source deny list.
-            excluded_tools = " --exclude-tools google_web_search,web_fetch,browser_agent"
-        return f"gemini -p {escaped_instruction} -y -m {model}{excluded_tools}"
+        return f"gemini -p {escaped_instruction} -y -m {model}"
+
+    def _prepare_filtered_settings(self) -> Path | None:
+        """Create a per-run Gemini settings file for provider-side tool blocking."""
+        if os.environ.get("AGENT_INTERNET_ACCESS") != "filtered":
+            return None
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix="gemini-system-settings-",
+            suffix=".json",
+            dir=self.logs_dir,
+            delete=False,
+        ) as settings_file:
+            json.dump(
+                {"tools": {"exclude": ["google_web_search", "web_fetch", "browser_agent"]}},
+                settings_file,
+            )
+            return Path(settings_file.name)
 
     def run(self, instruction: str) -> int:
         """
@@ -261,6 +276,9 @@ class GeminiCliAgent:
             return 1
 
         command = self._build_command(instruction)
+        filtered_settings = self._prepare_filtered_settings()
+        if filtered_settings is not None:
+            env["GEMINI_CLI_SYSTEM_SETTINGS_PATH"] = str(filtered_settings)
 
         logger.info(f"Executing command: {command}")
 
@@ -295,3 +313,6 @@ class GeminiCliAgent:
         except Exception as e:
             logger.error(f"Error running Gemini CLI: {e}")
             raise
+        finally:
+            if filtered_settings is not None:
+                filtered_settings.unlink(missing_ok=True)

--- a/docker/egress_proxy.py
+++ b/docker/egress_proxy.py
@@ -1,0 +1,53 @@
+"""mitmproxy addon that blocks direct access to configured GitHub owners."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from internet_policy import DEFAULT_BLOCKED_GITHUB_OWNERS, blocked_github_owner
+from mitmproxy import ctx, http
+
+BLOCKED_OWNERS = tuple(
+    owner.strip()
+    for owner in os.environ.get("BLOCKED_GITHUB_OWNERS", ",".join(DEFAULT_BLOCKED_GITHUB_OWNERS)).split(",")
+    if owner.strip()
+)
+BLOCK_LOG = Path(os.environ.get("BLOCKED_REQUEST_LOG", "/state/blocked-requests.jsonl"))
+
+
+def request(flow: http.HTTPFlow) -> None:
+    owner = blocked_github_owner(
+        flow.request.host,
+        flow.request.path,
+        flow.request.raw_content,
+        BLOCKED_OWNERS,
+    )
+    if owner is None:
+        return
+
+    flow.response = http.Response.make(
+        451,
+        b"Request blocked by the evaluation network policy.\n",
+        {"Content-Type": "text/plain; charset=utf-8"},
+    )
+    try:
+        _record_block(flow, owner)
+    except OSError as exc:
+        # Audit logging must never turn a blocked request into an allowed one.
+        ctx.log.error(f"Could not record blocked request: {exc}")
+
+
+def _record_block(flow: http.HTTPFlow, owner: str) -> None:
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "method": flow.request.method,
+        "host": flow.request.host,
+        "path": flow.request.path.split("?", 1)[0],
+        "blocked_owner": owner,
+    }
+    BLOCK_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with BLOCK_LOG.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")

--- a/docker/egress_proxy.py
+++ b/docker/egress_proxy.py
@@ -7,7 +7,11 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 
-from internet_policy import DEFAULT_BLOCKED_GITHUB_OWNERS, blocked_github_owner
+from internet_policy import (
+    DEFAULT_BLOCKED_GITHUB_OWNERS,
+    DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
+    blocked_github_owner,
+)
 from mitmproxy import ctx, http
 
 BLOCKED_OWNERS = tuple(
@@ -15,16 +19,30 @@ BLOCKED_OWNERS = tuple(
     for owner in os.environ.get("BLOCKED_GITHUB_OWNERS", ",".join(DEFAULT_BLOCKED_GITHUB_OWNERS)).split(",")
     if owner.strip()
 )
+BLOCKED_REPOSITORY_IDS = tuple(
+    repository_id.strip()
+    for repository_id in os.environ.get(
+        "BLOCKED_GITHUB_REPOSITORY_IDS", ",".join(DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS)
+    ).split(",")
+    if repository_id.strip()
+)
 BLOCK_LOG = Path(os.environ.get("BLOCKED_REQUEST_LOG", "/state/blocked-requests.jsonl"))
 
 
 def request(flow: http.HTTPFlow) -> None:
-    owner = blocked_github_owner(
-        flow.request.host,
-        flow.request.path,
-        flow.request.raw_content,
-        BLOCKED_OWNERS,
-    )
+    owner = None
+    # A request can use a GitHub IP in the URL while retaining a GitHub
+    # hostname in its HTTP Host header. Apply the policy to both values.
+    for host in (flow.request.host, flow.request.headers.get("host", "")):
+        owner = blocked_github_owner(
+            host,
+            flow.request.path,
+            flow.request.raw_content,
+            BLOCKED_OWNERS,
+            BLOCKED_REPOSITORY_IDS,
+        )
+        if owner is not None:
+            break
     if owner is None:
         return
 

--- a/docker/egress_proxy.py
+++ b/docker/egress_proxy.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from internet_policy import (
     DEFAULT_BLOCKED_GITHUB_OWNERS,
+    DEFAULT_BLOCKED_GITHUB_REPOSITORIES,
     DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
     blocked_github_owner,
 )
@@ -26,6 +27,13 @@ BLOCKED_REPOSITORY_IDS = tuple(
     ).split(",")
     if repository_id.strip()
 )
+BLOCKED_REPOSITORIES = tuple(
+    repository.strip()
+    for repository in os.environ.get(
+        "BLOCKED_GITHUB_REPOSITORIES", ",".join(DEFAULT_BLOCKED_GITHUB_REPOSITORIES)
+    ).split(",")
+    if repository.strip()
+)
 BLOCK_LOG = Path(os.environ.get("BLOCKED_REQUEST_LOG", "/state/blocked-requests.jsonl"))
 
 
@@ -40,6 +48,7 @@ def request(flow: http.HTTPFlow) -> None:
             flow.request.raw_content,
             BLOCKED_OWNERS,
             BLOCKED_REPOSITORY_IDS,
+            BLOCKED_REPOSITORIES,
         )
         if owner is not None:
             break

--- a/main.py
+++ b/main.py
@@ -76,13 +76,22 @@ def run_preflight_check(
         check_cmd = f"/opt/sregym/install-scripts/{install_script} > /dev/null 2>&1 && {check_cmd}"
 
     logger.info(f"🔍 Running pre-flight check for '{agent_name}'...")
-    result = container_runner.run_sync(ExecInput(command=check_cmd, label="preflight", timeout=180))
+    try:
+        result = container_runner.run_sync(ExecInput(command=check_cmd, label="preflight", timeout=180))
+    except BaseException:
+        # A failed or interrupted preflight happens before the API shutdown
+        # scope exists, so release the proxy and its Docker resources here.
+        container_runner.cleanup_egress_proxy()
+        container_runner.cleanup_credential_tmps()
+        raise
     if result.returncode != 0:
         if result.stdout:
             print(result.stdout.strip())
         if result.stderr:
             print(result.stderr.strip())
         logger.error(f"❌ Pre-flight check failed for '{agent_name}'")
+        container_runner.cleanup_egress_proxy()
+        container_runner.cleanup_credential_tmps()
         sys.exit(1)
 
     logger.info(f"✅ Pre-flight check passed for '{agent_name}'")
@@ -616,19 +625,24 @@ def main(args):
         enable_noise=args.noise,
         internet_policy=internet_policy,
         k8s_proxy_listen_host=k8s_proxy_listen_host,
+        block_workload_creation=internet_policy.is_filtered,
     )
     LAUNCHER.set_internet_policy(conductor_config.internet_policy)
 
-    if not agent_reg or agent_reg.container_isolation:
-        LAUNCHER.enable_container_isolation(force_build=args.force_build)
+    try:
+        if not agent_reg or agent_reg.container_isolation:
+            LAUNCHER.enable_container_isolation(force_build=args.force_build)
 
-    # Pre-flight check — makes a real (minimal) API call inside the agent
-    # container to validate model and credentials in one shot.
-    run_preflight_check(
-        args.agent,
-        container_runner=LAUNCHER._container_runner,
-        install_script=agent_reg.install_script if agent_reg else None,
-    )
+        # Pre-flight check — makes a real (minimal) API call inside the agent
+        # container to validate model and credentials in one shot.
+        run_preflight_check(
+            args.agent,
+            container_runner=LAUNCHER._container_runner,
+            install_script=agent_reg.install_script if agent_reg else None,
+        )
+    except BaseException:
+        LAUNCHER.cleanup_all()
+        raise
 
     conductor = Conductor(config=conductor_config)
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,8 @@ from sregym.conductor.conductor_api import request_shutdown, run_api
 from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.problem_sets import PROBLEM_SETS
 from sregym.run_artifacts import ArtifactFinalizationError, RunArtifacts
-from sregym.service.container_runner import ContainerRunner, ExecInput
+from sregym.service.container_runner import ContainerRunner, ExecInput, get_container_host_bind_address
+from sregym.service.internet_policy import InternetPolicy
 from sregym.traces import postprocess as trace_postprocess
 from sregym.traces import store as trace_store
 
@@ -453,6 +454,7 @@ def driver_loop(
                     "problem_id": pid,
                     "attempt": attempt,
                 }
+                snapshot.update(LAUNCHER.internet_policy_result(agent_proc))
                 for stage, outcome in conductor.results.items():
                     if isinstance(outcome, dict):
                         for k, v in outcome.items():
@@ -568,6 +570,7 @@ def main(args):
     init_logger()
 
     agent_model, judge_model = _configure_model_environment(args)
+    internet_policy = InternetPolicy.from_mode(args.internet_access)
 
     if args.noise:
         logger.info("Noise injection enabled.")
@@ -579,11 +582,9 @@ def main(args):
     logger.info(
         f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}, "
         f"reasoning_effort: {getattr(args, 'reasoning_effort', None) or 'agent default'}, "
+        f"internet_access: {internet_policy.mode.value}, "
         f"agent_api_base: {_env_status('AGENT_API_BASE')}, judge_api_base: {_env_status('JUDGE_API_BASE')}"
     )
-
-    if not args.use_external_harness:
-        run_judge_preflight_check()
 
     # Only build/check agent container image if the agent requires it
     agent_reg = (
@@ -591,6 +592,33 @@ def main(args):
         if args.agent
         else None
     )
+    if (
+        internet_policy.is_filtered
+        and not args.use_external_harness
+        and agent_reg
+        and not agent_reg.container_isolation
+    ):
+        raise RuntimeError(
+            f"Agent '{agent_reg.name}' does not use container isolation. "
+            "Run it with --internet-access open or enable container isolation."
+        )
+
+    if not args.use_external_harness:
+        run_judge_preflight_check()
+
+    k8s_proxy_listen_host = (
+        get_container_host_bind_address()
+        if internet_policy.is_filtered and not args.use_external_harness
+        else "127.0.0.1"
+    )
+    conductor_config = ConductorConfig(
+        deploy_loki=not args.use_external_harness,
+        enable_noise=args.noise,
+        internet_policy=internet_policy,
+        k8s_proxy_listen_host=k8s_proxy_listen_host,
+    )
+    LAUNCHER.set_internet_policy(conductor_config.internet_policy)
+
     if not agent_reg or agent_reg.container_isolation:
         LAUNCHER.enable_container_isolation(force_build=args.force_build)
 
@@ -602,7 +630,6 @@ def main(args):
         install_script=agent_reg.install_script if agent_reg else None,
     )
 
-    conductor_config = ConductorConfig(deploy_loki=not args.use_external_harness, enable_noise=args.noise)
     conductor = Conductor(config=conductor_config)
 
     suite = getattr(args, "suite", None)
@@ -726,6 +753,12 @@ if __name__ == "__main__":
         "--noise",
         action="store_true",
         help="Enable transient noise injection via Chaos Mesh during problem runs",
+    )
+    parser.add_argument(
+        "--internet-access",
+        choices=("filtered", "open"),
+        default="filtered",
+        help="Agent internet policy. Filtered mode blocks direct access to SREGym GitHub source.",
     )
     parser.add_argument(
         "--n-attempts",

--- a/sregym/agent_launcher.py
+++ b/sregym/agent_launcher.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from clients.harness.problem_id import HARNESS_ARTIFACT_ID_ENV, HARNESS_PROBLEM_ID_ENV
 from sregym.service.container_runner import ContainerConfig, ContainerRunner, ExecInput
+from sregym.service.internet_policy import InternetPolicy
 
 from .agent_registry import AgentRegistration
 
@@ -24,6 +25,7 @@ class AgentProcess:
         self.started_at = datetime.now(UTC)
         self.container_name: str | None = None  # set when running in container mode
         self.pgid = pgid  # process group of shell-launched agents, for tree cleanup
+        self.egress_blocked_start = 0
 
 
 class AgentLauncher:
@@ -32,6 +34,12 @@ class AgentLauncher:
         self._agent_kubeconfig_path: str | None = None
         self._use_containers: bool = True
         self._container_runner: ContainerRunner | None = None
+        self._internet_policy = InternetPolicy()
+
+    def set_internet_policy(self, policy: InternetPolicy) -> None:
+        if self._container_runner is not None:
+            raise RuntimeError("Internet policy cannot change after the container runner is initialized")
+        self._internet_policy = policy
 
     def set_agent_kubeconfig(self, kubeconfig_path: str | None):
         """
@@ -48,6 +56,7 @@ class AgentLauncher:
                 logs_path=Path("./logs"),
                 sregym_apps_path=Path("./SREGym-applications"),
                 sregym_app_subdirs=["socialNetwork/wrk2", "hotelReservation/wrk2"],
+                internet_policy=self._internet_policy,
             )
             self._container_runner = ContainerRunner(config)
             if force_build:
@@ -67,6 +76,12 @@ class AgentLauncher:
 
         if self._use_containers and reg.container_isolation:
             return await self._start_containerized(reg)
+
+        if self._internet_policy.is_filtered:
+            raise RuntimeError(
+                f"Agent '{reg.name}' does not use container isolation. "
+                "Run it with --internet-access open or enable container isolation."
+            )
 
         env = os.environ.copy()
         if reg.kickoff_env:
@@ -152,9 +167,11 @@ class AgentLauncher:
         if harness_artifact_id:
             exec_input.env[HARNESS_ARTIFACT_ID_ENV] = harness_artifact_id
 
+        blocked_start = self._container_runner.blocked_request_count()
         proc = self._container_runner.run_async(exec_input)
         ap = AgentProcess(reg.name, proc)
         ap.container_name = exec_input.container_name  # track for cleanup
+        ap.egress_blocked_start = blocked_start
         self._procs[reg.name] = ap
         t = threading.Thread(target=self._pipe_logs, args=(reg.name, proc), daemon=True)
         t.start()
@@ -164,6 +181,17 @@ class AgentLauncher:
         """Terminate and cleanup all tracked agent processes/containers."""
         for name in list(self._procs):
             self.cleanup_agent(name, timeout=timeout)
+        if self._container_runner:
+            self._container_runner.cleanup_egress_proxy()
+
+    def internet_policy_result(self, process: AgentProcess | None = None) -> dict[str, str | int]:
+        blocked = 0
+        if process is not None and self._container_runner is not None:
+            blocked = max(0, self._container_runner.blocked_request_count() - process.egress_blocked_start)
+        return {
+            "internet_access": self._internet_policy.mode.value,
+            "blocked_requests": blocked,
+        }
 
     def cleanup_agent(self, agent_name: str, timeout: int = 5) -> None:
         """

--- a/sregym/agent_launcher.py
+++ b/sregym/agent_launcher.py
@@ -183,6 +183,8 @@ class AgentLauncher:
             self.cleanup_agent(name, timeout=timeout)
         if self._container_runner:
             self._container_runner.cleanup_egress_proxy()
+            self._container_runner.cleanup_credential_tmps()
+            self._container_runner = None
 
     def internet_policy_result(self, process: AgentProcess | None = None) -> dict[str, str | int]:
         blocked = 0

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -41,6 +41,7 @@ class ConductorConfig:
     enable_noise: bool = False
     internet_policy: InternetPolicy = field(default_factory=InternetPolicy)
     k8s_proxy_listen_host: str = "127.0.0.1"
+    block_workload_creation: bool = False
 
 
 class Conductor:
@@ -68,6 +69,7 @@ class Conductor:
             hidden_namespaces={"chaos-mesh", "khaos"},
             listen_port=16443,
             listen_host=self.config.k8s_proxy_listen_host,
+            block_workload_creation=self.config.block_workload_creation,
         )
         self._agent_kubeconfig_path: str | None = None
 

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -5,7 +5,7 @@ import logging
 import shlex
 import shutil
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
@@ -24,6 +24,7 @@ from sregym.paths import CLUSTER_BASELINE_STATE_FILE
 from sregym.service.apps.app_registry import AppRegistry
 from sregym.service.cluster_state import ClusterStateManager
 from sregym.service.dm_flakey_manager import DmFlakeyManager
+from sregym.service.internet_policy import InternetPolicy
 from sregym.service.k8s_proxy import KubernetesAPIProxy
 from sregym.service.khaos import KhaosController
 from sregym.service.kubectl import KubeCtl
@@ -38,6 +39,8 @@ class ConductorConfig:
 
     deploy_loki: bool = True
     enable_noise: bool = False
+    internet_policy: InternetPolicy = field(default_factory=InternetPolicy)
+    k8s_proxy_listen_host: str = "127.0.0.1"
 
 
 class Conductor:
@@ -64,6 +67,7 @@ class Conductor:
         self.k8s_proxy = KubernetesAPIProxy(
             hidden_namespaces={"chaos-mesh", "khaos"},
             listen_port=16443,
+            listen_host=self.config.k8s_proxy_listen_host,
         )
         self._agent_kubeconfig_path: str | None = None
 

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -322,6 +322,12 @@ class ContainerRunner:
                     str(EGRESS_PROXY_PORT),
                     "--set",
                     "connection_strategy=lazy",
+                    # Keep the local Kubernetes TLS connection as an
+                    # end-to-end tunnel. The agent trusts the per-run
+                    # certificate from its kubeconfig; mitmproxy must not
+                    # replace it with an egress certificate.
+                    "--set",
+                    r"ignore_hosts=^host\.docker\.internal:16443$",
                     "-s",
                     "/addons/egress_proxy.py",
                 ],
@@ -477,6 +483,9 @@ class ContainerRunner:
                     "HTTPS_PROXY": proxy_url,
                     "http_proxy": proxy_url,
                     "https_proxy": proxy_url,
+                    # The private agent network cannot route directly to the
+                    # host. Local Kubernetes HTTPS traffic uses the egress
+                    # proxy's CONNECT tunnel instead of being intercepted.
                     "NO_PROXY": "",
                     "no_proxy": "",
                     "SSL_CERT_FILE": PROXY_BUNDLE_CONTAINER_PATH,

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -3,6 +3,7 @@ import logging
 import os
 import platform
 import shutil
+import ssl
 import subprocess
 import tempfile
 import time
@@ -42,9 +43,13 @@ def _replace_loopback_host(url: str) -> str:
 
 
 def get_container_host_bind_address() -> str:
-    """Return a host address reachable from Linux containers but not the public network."""
+    """Return a host bind address reachable from the agent container."""
     if platform.system() != "Linux":
-        return "127.0.0.1"
+        # Docker Desktop exposes the host to containers through
+        # host.docker.internal. The proxy must therefore bind beyond the host
+        # loopback interface; its per-run bearer token prevents unauthenticated
+        # access.
+        return "0.0.0.0"
     result = subprocess.run(
         ["docker", "network", "inspect", "bridge", "-f", "{{(index .IPAM.Config 0).Gateway}}"],
         capture_output=True,
@@ -55,6 +60,36 @@ def get_container_host_bind_address() -> str:
         detail = (result.stderr or result.stdout).strip()
         raise RuntimeError(f"Could not determine the Docker host gateway: {detail}")
     return address
+
+
+def _find_host_ca_bundle() -> Path:
+    """Find a usable host CA bundle on common Linux, macOS, and WSL images."""
+    candidates: list[str] = []
+    configured = os.environ.get("SSL_CERT_FILE")
+    if configured:
+        candidates.append(configured)
+    default_paths = ssl.get_default_verify_paths()
+    if default_paths.cafile:
+        candidates.append(default_paths.cafile)
+    candidates.extend(
+        [
+            "/etc/ssl/certs/ca-certificates.crt",
+            "/etc/pki/tls/certs/ca-bundle.crt",
+            "/etc/ssl/cert.pem",
+        ]
+    )
+    try:
+        import certifi
+
+        candidates.append(certifi.where())
+    except ImportError:
+        pass
+
+    for candidate in dict.fromkeys(candidates):
+        path = Path(candidate)
+        if path.is_file() and path.stat().st_size > 0:
+            return path
+    raise FileNotFoundError("Could not find a readable host CA bundle")
 
 
 @dataclass
@@ -251,6 +286,7 @@ class ContainerRunner:
             )
             owners = ",".join(self.config.internet_policy.blocked_github_owners)
             repository_ids = ",".join(self.config.internet_policy.blocked_github_repository_ids)
+            repositories = ",".join(self.config.internet_policy.blocked_github_repositories)
             self._run_docker_checked(
                 [
                     "docker",
@@ -272,6 +308,8 @@ class ContainerRunner:
                     f"BLOCKED_GITHUB_OWNERS={owners}",
                     "-e",
                     f"BLOCKED_GITHUB_REPOSITORY_IDS={repository_ids}",
+                    "-e",
+                    f"BLOCKED_GITHUB_REPOSITORIES={repositories}",
                     "-e",
                     "BLOCKED_REQUEST_LOG=/state/blocked-requests.jsonl",
                     "-e",
@@ -352,9 +390,7 @@ class ContainerRunner:
         else:
             raise TimeoutError("Timed out while waiting for the filtered egress proxy certificate")
 
-        system_bundle = Path("/etc/ssl/certs/ca-certificates.crt")
-        if not system_bundle.is_file():
-            raise FileNotFoundError(f"System CA bundle not found: {system_bundle}")
+        system_bundle = _find_host_ca_bundle()
         combined_bundle = self._egress_tmp_dir / "ca-certificates.crt"
         combined_bundle.write_bytes(system_bundle.read_bytes() + b"\n" + proxy_ca.read_bytes())
         self._egress_proxy_ca = proxy_ca
@@ -451,11 +487,17 @@ class ContainerRunner:
                 }
             )
 
-        # Docker Desktop and filtered containers cannot reach host loopback directly.
-        if (_docker_uses_separate_host() or self.config.internet_policy.is_filtered) and (
-            api_base := env_vars.get("AGENT_API_BASE")
-        ):
-            env_vars["AGENT_API_BASE"] = _replace_loopback_host(api_base)
+        # Docker Desktop and filtered containers cannot reach host loopback
+        # directly. Rewrite every forwarded provider endpoint that points to a
+        # loopback address, not only the primary agent endpoint.
+        if _docker_uses_separate_host() or self.config.internet_policy.is_filtered:
+            for key, value in list(env_vars.items()):
+                if not isinstance(value, str) or not (
+                    key.endswith(("_API_BASE", "_BASE_URL", "_URL", "_ENDPOINT"))
+                    or key in {"AGENT_API_BASE", "JUDGE_API_BASE"}
+                ):
+                    continue
+                env_vars[key] = _replace_loopback_host(value)
 
         # Agent containers use Docker's host alias to reach SREGym services
         # running on the host, including the MCP port-forward.

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -5,14 +5,27 @@ import platform
 import shutil
 import subprocess
 import tempfile
+import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
+import yaml
+
+from sregym.service.internet_policy import InternetPolicy
+
 logger = logging.getLogger("all.sregym.container_runner")
 
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+DEFAULT_EGRESS_PROXY_IMAGE = "mitmproxy/mitmproxy:12.2.3"
+EGRESS_PROXY_PORT = 8080
+PROXY_CA_CONTAINER_PATH = "/etc/evaluation-egress/mitmproxy-ca-cert.pem"
+PROXY_BUNDLE_CONTAINER_PATH = "/etc/evaluation-egress/ca-certificates.crt"
+GITHUB_TLS_IGNORE_PATTERN = (
+    r"^(?!(?:github\.com|api\.github\.com|raw\.githubusercontent\.com|codeload\.github\.com)"
+    r"(?::443)?$).*"
+)
 
 
 def _docker_uses_separate_host() -> bool:
@@ -30,6 +43,22 @@ def _replace_loopback_host(url: str) -> str:
     if parsed.port is not None:
         netloc += f":{parsed.port}"
     return urlunsplit(parsed._replace(netloc=netloc))
+
+
+def get_container_host_bind_address() -> str:
+    """Return a host address reachable from Linux containers but not the public network."""
+    if platform.system() != "Linux":
+        return "127.0.0.1"
+    result = subprocess.run(
+        ["docker", "network", "inspect", "bridge", "-f", "{{(index .IPAM.Config 0).Gateway}}"],
+        capture_output=True,
+        text=True,
+    )
+    address = result.stdout.strip()
+    if result.returncode != 0 or not address:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"Could not determine the Docker host gateway: {detail}")
+    return address
 
 
 @dataclass
@@ -54,6 +83,8 @@ class ContainerConfig:
     env_vars: dict = field(default_factory=dict)
     cpus: float = 4.0
     memory: str = "8g"
+    internet_policy: InternetPolicy = field(default_factory=InternetPolicy)
+    egress_proxy_image: str = DEFAULT_EGRESS_PROXY_IMAGE
 
 
 class ContainerRunner:
@@ -171,12 +202,200 @@ class ContainerRunner:
     def __init__(self, config: ContainerConfig | None = None):
         self.config = config or ContainerConfig()
         self._credential_tmps: list[str] = []
+        self._egress_network_name: str | None = None
+        self._egress_proxy_name: str | None = None
+        self._egress_tmp_dir: Path | None = None
+        self._egress_proxy_ca: Path | None = None
+        self._egress_ca_bundle: Path | None = None
+
+    @property
+    def internet_access_mode(self) -> str:
+        return self.config.internet_policy.mode.value
+
+    def blocked_request_count(self) -> int:
+        if self._egress_tmp_dir is None:
+            return 0
+        log_path = self._egress_tmp_dir / "blocked-requests.jsonl"
+        try:
+            with log_path.open(encoding="utf-8") as handle:
+                return sum(1 for line in handle if line.strip())
+        except FileNotFoundError:
+            return 0
+
+    def _ensure_filtered_egress(self) -> None:
+        if not self.config.internet_policy.is_filtered:
+            return
+        if self._egress_proxy_name is not None:
+            running = subprocess.run(
+                ["docker", "inspect", "-f", "{{.State.Running}}", self._egress_proxy_name],
+                capture_output=True,
+                text=True,
+            )
+            if running.returncode == 0 and running.stdout.strip() == "true":
+                return
+            raise RuntimeError("Filtered egress proxy is not running; refusing to start an unrestricted agent")
+
+        self._ensure_proxy_image_exists()
+        suffix = uuid.uuid4().hex[:8]
+        self._egress_network_name = f"evaluation-egress-{suffix}"
+        self._egress_proxy_name = f"evaluation-egress-proxy-{suffix}"
+        self._prepare_egress_state()
+
+        repo_root = Path(__file__).resolve().parents[2]
+        addon_path = repo_root / "docker" / "egress_proxy.py"
+        policy_path = repo_root / "sregym" / "service" / "internet_policy.py"
+        if not addon_path.is_file() or not policy_path.is_file():
+            self.cleanup_egress_proxy()
+            raise FileNotFoundError("Egress proxy policy files are missing")
+
+        try:
+            self._run_docker_checked(
+                ["docker", "network", "create", "--internal", self._egress_network_name],
+                "create the filtered egress network",
+            )
+            owners = ",".join(self.config.internet_policy.blocked_github_owners)
+            self._run_docker_checked(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--rm",
+                    "--name",
+                    self._egress_proxy_name,
+                    "--network",
+                    self._egress_network_name,
+                    "--add-host=host.docker.internal:host-gateway",
+                    "-v",
+                    f"{addon_path}:/addons/egress_proxy.py:ro",
+                    "-v",
+                    f"{policy_path}:/addons/internet_policy.py:ro",
+                    "-v",
+                    f"{self._egress_tmp_dir}:/state",
+                    "-e",
+                    f"BLOCKED_GITHUB_OWNERS={owners}",
+                    "-e",
+                    "BLOCKED_REQUEST_LOG=/state/blocked-requests.jsonl",
+                    "-e",
+                    "PYTHONPATH=/addons",
+                    self.config.egress_proxy_image,
+                    "mitmdump",
+                    "--listen-host",
+                    "0.0.0.0",
+                    "--listen-port",
+                    str(EGRESS_PROXY_PORT),
+                    "--ignore-hosts",
+                    GITHUB_TLS_IGNORE_PATTERN,
+                    "--set",
+                    "connection_strategy=lazy",
+                    "-s",
+                    "/addons/egress_proxy.py",
+                ],
+                "start the filtered egress proxy",
+            )
+            self._run_docker_checked(
+                ["docker", "network", "connect", "bridge", self._egress_proxy_name],
+                "connect the egress proxy to the internet",
+            )
+            self._copy_proxy_certificate()
+        except Exception:
+            self.cleanup_egress_proxy()
+            raise
+
+    def _prepare_egress_state(self) -> None:
+        """Create an audit log that the unprivileged proxy process can append to."""
+        self._egress_tmp_dir = Path(tempfile.mkdtemp(prefix="evaluation-egress-"))
+        blocked_log = self._egress_tmp_dir / "blocked-requests.jsonl"
+        blocked_log.touch()
+
+        # The mitmproxy image drops privileges before loading the addon. Allow
+        # it to traverse the private temp directory and append to this one file
+        # without making the audit log readable by other host users.
+        self._egress_tmp_dir.chmod(0o711)
+        blocked_log.chmod(0o622)
+
+    def _ensure_proxy_image_exists(self) -> None:
+        image = self.config.egress_proxy_image
+        inspected = subprocess.run(["docker", "image", "inspect", image], capture_output=True)
+        if inspected.returncode == 0:
+            return
+        logger.info("Pulling filtered egress proxy image '%s'...", image)
+        self._run_docker_checked(["docker", "pull", image], "pull the filtered egress proxy image")
+
+    def _copy_proxy_certificate(self) -> None:
+        if self._egress_proxy_name is None or self._egress_tmp_dir is None:
+            raise RuntimeError("Filtered egress proxy is not initialized")
+
+        proxy_ca = self._egress_tmp_dir / "mitmproxy-ca-cert.pem"
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            copied = subprocess.run(
+                [
+                    "docker",
+                    "cp",
+                    f"{self._egress_proxy_name}:/home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem",
+                    str(proxy_ca),
+                ],
+                capture_output=True,
+            )
+            if copied.returncode == 0 and proxy_ca.is_file() and proxy_ca.stat().st_size > 0:
+                break
+            running = subprocess.run(
+                ["docker", "inspect", "-f", "{{.State.Running}}", self._egress_proxy_name],
+                capture_output=True,
+                text=True,
+            )
+            if running.returncode != 0 or running.stdout.strip() != "true":
+                logs = subprocess.run(
+                    ["docker", "logs", self._egress_proxy_name],
+                    capture_output=True,
+                    text=True,
+                )
+                raise RuntimeError(f"Filtered egress proxy stopped during startup: {logs.stderr or logs.stdout}")
+            time.sleep(0.25)
+        else:
+            raise TimeoutError("Timed out while waiting for the filtered egress proxy certificate")
+
+        system_bundle = Path("/etc/ssl/certs/ca-certificates.crt")
+        if not system_bundle.is_file():
+            raise FileNotFoundError(f"System CA bundle not found: {system_bundle}")
+        combined_bundle = self._egress_tmp_dir / "ca-certificates.crt"
+        combined_bundle.write_bytes(system_bundle.read_bytes() + b"\n" + proxy_ca.read_bytes())
+        self._egress_proxy_ca = proxy_ca
+        self._egress_ca_bundle = combined_bundle
+
+    @staticmethod
+    def _run_docker_checked(command: list[str], action: str) -> subprocess.CompletedProcess:
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            raise RuntimeError(f"Could not {action}: {detail}")
+        return result
+
+    def cleanup_egress_proxy(self) -> None:
+        if self._egress_proxy_name:
+            subprocess.run(
+                ["docker", "rm", "-f", self._egress_proxy_name],
+                capture_output=True,
+            )
+        if self._egress_network_name:
+            subprocess.run(
+                ["docker", "network", "rm", self._egress_network_name],
+                capture_output=True,
+            )
+        if self._egress_tmp_dir:
+            shutil.rmtree(self._egress_tmp_dir, ignore_errors=True)
+        self._egress_network_name = None
+        self._egress_proxy_name = None
+        self._egress_tmp_dir = None
+        self._egress_proxy_ca = None
+        self._egress_ca_bundle = None
 
     def _mount_codex_credentials(self, args: list[str]) -> None:
-        """Mount Codex auth into a throwaway tempdir
+        """Mount Codex auth into a throwaway tempdir.
 
-        Copies only auth.json + config.toml and never sessions/logs/telemetry
-        so each container gets isolated state that dies with it.
+        Only the copied auth file is mounted from the host. Codex can write its
+        generated state elsewhere in /root/.codex, but that state remains in
+        the disposable container instead of making the host tempdir root-owned.
         """
         codex_dir = Path.home() / ".codex"
         if not codex_dir.is_dir():
@@ -189,9 +408,10 @@ class ContainerRunner:
             shutil.rmtree(tmp, ignore_errors=True)
             return
 
-        shutil.copy2(auth_src, Path(tmp) / "auth.json")
+        auth_dst = Path(tmp) / "auth.json"
+        shutil.copy2(auth_src, auth_dst)
 
-        args.extend(["-v", f"{tmp}:/root/.codex"])
+        args.extend(["-v", f"{auth_dst}:/root/.codex/auth.json:ro"])
         self._credential_tmps.append(tmp)
 
     def cleanup_credential_tmps(self) -> None:
@@ -213,13 +433,36 @@ class ContainerRunner:
         if extra_env:
             env_vars.update(extra_env)
 
-        # Docker Desktop containers cannot reach host loopback directly.
-        if _docker_uses_separate_host() and (api_base := env_vars.get("AGENT_API_BASE")):
+        env_vars["AGENT_INTERNET_ACCESS"] = self.internet_access_mode
+        if self.config.internet_policy.is_filtered:
+            if self._egress_proxy_name is None or self._egress_proxy_ca is None or self._egress_ca_bundle is None:
+                raise RuntimeError("Filtered egress proxy is not ready")
+            proxy_url = f"http://{self._egress_proxy_name}:{EGRESS_PROXY_PORT}"
+            env_vars.update(
+                {
+                    "HTTP_PROXY": proxy_url,
+                    "HTTPS_PROXY": proxy_url,
+                    "http_proxy": proxy_url,
+                    "https_proxy": proxy_url,
+                    "NO_PROXY": "",
+                    "no_proxy": "",
+                    "SSL_CERT_FILE": PROXY_BUNDLE_CONTAINER_PATH,
+                    "REQUESTS_CA_BUNDLE": PROXY_BUNDLE_CONTAINER_PATH,
+                    "CURL_CA_BUNDLE": PROXY_BUNDLE_CONTAINER_PATH,
+                    "GIT_SSL_CAINFO": PROXY_BUNDLE_CONTAINER_PATH,
+                    "NODE_EXTRA_CA_CERTS": PROXY_CA_CONTAINER_PATH,
+                }
+            )
+
+        # Docker Desktop and filtered containers cannot reach host loopback directly.
+        if (_docker_uses_separate_host() or self.config.internet_policy.is_filtered) and (
+            api_base := env_vars.get("AGENT_API_BASE")
+        ):
             env_vars["AGENT_API_BASE"] = _replace_loopback_host(api_base)
 
         # Agent containers use Docker's host alias to reach SREGym services
         # running on the host, including the MCP port-forward.
-        if self.config.network_mode == "host":
+        if self.config.network_mode == "host" or self.config.internet_policy.is_filtered:
             env_vars["API_HOSTNAME"] = "host.docker.internal"
             mcp_port = env_vars.get("MCP_SERVER_PORT", os.environ.get("MCP_SERVER_PORT", "9954"))
             env_vars["MCP_SERVER_URL"] = f"http://host.docker.internal:{mcp_port}"
@@ -237,8 +480,16 @@ class ContainerRunner:
             f"--memory={self.config.memory}",
         ]
 
-        # Configure networking based on the network mode
-        if self.config.network_mode == "host":
+        # Filtered agents have no direct external route. The proxy container is
+        # the only member of their private network that also joins a public one.
+        if self.config.internet_policy.is_filtered:
+            if self._egress_network_name is None or self._egress_proxy_ca is None or self._egress_ca_bundle is None:
+                raise RuntimeError("Filtered egress proxy is not ready")
+            args.append(f"--network={self._egress_network_name}")
+            args.append("--add-host=host.docker.internal:host-gateway")
+            args.extend(["-v", f"{self._egress_proxy_ca}:{PROXY_CA_CONTAINER_PATH}:ro"])
+            args.extend(["-v", f"{self._egress_ca_bundle}:{PROXY_BUNDLE_CONTAINER_PATH}:ro"])
+        elif self.config.network_mode == "host":
             if platform.system() == "Darwin":
                 # macOS: Don't use --network host (it's ignored), rely on host.docker.internal
                 args.append("--add-host=host.docker.internal:host-gateway")
@@ -252,14 +503,16 @@ class ContainerRunner:
 
         # Mount kubeconfig (read-only)
         if self.config.kubeconfig_path and self.config.kubeconfig_path.exists():
-            args.extend(["-v", f"{self.config.kubeconfig_path.resolve()}:/root/.kube/config:ro"])
+            kubeconfig_path = self._prepare_kubeconfig(self.config.kubeconfig_path)
+            args.extend(["-v", f"{kubeconfig_path.resolve()}:/root/.kube/config:ro"])
             args.extend(["-e", "KUBECONFIG=/root/.kube/config"])
 
         # Mount the real (unproxied) kubeconfig so that workload oracles
         # running inside the container can bypass the filtering proxy.
         real_kubeconfig = Path(os.path.expanduser("~/.kube/config"))
         if real_kubeconfig.exists():
-            args.extend(["-v", f"{real_kubeconfig.resolve()}:/root/.kube/real-config:ro"])
+            real_kubeconfig_path = self._prepare_kubeconfig(real_kubeconfig)
+            args.extend(["-v", f"{real_kubeconfig_path.resolve()}:/root/.kube/real-config:ro"])
             args.extend(["-e", "SREGYM_REAL_KUBECONFIG=/root/.kube/real-config"])
 
         # Mount AWS credentials directory (read-only) for Bedrock and other AWS services
@@ -288,7 +541,34 @@ class ContainerRunner:
 
         return args
 
+    def _prepare_kubeconfig(self, source: Path) -> Path:
+        if not self.config.internet_policy.is_filtered:
+            return source
+
+        with source.open(encoding="utf-8") as handle:
+            config = yaml.safe_load(handle)
+        changed = False
+        for cluster in config.get("clusters", []):
+            cluster_config = cluster.get("cluster", {})
+            server = cluster_config.get("server")
+            if isinstance(server, str):
+                container_server = _replace_loopback_host(server)
+                if container_server != server:
+                    cluster_config["server"] = container_server
+                    changed = True
+        if not changed:
+            return source
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="sregym-kubeconfig-"))
+        output = temp_dir / source.name
+        with output.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(config, handle, sort_keys=False)
+        output.chmod(0o600)
+        self._credential_tmps.append(str(temp_dir))
+        return output
+
     def build_docker_command(self, exec_input: ExecInput) -> list[str]:
+        self._ensure_filtered_egress()
         cmd = self._build_base_docker_args()
         suffix = uuid.uuid4().hex[:8]
         if exec_input.label:

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -22,10 +22,6 @@ DEFAULT_EGRESS_PROXY_IMAGE = "mitmproxy/mitmproxy:12.2.3"
 EGRESS_PROXY_PORT = 8080
 PROXY_CA_CONTAINER_PATH = "/etc/evaluation-egress/mitmproxy-ca-cert.pem"
 PROXY_BUNDLE_CONTAINER_PATH = "/etc/evaluation-egress/ca-certificates.crt"
-GITHUB_TLS_IGNORE_PATTERN = (
-    r"^(?!(?:github\.com|api\.github\.com|raw\.githubusercontent\.com|codeload\.github\.com)"
-    r"(?::443)?$).*"
-)
 
 
 def _docker_uses_separate_host() -> bool:
@@ -254,6 +250,7 @@ class ContainerRunner:
                 "create the filtered egress network",
             )
             owners = ",".join(self.config.internet_policy.blocked_github_owners)
+            repository_ids = ",".join(self.config.internet_policy.blocked_github_repository_ids)
             self._run_docker_checked(
                 [
                     "docker",
@@ -274,6 +271,8 @@ class ContainerRunner:
                     "-e",
                     f"BLOCKED_GITHUB_OWNERS={owners}",
                     "-e",
+                    f"BLOCKED_GITHUB_REPOSITORY_IDS={repository_ids}",
+                    "-e",
                     "BLOCKED_REQUEST_LOG=/state/blocked-requests.jsonl",
                     "-e",
                     "PYTHONPATH=/addons",
@@ -283,8 +282,6 @@ class ContainerRunner:
                     "0.0.0.0",
                     "--listen-port",
                     str(EGRESS_PROXY_PORT),
-                    "--ignore-hosts",
-                    GITHUB_TLS_IGNORE_PATTERN,
                     "--set",
                     "connection_strategy=lazy",
                     "-s",

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -504,14 +504,6 @@ class ContainerRunner:
             args.extend(["-v", f"{kubeconfig_path.resolve()}:/root/.kube/config:ro"])
             args.extend(["-e", "KUBECONFIG=/root/.kube/config"])
 
-        # Mount the real (unproxied) kubeconfig so that workload oracles
-        # running inside the container can bypass the filtering proxy.
-        real_kubeconfig = Path(os.path.expanduser("~/.kube/config"))
-        if real_kubeconfig.exists():
-            real_kubeconfig_path = self._prepare_kubeconfig(real_kubeconfig)
-            args.extend(["-v", f"{real_kubeconfig_path.resolve()}:/root/.kube/real-config:ro"])
-            args.extend(["-e", "SREGYM_REAL_KUBECONFIG=/root/.kube/real-config"])
-
         # Mount AWS credentials directory (read-only) for Bedrock and other AWS services
         aws_dir = Path.home() / ".aws"
         if aws_dir.is_dir():

--- a/sregym/service/internet_policy.py
+++ b/sregym/service/internet_policy.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from enum import StrEnum
-from urllib.parse import unquote, urlsplit
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 
 class InternetAccessMode(StrEnum):
@@ -14,15 +15,19 @@ class InternetAccessMode(StrEnum):
 
 
 DEFAULT_BLOCKED_GITHUB_OWNERS = ("SREGym",)
+DEFAULT_BLOCKED_GITHUB_REPOSITORIES = ("SREGym",)
 # The repository API accepts numeric IDs instead of an owner/repository path.
 # Keep the benchmark repository protected when an agent uses that form.
 DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS = ("986527564",)
 GITHUB_CONTENT_HOSTS = {
     "api.github.com",
     "codeload.github.com",
+    "cdn.jsdelivr.net",
     "github.com",
     "raw.githubusercontent.com",
+    "raw.githack.com",
 }
+GITHUB_MIRROR_HOSTS = {"cdn.jsdelivr.net", "raw.githack.com"}
 
 
 @dataclass(frozen=True)
@@ -30,6 +35,7 @@ class InternetPolicy:
     mode: InternetAccessMode = InternetAccessMode.FILTERED
     blocked_github_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS
     blocked_github_repository_ids: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS
+    blocked_github_repositories: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORIES
 
     @classmethod
     def from_mode(cls, mode: str | InternetAccessMode) -> InternetPolicy:
@@ -46,6 +52,7 @@ def blocked_github_owner(
     request_body: bytes | str | None,
     blocked_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS,
     blocked_repository_ids: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
+    blocked_repositories: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORIES,
 ) -> str | None:
     """Return the blocked GitHub owner or repository route, if any."""
     normalized_host = host.partition(":")[0].rstrip(".").casefold()
@@ -55,7 +62,6 @@ def blocked_github_owner(
     parsed = urlsplit(_decode_repeatedly(request_target))
     segments = _normalise_path_segments(parsed.path)
     query = _decode_repeatedly(parsed.query).casefold()
-    body = _body_text(request_body).casefold()
 
     if (
         normalized_host == "api.github.com"
@@ -71,11 +77,15 @@ def blocked_github_owner(
             continue
         if _owner_is_in_path(normalized_host, segments, normalized_owner):
             return owner
-        if normalized_owner in query or normalized_owner in body:
+        if _query_references_owner(query, normalized_owner):
             return owner
         if normalized_host == "api.github.com" and segments and segments[0] == "graphql":
-            if _decoded_json_contains(request_body, normalized_owner):
+            if _decoded_json_references_owner(request_body, normalized_owner):
                 return owner
+
+    repository = _repository_in_path(normalized_host, segments, blocked_repositories)
+    if repository is not None:
+        return f"repository:{repository}"
     return None
 
 
@@ -88,6 +98,44 @@ def _owner_is_in_path(host: str, segments: tuple[str, ...], owner: str) -> bool:
         return segments[0] == owner or (len(segments) > 1 and segments[0] in {"orgs", "users"} and segments[1] == owner)
     if host == "api.github.com":
         return len(segments) > 1 and segments[0] in {"orgs", "repos", "users"} and segments[1] == owner
+    if host == "cdn.jsdelivr.net":
+        return len(segments) > 2 and segments[0] == "gh" and segments[1] == owner
+    if host == "raw.githack.com":
+        return len(segments) > 1 and segments[0] == owner
+    return False
+
+
+def _repository_in_path(host: str, segments: tuple[str, ...], repositories: tuple[str, ...]) -> str | None:
+    blocked = {repository.strip().casefold() for repository in repositories if repository.strip()}
+    if not blocked:
+        return None
+
+    repository_segment: str | None = None
+    if host in {"github.com", "raw.githubusercontent.com", "codeload.github.com"} and len(segments) > 1:
+        repository_segment = segments[1]
+    elif host == "api.github.com" and len(segments) > 2 and segments[0] in {"orgs", "repos"}:
+        repository_segment = segments[2]
+    elif host in GITHUB_MIRROR_HOSTS:
+        # jsDelivr uses /gh/{owner}/{repo}@{ref}/..., while raw.githack uses
+        # /{owner}/{repo}/{ref}/....
+        if host == "cdn.jsdelivr.net" and len(segments) > 2 and segments[0] == "gh":
+            repository_segment = segments[2].split("@", 1)[0]
+        elif len(segments) > 1:
+            repository_segment = segments[1]
+
+    if repository_segment in blocked:
+        return repository_segment
+    return None
+
+
+def _query_references_owner(query: str, owner: str) -> bool:
+    for key, value in parse_qsl(_decode_repeatedly(query), keep_blank_values=True):
+        key = key.casefold()
+        value = _decode_repeatedly(value).casefold()
+        if key in {"owner", "organization", "org"} and value == owner:
+            return True
+        if key in {"q", "query"} and re.search(rf"(?:^|\s)(?:org|user|repo):{re.escape(owner)}(?:\b|/)", value):
+            return True
     return False
 
 
@@ -116,13 +164,30 @@ def _normalise_path_segments(path: str) -> tuple[str, ...]:
     return tuple(normalised)
 
 
-def _decoded_json_contains(body: bytes | str | None, needle: str) -> bool:
-    """Match JSON string values after JSON escape processing."""
+def _decoded_json_references_owner(body: bytes | str | None, needle: str) -> bool:
+    """Match GraphQL owner/repository fields after JSON escape processing."""
     try:
         decoded = json.loads(_body_text(body))
     except (TypeError, ValueError):
         return False
-    return needle in json.dumps(decoded, ensure_ascii=False).casefold()
+
+    def references(value: object, key: str = "") -> bool:
+        if isinstance(value, dict):
+            return any(references(child_value, str(child_key).casefold()) for child_key, child_value in value.items())
+        if isinstance(value, list):
+            return any(references(item, key) for item in value)
+        if not isinstance(value, str):
+            return False
+        normalized = value.casefold()
+        if key in {"owner", "repositoryowner", "repository_owner", "organization", "org"}:
+            return normalized == needle
+        if key in {"repo", "repository"}:
+            return normalized == needle or normalized.startswith(f"{needle}/")
+        if key in {"q", "query"}:
+            return bool(re.search(rf"(?:^|\s)(?:org|user|repo):{re.escape(needle)}(?:\b|/)", normalized))
+        return False
+
+    return references(decoded)
 
 
 def _body_text(body: bytes | str | None, limit: int = 1_000_000) -> str:

--- a/sregym/service/internet_policy.py
+++ b/sregym/service/internet_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from enum import StrEnum
 from urllib.parse import unquote, urlsplit
@@ -13,6 +14,9 @@ class InternetAccessMode(StrEnum):
 
 
 DEFAULT_BLOCKED_GITHUB_OWNERS = ("SREGym",)
+# The repository API accepts numeric IDs instead of an owner/repository path.
+# Keep the benchmark repository protected when an agent uses that form.
+DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS = ("986527564",)
 GITHUB_CONTENT_HOSTS = {
     "api.github.com",
     "codeload.github.com",
@@ -25,6 +29,7 @@ GITHUB_CONTENT_HOSTS = {
 class InternetPolicy:
     mode: InternetAccessMode = InternetAccessMode.FILTERED
     blocked_github_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS
+    blocked_github_repository_ids: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS
 
     @classmethod
     def from_mode(cls, mode: str | InternetAccessMode) -> InternetPolicy:
@@ -40,16 +45,25 @@ def blocked_github_owner(
     request_target: str,
     request_body: bytes | str | None,
     blocked_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS,
+    blocked_repository_ids: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
 ) -> str | None:
-    """Return the blocked GitHub owner referenced by a request, if any."""
+    """Return the blocked GitHub owner or repository route, if any."""
     normalized_host = host.partition(":")[0].rstrip(".").casefold()
     if normalized_host not in GITHUB_CONTENT_HOSTS:
         return None
 
     parsed = urlsplit(_decode_repeatedly(request_target))
-    segments = tuple(_decode_repeatedly(segment).casefold() for segment in parsed.path.split("/") if segment)
+    segments = _normalise_path_segments(parsed.path)
     query = _decode_repeatedly(parsed.query).casefold()
     body = _body_text(request_body).casefold()
+
+    if (
+        normalized_host == "api.github.com"
+        and len(segments) > 1
+        and segments[0] == "repositories"
+        and segments[1] in {repository_id.casefold() for repository_id in blocked_repository_ids}
+    ):
+        return f"repository:{segments[1]}"
 
     for owner in blocked_owners:
         normalized_owner = owner.strip().casefold()
@@ -59,6 +73,9 @@ def blocked_github_owner(
             return owner
         if normalized_owner in query or normalized_owner in body:
             return owner
+        if normalized_host == "api.github.com" and segments and segments[0] == "graphql":
+            if _decoded_json_contains(request_body, normalized_owner):
+                return owner
     return None
 
 
@@ -82,6 +99,30 @@ def _decode_repeatedly(value: str, limit: int = 3) -> str:
             break
         decoded = next_value
     return decoded
+
+
+def _normalise_path_segments(path: str) -> tuple[str, ...]:
+    """Decode and resolve dot segments before applying path-based rules."""
+    normalised: list[str] = []
+    for raw_segment in path.split("/"):
+        segment = _decode_repeatedly(raw_segment).casefold()
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            if normalised:
+                normalised.pop()
+            continue
+        normalised.append(segment)
+    return tuple(normalised)
+
+
+def _decoded_json_contains(body: bytes | str | None, needle: str) -> bool:
+    """Match JSON string values after JSON escape processing."""
+    try:
+        decoded = json.loads(_body_text(body))
+    except (TypeError, ValueError):
+        return False
+    return needle in json.dumps(decoded, ensure_ascii=False).casefold()
 
 
 def _body_text(body: bytes | str | None, limit: int = 1_000_000) -> str:

--- a/sregym/service/internet_policy.py
+++ b/sregym/service/internet_policy.py
@@ -1,0 +1,92 @@
+"""Internet-access policy shared by the agent runner and egress proxy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from urllib.parse import unquote, urlsplit
+
+
+class InternetAccessMode(StrEnum):
+    OPEN = "open"
+    FILTERED = "filtered"
+
+
+DEFAULT_BLOCKED_GITHUB_OWNERS = ("SREGym",)
+GITHUB_CONTENT_HOSTS = {
+    "api.github.com",
+    "codeload.github.com",
+    "github.com",
+    "raw.githubusercontent.com",
+}
+
+
+@dataclass(frozen=True)
+class InternetPolicy:
+    mode: InternetAccessMode = InternetAccessMode.FILTERED
+    blocked_github_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS
+
+    @classmethod
+    def from_mode(cls, mode: str | InternetAccessMode) -> InternetPolicy:
+        return cls(mode=InternetAccessMode(mode))
+
+    @property
+    def is_filtered(self) -> bool:
+        return self.mode == InternetAccessMode.FILTERED
+
+
+def blocked_github_owner(
+    host: str,
+    request_target: str,
+    request_body: bytes | str | None,
+    blocked_owners: tuple[str, ...] = DEFAULT_BLOCKED_GITHUB_OWNERS,
+) -> str | None:
+    """Return the blocked GitHub owner referenced by a request, if any."""
+    normalized_host = host.partition(":")[0].rstrip(".").casefold()
+    if normalized_host not in GITHUB_CONTENT_HOSTS:
+        return None
+
+    parsed = urlsplit(_decode_repeatedly(request_target))
+    segments = tuple(_decode_repeatedly(segment).casefold() for segment in parsed.path.split("/") if segment)
+    query = _decode_repeatedly(parsed.query).casefold()
+    body = _body_text(request_body).casefold()
+
+    for owner in blocked_owners:
+        normalized_owner = owner.strip().casefold()
+        if not normalized_owner:
+            continue
+        if _owner_is_in_path(normalized_host, segments, normalized_owner):
+            return owner
+        if normalized_owner in query or normalized_owner in body:
+            return owner
+    return None
+
+
+def _owner_is_in_path(host: str, segments: tuple[str, ...], owner: str) -> bool:
+    if not segments:
+        return False
+    if host in {"raw.githubusercontent.com", "codeload.github.com"}:
+        return segments[0] == owner
+    if host == "github.com":
+        return segments[0] == owner or (len(segments) > 1 and segments[0] in {"orgs", "users"} and segments[1] == owner)
+    if host == "api.github.com":
+        return len(segments) > 1 and segments[0] in {"orgs", "repos", "users"} and segments[1] == owner
+    return False
+
+
+def _decode_repeatedly(value: str, limit: int = 3) -> str:
+    decoded = value
+    for _ in range(limit):
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            break
+        decoded = next_value
+    return decoded
+
+
+def _body_text(body: bytes | str | None, limit: int = 1_000_000) -> str:
+    if body is None:
+        return ""
+    if isinstance(body, bytes):
+        return body[:limit].decode("utf-8", errors="ignore")
+    return body[:limit]

--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -23,10 +23,16 @@ import secrets
 import ssl
 import tempfile
 import threading
+from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import ip_address
 from urllib.parse import unquote, urlparse
 
 import urllib3
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 from kubernetes import config
 
 logger = logging.getLogger("all.infra.k8s_proxy")
@@ -90,6 +96,7 @@ class KubernetesAPIProxy:
         self._bearer_token: str | None = None
         self._agent_token = secrets.token_urlsafe(32)
         self._agent_kubeconfig_path: str | None = None
+        self._server_cert_pem: str | None = None
 
         if os.path.exists(self._INCLUSTER_TOKEN_PATH):
             # Running inside a Kubernetes pod — use ServiceAccount credentials
@@ -200,11 +207,57 @@ class KubernetesAPIProxy:
 
         return files
 
+    def _create_server_cert_files(self) -> dict[str, str]:
+        """Create a short-lived certificate for the local agent endpoint."""
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+        dns_names = ["host.docker.internal", "localhost"]
+        ip_names = [ip_address("127.0.0.1")]
+        if self.listen_host not in {"0.0.0.0", "::", ""}:
+            try:
+                ip_names.append(ip_address(self.listen_host))
+            except ValueError:
+                dns_names.append(self.listen_host.rstrip("."))
+
+        san_names: list[x509.GeneralName] = [x509.DNSName(name) for name in dict.fromkeys(dns_names)]
+        san_names.extend(x509.IPAddress(address) for address in dict.fromkeys(ip_names))
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "local Kubernetes proxy")])
+        now = datetime.now(UTC)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(hours=12))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+            .add_extension(x509.SubjectAlternativeName(san_names), critical=False)
+            .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), critical=False)
+            .sign(private_key, hashes.SHA256())
+        )
+        certificate_pem = certificate.public_bytes(serialization.Encoding.PEM).decode()
+        key_pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".crt", delete=False) as cert_file:
+            cert_file.write(certificate_pem)
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".key", delete=False) as key_file:
+            key_file.write(key_pem)
+        os.chmod(key_file.name, 0o600)
+        self._temp_files.extend([cert_file.name, key_file.name])
+        return {"server_cert": cert_file.name, "server_key": key_file.name, "server_cert_pem": certificate_pem}
+
     def start(self):
         """Start the proxy server in a background thread."""
         # Rotate the client token for every proxy lifecycle.
         self._agent_token = secrets.token_urlsafe(32)
         cert_files = self._create_temp_cert_files()
+        cert_files.update(self._create_server_cert_files())
+        self._server_cert_pem = cert_files["server_cert_pem"]
         hidden_namespaces = self.hidden_namespaces
         hidden_labels = self.hidden_labels
         api_host = self.api_host
@@ -431,6 +484,10 @@ class KubernetesAPIProxy:
 
         # Create and start server
         self.server = ThreadingHTTPServer((self.listen_host, self.listen_port), FilteringProxyHandler)
+        tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
+        tls_context.load_cert_chain(cert_files["server_cert"], cert_files["server_key"])
+        self.server.socket = tls_context.wrap_socket(self.server.socket, server_side=True)
         self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.server_thread.start()
         logger.info(f"Kubernetes API filtering proxy started on {self.listen_host}:{self.listen_port}")
@@ -450,6 +507,7 @@ class KubernetesAPIProxy:
             with contextlib.suppress(OSError):
                 os.unlink(temp_file)
         self._temp_files = []
+        self._server_cert_pem = None
 
         if self._agent_kubeconfig_path:
             with contextlib.suppress(OSError):
@@ -468,6 +526,16 @@ class KubernetesAPIProxy:
         """
         import yaml
 
+        if not self._server_cert_pem:
+            raise RuntimeError("Kubernetes proxy must be started before generating an agent kubeconfig")
+
+        # A non-loopback bind address is used for Docker agents. Use Docker's
+        # stable host alias in their kubeconfig so the egress proxy can tunnel
+        # this local HTTPS connection without inspecting or rewriting it.
+        server_host = (
+            self.listen_host if self.listen_host in {"127.0.0.1", "::1", "localhost"} else "host.docker.internal"
+        )
+
         kubeconfig = {
             "apiVersion": "v1",
             "kind": "Config",
@@ -476,10 +544,8 @@ class KubernetesAPIProxy:
                 {
                     "name": "sregym-proxy",
                     "cluster": {
-                        # Use HTTP since proxy runs locally without TLS
-                        "server": f"http://127.0.0.1:{self.listen_port}",
-                        # Skip TLS verification for local proxy
-                        "insecure-skip-tls-verify": True,
+                        "server": f"https://{server_host}:{self.listen_port}",
+                        "certificate-authority-data": base64.b64encode(self._server_cert_pem.encode()).decode(),
                     },
                 }
             ],
@@ -516,7 +582,10 @@ class KubernetesAPIProxy:
 
     def get_proxy_url(self) -> str:
         """Get the URL of the proxy server."""
-        return f"http://127.0.0.1:{self.listen_port}"
+        server_host = (
+            self.listen_host if self.listen_host in {"127.0.0.1", "::1", "localhost"} else "host.docker.internal"
+        )
+        return f"https://{server_host}:{self.listen_port}"
 
 
 # Module-level singleton for easy access

--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -19,11 +19,12 @@ import contextlib
 import json
 import logging
 import os
+import secrets
 import ssl
 import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import urllib3
 from kubernetes import config
@@ -42,9 +43,25 @@ HIDDEN_LABELS: dict[str, set[str]] = {
     "job": {"workload"},
     "opentelemetry.io/name": {"load-generator"},
 }
+WORKLOAD_CREATE_SUFFIXES = {
+    "/pods",
+    "/jobs",
+    "/cronjobs",
+    "/deployments",
+    "/statefulsets",
+    "/daemonsets",
+    "/replicasets",
+    "/replicationcontrollers",
+}
 
 # Disable SSL warnings for self-signed certs
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def is_valid_bearer_token(authorization: str | None, expected_token: str) -> bool:
+    """Validate the bearer token presented by an agent request."""
+    scheme, separator, token = (authorization or "").partition(" ")
+    return bool(separator and scheme.casefold() == "bearer" and secrets.compare_digest(token, expected_token))
 
 
 class KubernetesAPIProxy:
@@ -60,15 +77,19 @@ class KubernetesAPIProxy:
         hidden_labels: dict[str, set[str]] | None = None,
         listen_port: int = 6443,
         listen_host: str = "127.0.0.1",
+        block_workload_creation: bool = False,
     ):
         self.hidden_namespaces: set[str] = hidden_namespaces if hidden_namespaces is not None else HIDDEN_NAMESPACES
         self.hidden_labels: dict[str, set[str]] = hidden_labels if hidden_labels is not None else HIDDEN_LABELS
         self.listen_port = listen_port
         self.listen_host = listen_host
+        self.block_workload_creation = block_workload_creation
         self.server: ThreadingHTTPServer | None = None
         self.server_thread: threading.Thread | None = None
         self._temp_files: list = []
         self._bearer_token: str | None = None
+        self._agent_token = secrets.token_urlsafe(32)
+        self._agent_kubeconfig_path: str | None = None
 
         if os.path.exists(self._INCLUSTER_TOKEN_PATH):
             # Running inside a Kubernetes pod — use ServiceAccount credentials
@@ -181,12 +202,16 @@ class KubernetesAPIProxy:
 
     def start(self):
         """Start the proxy server in a background thread."""
+        # Rotate the client token for every proxy lifecycle.
+        self._agent_token = secrets.token_urlsafe(32)
         cert_files = self._create_temp_cert_files()
         hidden_namespaces = self.hidden_namespaces
         hidden_labels = self.hidden_labels
         api_host = self.api_host
         api_port = self.api_port
         bearer_token = self._bearer_token
+        agent_token = self._agent_token
+        block_workload_creation = self.block_workload_creation
 
         class FilteringProxyHandler(BaseHTTPRequestHandler):
             """HTTP request handler that proxies and filters Kubernetes API responses."""
@@ -302,6 +327,14 @@ class KubernetesAPIProxy:
                 """Proxy request to upstream API and filter response."""
                 path = self.path
 
+                if not is_valid_bearer_token(self.headers.get("Authorization"), agent_token):
+                    self.send_error(401, "Unauthorized: valid agent token required")
+                    return
+
+                if block_workload_creation and method == "POST" and _is_workload_create_path(path):
+                    self.send_error(403, "Forbidden: workload creation is disabled in filtered mode")
+                    return
+
                 # Block direct access to hidden namespaces
                 if self._is_hidden_namespace_request(path):
                     self.send_error(403, "Forbidden: Access to this namespace is not allowed")
@@ -315,7 +348,11 @@ class KubernetesAPIProxy:
                 try:
                     conn = self._get_upstream_connection()
                     # Forward headers (except Host and Accept-Encoding to avoid gzip)
-                    headers = {k: v for k, v in self.headers.items() if k.lower() not in ("host", "accept-encoding")}
+                    headers = {
+                        k: v
+                        for k, v in self.headers.items()
+                        if k.lower() not in ("host", "accept-encoding", "authorization")
+                    }
                     # In-cluster mode: authenticate to the API server with the ServiceAccount bearer token
                     if bearer_token:
                         headers["Authorization"] = f"Bearer {bearer_token}"
@@ -414,6 +451,11 @@ class KubernetesAPIProxy:
                 os.unlink(temp_file)
         self._temp_files = []
 
+        if self._agent_kubeconfig_path:
+            with contextlib.suppress(OSError):
+                os.unlink(self._agent_kubeconfig_path)
+            self._agent_kubeconfig_path = None
+
     def generate_agent_kubeconfig(self, output_path: str | None = None) -> str:
         """
         Generate a kubeconfig file for agents that points to this proxy.
@@ -453,17 +495,21 @@ class KubernetesAPIProxy:
             "users": [
                 {
                     "name": "sregym-agent",
-                    # No credentials needed - proxy handles auth to real API
-                    "user": {},
+                    "user": {"token": self._agent_token},
                 }
             ],
         }
 
-        if output_path is None:
-            output_path = os.path.join(tempfile.gettempdir(), "sregym-agent-kubeconfig")
+        owns_output = output_path is None
+        if owns_output:
+            fd, output_path = tempfile.mkstemp(prefix="sregym-agent-kubeconfig-", suffix=".yaml")
+            os.close(fd)
 
         with open(output_path, "w") as f:
             yaml.dump(kubeconfig, f)
+        os.chmod(output_path, 0o600)
+        if owns_output:
+            self._agent_kubeconfig_path = output_path
 
         logger.info(f"Generated agent kubeconfig at {output_path}")
         return output_path
@@ -489,13 +535,17 @@ def start_proxy(
     hidden_namespaces: set[str] | None = None,
     hidden_labels: dict[str, set[str]] | None = None,
     port: int = 16443,
+    block_workload_creation: bool = False,
 ) -> KubernetesAPIProxy:
     """Start the Kubernetes API filtering proxy."""
     global _proxy_instance
     if _proxy_instance is not None:
         _proxy_instance.stop()
     _proxy_instance = KubernetesAPIProxy(
-        hidden_namespaces=hidden_namespaces, hidden_labels=hidden_labels, listen_port=port
+        hidden_namespaces=hidden_namespaces,
+        hidden_labels=hidden_labels,
+        listen_port=port,
+        block_workload_creation=block_workload_creation,
     )
     _proxy_instance.start()
     return _proxy_instance
@@ -507,3 +557,14 @@ def stop_proxy():
     if _proxy_instance is not None:
         _proxy_instance.stop()
         _proxy_instance = None
+
+
+def _is_workload_create_path(path: str) -> bool:
+    """Return whether a Kubernetes API path creates a new workload object."""
+    normalized = urlparse(path).path
+    for _ in range(3):
+        decoded = unquote(normalized)
+        if decoded == normalized:
+            break
+        normalized = decoded
+    return normalized.casefold().rstrip("/").endswith(tuple(WORKLOAD_CREATE_SUFFIXES))

--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -59,10 +59,12 @@ class KubernetesAPIProxy:
         hidden_namespaces: set[str] | None = None,
         hidden_labels: dict[str, set[str]] | None = None,
         listen_port: int = 6443,
+        listen_host: str = "127.0.0.1",
     ):
         self.hidden_namespaces: set[str] = hidden_namespaces if hidden_namespaces is not None else HIDDEN_NAMESPACES
         self.hidden_labels: dict[str, set[str]] = hidden_labels if hidden_labels is not None else HIDDEN_LABELS
         self.listen_port = listen_port
+        self.listen_host = listen_host
         self.server: ThreadingHTTPServer | None = None
         self.server_thread: threading.Thread | None = None
         self._temp_files: list = []
@@ -391,10 +393,10 @@ class KubernetesAPIProxy:
                 self._proxy_request("HEAD")
 
         # Create and start server
-        self.server = ThreadingHTTPServer(("127.0.0.1", self.listen_port), FilteringProxyHandler)
+        self.server = ThreadingHTTPServer((self.listen_host, self.listen_port), FilteringProxyHandler)
         self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.server_thread.start()
-        logger.info(f"Kubernetes API filtering proxy started on port {self.listen_port}")
+        logger.info(f"Kubernetes API filtering proxy started on {self.listen_host}:{self.listen_port}")
         logger.info(f"Hidden namespaces: {self.hidden_namespaces}")
         logger.info(f"Hidden labels: {self.hidden_labels}")
 

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -1,0 +1,200 @@
+import asyncio
+import stat
+from pathlib import Path
+
+import pytest
+import yaml
+
+from clients.claudecode.claudecode_agent import ClaudeCodeAgent
+from clients.copilot.copilot_agent import CopilotCliAgent
+from clients.geminicli.geminicli_agent import GeminiCliAgent
+from sregym.agent_launcher import AgentLauncher
+from sregym.agent_registry import AgentRegistration
+from sregym.conductor.conductor import ConductorConfig
+from sregym.service.container_runner import (
+    PROXY_BUNDLE_CONTAINER_PATH,
+    PROXY_CA_CONTAINER_PATH,
+    ContainerConfig,
+    ContainerRunner,
+)
+from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
+
+
+@pytest.mark.parametrize(
+    ("host", "target", "body"),
+    [
+        ("github.com", "/SREGym/SREGym", None),
+        ("github.com", "/orgs/sregym/repositories", None),
+        ("github.com", "/search?q=org%253ASREGym", None),
+        ("api.github.com", "/repos/SREGym/SREGym", None),
+        ("api.github.com", "/graphql", b'{"variables":{"owner":"SREGym"}}'),
+        ("raw.githubusercontent.com", "/SREGym/SREGym/main/README.md", None),
+        ("codeload.github.com", "/SREGym/SREGym/tar.gz/main", None),
+    ],
+)
+def test_blocks_configured_github_owner(host, target, body):
+    assert blocked_github_owner(host, target, body) == "SREGym"
+
+
+@pytest.mark.parametrize(
+    ("host", "target"),
+    [
+        ("github.com", "/kubernetes/kubernetes"),
+        ("api.github.com", "/repos/kubernetes/kubernetes"),
+        ("raw.githubusercontent.com", "/kubernetes/kubernetes/master/README.md"),
+        ("example.com", "/SREGym/SREGym"),
+    ],
+)
+def test_allows_other_github_owners_and_hosts(host, target):
+    assert blocked_github_owner(host, target, None) is None
+
+
+def test_filtered_runner_uses_private_network_and_proxy(tmp_path):
+    runner = ContainerRunner(
+        ContainerConfig(
+            internet_policy=InternetPolicy.from_mode("filtered"),
+            env_vars={"AGENT_API_BASE": "http://127.0.0.1:8001/v1"},
+        )
+    )
+    runner._egress_network_name = "private-network"
+    runner._egress_proxy_name = "filter-proxy"
+    runner._egress_proxy_ca = tmp_path / "proxy-ca.pem"
+    runner._egress_ca_bundle = tmp_path / "ca-bundle.pem"
+    runner._egress_proxy_ca.touch()
+    runner._egress_ca_bundle.touch()
+
+    try:
+        args = runner._build_base_docker_args()
+        env_flags = runner._build_env_flags()
+
+        assert "--network=private-network" in args
+        assert "--network=host" not in args
+        env = dict(item.split("=", 1) for item in env_flags[1::2])
+        assert env["HTTPS_PROXY"] == "http://filter-proxy:8080"
+        assert env["SSL_CERT_FILE"] == PROXY_BUNDLE_CONTAINER_PATH
+        assert env["NODE_EXTRA_CA_CERTS"] == PROXY_CA_CONTAINER_PATH
+        assert env["AGENT_API_BASE"] == "http://host.docker.internal:8001/v1"
+    finally:
+        runner.cleanup_credential_tmps()
+
+
+def test_filtered_runner_prepares_proxy_audit_log():
+    runner = ContainerRunner(ContainerConfig(internet_policy=InternetPolicy.from_mode("filtered")))
+
+    try:
+        runner._prepare_egress_state()
+        assert runner._egress_tmp_dir is not None
+        blocked_log = runner._egress_tmp_dir / "blocked-requests.jsonl"
+
+        assert stat.S_IMODE(runner._egress_tmp_dir.stat().st_mode) == 0o711
+        assert stat.S_IMODE(blocked_log.stat().st_mode) == 0o622
+    finally:
+        runner.cleanup_egress_proxy()
+
+
+def test_open_runner_keeps_existing_host_network():
+    runner = ContainerRunner(ContainerConfig(internet_policy=InternetPolicy.from_mode("open")))
+
+    try:
+        args = runner._build_base_docker_args()
+        env_flags = runner._build_env_flags()
+
+        assert "--network=host" in args
+        env = dict(item.split("=", 1) for item in env_flags[1::2])
+        assert env["AGENT_INTERNET_ACCESS"] == "open"
+        assert "HTTPS_PROXY" not in env
+    finally:
+        runner.cleanup_credential_tmps()
+
+
+def test_codex_auth_mount_does_not_expose_writable_host_directory(monkeypatch, tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text('{"tokens": {}}')
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    runner = ContainerRunner()
+    args: list[str] = []
+
+    try:
+        runner._mount_codex_credentials(args)
+
+        mount = args[args.index("-v") + 1]
+        host_path, container_path, mode = mount.split(":")
+        assert Path(host_path).name == "auth.json"
+        assert container_path == "/root/.codex/auth.json"
+        assert mode == "ro"
+    finally:
+        credential_tmps = list(runner._credential_tmps)
+        runner.cleanup_credential_tmps()
+
+    assert all(not Path(path).exists() for path in credential_tmps)
+
+
+def test_filtered_runner_rewrites_loopback_kubeconfig(tmp_path):
+    source = tmp_path / "config"
+    source.write_text(
+        yaml.safe_dump(
+            {
+                "clusters": [{"name": "proxy", "cluster": {"server": "http://127.0.0.1:16443"}}],
+            }
+        )
+    )
+    runner = ContainerRunner(ContainerConfig(internet_policy=InternetPolicy.from_mode("filtered")))
+
+    try:
+        rewritten = runner._prepare_kubeconfig(source)
+        data = yaml.safe_load(Path(rewritten).read_text())
+        assert data["clusters"][0]["cluster"]["server"] == "http://host.docker.internal:16443"
+    finally:
+        runner.cleanup_credential_tmps()
+
+
+def test_filtered_mode_disables_claude_web_search(monkeypatch):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
+    assert "WebFetch" in ClaudeCodeAgent.allowed_tools()
+    assert "WebSearch" not in ClaudeCodeAgent.allowed_tools()
+
+
+def test_open_mode_keeps_claude_web_search(monkeypatch):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "open")
+    assert "WebFetch" in ClaudeCodeAgent.allowed_tools()
+    assert "WebSearch" in ClaudeCodeAgent.allowed_tools()
+
+
+def test_filtered_mode_disables_gemini_provider_web_tools(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
+    agent = GeminiCliAgent(logs_dir=tmp_path, model_name="gemini-2.5-pro")
+
+    command = agent._build_command("inspect the cluster")
+
+    assert "--exclude-tools google_web_search,web_fetch,browser_agent" in command
+
+
+def test_filtered_mode_disables_copilot_provider_web_tools(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
+    agent = CopilotCliAgent(logs_dir=tmp_path, model_name="gpt-5")
+
+    command = agent._build_command("inspect the cluster")
+
+    assert command[-2:] == ["--excluded-tools", "web_fetch,web_search"]
+
+
+def test_open_mode_keeps_gemini_and_copilot_web_tools(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "open")
+    gemini = GeminiCliAgent(logs_dir=tmp_path / "gemini", model_name="gemini-2.5-pro")
+    copilot = CopilotCliAgent(logs_dir=tmp_path / "copilot", model_name="gpt-5")
+
+    assert "--exclude-tools" not in gemini._build_command("inspect the cluster")
+    assert "--excluded-tools" not in copilot._build_command("inspect the cluster")
+
+
+def test_filtered_mode_rejects_non_container_agent():
+    launcher = AgentLauncher()
+    registration = AgentRegistration(name="local", kickoff_command="true", container_isolation=False)
+
+    with pytest.raises(RuntimeError, match="does not use container isolation"):
+        asyncio.run(launcher.ensure_started(registration))
+
+
+def test_conductor_config_defaults_to_filtered_internet():
+    assert ConductorConfig().internet_policy.is_filtered

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import stat
 from pathlib import Path
 
@@ -137,6 +138,7 @@ def test_filtered_runner_uses_private_network_and_proxy(tmp_path):
         assert "--network=host" not in args
         env = dict(item.split("=", 1) for item in env_flags[1::2])
         assert env["HTTPS_PROXY"] == "http://filter-proxy:8080"
+        assert env["NO_PROXY"] == ""
         assert env["SSL_CERT_FILE"] == PROXY_BUNDLE_CONTAINER_PATH
         assert env["NODE_EXTRA_CA_CERTS"] == PROXY_CA_CONTAINER_PATH
         assert env["AGENT_API_BASE"] == "http://host.docker.internal:8001/v1"
@@ -201,7 +203,7 @@ def test_filtered_runner_rewrites_loopback_kubeconfig(tmp_path):
     source.write_text(
         yaml.safe_dump(
             {
-                "clusters": [{"name": "proxy", "cluster": {"server": "http://127.0.0.1:16443"}}],
+                "clusters": [{"name": "proxy", "cluster": {"server": "https://127.0.0.1:16443"}}],
             }
         )
     )
@@ -210,7 +212,7 @@ def test_filtered_runner_rewrites_loopback_kubeconfig(tmp_path):
     try:
         rewritten = runner._prepare_kubeconfig(source)
         data = yaml.safe_load(Path(rewritten).read_text())
-        assert data["clusters"][0]["cluster"]["server"] == "http://host.docker.internal:16443"
+        assert data["clusters"][0]["cluster"]["server"] == "https://host.docker.internal:16443"
     finally:
         runner.cleanup_credential_tmps()
 
@@ -257,20 +259,30 @@ def test_kubernetes_proxy_requires_agent_bearer_token(authorization, expected):
 def test_kubernetes_proxy_kubeconfig_contains_private_token(tmp_path):
     proxy = KubernetesAPIProxy.__new__(KubernetesAPIProxy)
     proxy.listen_port = 16443
+    proxy.listen_host = "127.0.0.1"
     proxy._agent_token = "secret"
+    proxy._server_cert_pem = "-----BEGIN CERTIFICATE-----\nlocal\n-----END CERTIFICATE-----\n"
     path = tmp_path / "kubeconfig"
 
     proxy.generate_agent_kubeconfig(str(path))
 
     data = yaml.safe_load(path.read_text())
     assert data["users"][0]["user"]["token"] == "secret"
+    assert data["clusters"][0]["cluster"]["server"] == "https://127.0.0.1:16443"
+    assert (
+        base64.b64decode(data["clusters"][0]["cluster"]["certificate-authority-data"]).decode()
+        == proxy._server_cert_pem
+    )
+    assert "insecure-skip-tls-verify" not in data["clusters"][0]["cluster"]
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_kubernetes_proxy_removes_owned_kubeconfig_on_stop(tmp_path):
     proxy = KubernetesAPIProxy.__new__(KubernetesAPIProxy)
     proxy.listen_port = 16443
+    proxy.listen_host = "127.0.0.1"
     proxy._agent_token = "secret"
+    proxy._server_cert_pem = "-----BEGIN CERTIFICATE-----\nlocal\n-----END CERTIFICATE-----\n"
     proxy._temp_files = []
     proxy.server = None
     proxy.server_thread = None

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -21,19 +21,21 @@ from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
 
 
 @pytest.mark.parametrize(
-    ("host", "target", "body"),
+    ("host", "target", "body", "expected"),
     [
-        ("github.com", "/SREGym/SREGym", None),
-        ("github.com", "/orgs/sregym/repositories", None),
-        ("github.com", "/search?q=org%253ASREGym", None),
-        ("api.github.com", "/repos/SREGym/SREGym", None),
-        ("api.github.com", "/graphql", b'{"variables":{"owner":"SREGym"}}'),
-        ("raw.githubusercontent.com", "/SREGym/SREGym/main/README.md", None),
-        ("codeload.github.com", "/SREGym/SREGym/tar.gz/main", None),
+        ("github.com", "/SREGym/SREGym", None, "SREGym"),
+        ("github.com", "/orgs/sregym/repositories", None, "SREGym"),
+        ("github.com", "/search?q=org%253ASREGym", None, "SREGym"),
+        ("api.github.com", "/repos/SREGym/SREGym", None, "SREGym"),
+        ("api.github.com", "/graphql", b'{"variables":{"owner":"SREGym"}}', "SREGym"),
+        ("api.github.com", "/graphql", b'{"variables":{"owner":"S\\u0052EGym"}}', "SREGym"),
+        ("api.github.com", "/repositories/986527564/contents/README.md", None, "repository:986527564"),
+        ("raw.githubusercontent.com", "/SREGym/SREGym/main/README.md", None, "SREGym"),
+        ("codeload.github.com", "/SREGym/SREGym/tar.gz/main", None, "SREGym"),
     ],
 )
-def test_blocks_configured_github_owner(host, target, body):
-    assert blocked_github_owner(host, target, body) == "SREGym"
+def test_blocks_configured_github_owner(host, target, body, expected):
+    assert blocked_github_owner(host, target, body) == expected
 
 
 @pytest.mark.parametrize(
@@ -47,6 +49,21 @@ def test_blocks_configured_github_owner(host, target, body):
 )
 def test_allows_other_github_owners_and_hosts(host, target):
     assert blocked_github_owner(host, target, None) is None
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "/kubernetes/../SREGym/SREGym/blob/main/README.md",
+        "/kubernetes/%2e%2e/SREGym/SREGym/blob/main/README.md",
+    ],
+)
+def test_resolves_dot_segments_before_applying_github_policy(target):
+    assert blocked_github_owner("github.com", target, None) == "SREGym"
+
+
+def test_allows_unconfigured_numeric_github_repository_id():
+    assert blocked_github_owner("api.github.com", "/repositories/12345/contents/README.md", None) is None
 
 
 def test_filtered_runner_uses_private_network_and_proxy(tmp_path):
@@ -167,7 +184,13 @@ def test_filtered_mode_disables_gemini_provider_web_tools(monkeypatch, tmp_path)
 
     command = agent._build_command("inspect the cluster")
 
-    assert "--exclude-tools google_web_search,web_fetch,browser_agent" in command
+    assert "--exclude-tools" not in command
+    settings_file = agent._prepare_filtered_settings()
+    assert settings_file is not None
+    try:
+        assert '"google_web_search"' in settings_file.read_text()
+    finally:
+        settings_file.unlink()
 
 
 def test_filtered_mode_disables_copilot_provider_web_tools(monkeypatch, tmp_path):
@@ -176,7 +199,12 @@ def test_filtered_mode_disables_copilot_provider_web_tools(monkeypatch, tmp_path
 
     command = agent._build_command("inspect the cluster")
 
-    assert command[-2:] == ["--excluded-tools", "web_fetch,web_search"]
+    assert command[-4:] == [
+        "--excluded-tools",
+        "web_fetch,web_search",
+        "--disable-mcp-server",
+        "github-mcp-server",
+    ]
 
 
 def test_open_mode_keeps_gemini_and_copilot_web_tools(monkeypatch, tmp_path):
@@ -186,6 +214,7 @@ def test_open_mode_keeps_gemini_and_copilot_web_tools(monkeypatch, tmp_path):
 
     assert "--exclude-tools" not in gemini._build_command("inspect the cluster")
     assert "--excluded-tools" not in copilot._build_command("inspect the cluster")
+    assert "--disable-mcp-server" not in copilot._build_command("inspect the cluster")
 
 
 def test_filtered_mode_rejects_non_container_agent():

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -16,8 +16,10 @@ from sregym.service.container_runner import (
     PROXY_CA_CONTAINER_PATH,
     ContainerConfig,
     ContainerRunner,
+    _find_host_ca_bundle,
 )
 from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
+from sregym.service.k8s_proxy import KubernetesAPIProxy, _is_workload_create_path, is_valid_bearer_token
 
 
 @pytest.mark.parametrize(
@@ -32,6 +34,8 @@ from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
         ("api.github.com", "/repositories/986527564/contents/README.md", None, "repository:986527564"),
         ("raw.githubusercontent.com", "/SREGym/SREGym/main/README.md", None, "SREGym"),
         ("codeload.github.com", "/SREGym/SREGym/tar.gz/main", None, "SREGym"),
+        ("cdn.jsdelivr.net", "/gh/someone/SREGym@main/README.md", None, "repository:sregym"),
+        ("raw.githack.com", "/someone/SREGym/main/README.md", None, "repository:sregym"),
     ],
 )
 def test_blocks_configured_github_owner(host, target, body, expected):
@@ -64,6 +68,51 @@ def test_resolves_dot_segments_before_applying_github_policy(target):
 
 def test_allows_unconfigured_numeric_github_repository_id():
     assert blocked_github_owner("api.github.com", "/repositories/12345/contents/README.md", None) is None
+
+
+def test_ignores_unrelated_query_and_json_text():
+    assert blocked_github_owner("github.com", "/kubernetes/kubernetes?note=not-sregymnasium", None) is None
+    assert (
+        blocked_github_owner(
+            "api.github.com",
+            "/graphql",
+            b'{"variables":{"note":"SREGym"}}',
+        )
+        is None
+    )
+
+
+def test_filtered_runner_rewrites_all_local_provider_endpoints(tmp_path):
+    runner = ContainerRunner(
+        ContainerConfig(
+            internet_policy=InternetPolicy.from_mode("filtered"),
+            env_vars={
+                "AGENT_API_BASE": "http://127.0.0.1:8001/v1",
+                "OPENAI_BASE_URL": "http://localhost:11434/v1",
+                "ANTHROPIC_API_BASE": "http://[::1]:9000",
+                "UNRELATED_VALUE": "http://127.0.0.1:9999",
+            },
+        )
+    )
+    runner._egress_network_name = "private-network"
+    runner._egress_proxy_name = "filter-proxy"
+    runner._egress_proxy_ca = tmp_path / "proxy-ca.pem"
+    runner._egress_ca_bundle = tmp_path / "ca-bundle.pem"
+    runner._egress_proxy_ca.touch()
+    runner._egress_ca_bundle.touch()
+
+    try:
+        env = dict(item.split("=", 1) for item in runner._build_env_flags()[1::2])
+        assert env["AGENT_API_BASE"] == "http://host.docker.internal:8001/v1"
+        assert env["OPENAI_BASE_URL"] == "http://host.docker.internal:11434/v1"
+        assert env["ANTHROPIC_API_BASE"] == "http://host.docker.internal:9000"
+        assert env["UNRELATED_VALUE"] == "http://127.0.0.1:9999"
+    finally:
+        runner.cleanup_credential_tmps()
+
+
+def test_host_ca_bundle_is_available():
+    assert _find_host_ca_bundle().is_file()
 
 
 def test_filtered_runner_uses_private_network_and_proxy(tmp_path):
@@ -191,6 +240,67 @@ def test_filtered_runner_does_not_mount_unproxied_kubeconfig(tmp_path, monkeypat
         runner.cleanup_credential_tmps()
 
 
+@pytest.mark.parametrize(
+    ("authorization", "expected"),
+    [
+        ("Bearer secret", True),
+        ("bearer secret", True),
+        ("Bearer wrong", False),
+        (None, False),
+        ("Basic secret", False),
+    ],
+)
+def test_kubernetes_proxy_requires_agent_bearer_token(authorization, expected):
+    assert is_valid_bearer_token(authorization, "secret") is expected
+
+
+def test_kubernetes_proxy_kubeconfig_contains_private_token(tmp_path):
+    proxy = KubernetesAPIProxy.__new__(KubernetesAPIProxy)
+    proxy.listen_port = 16443
+    proxy._agent_token = "secret"
+    path = tmp_path / "kubeconfig"
+
+    proxy.generate_agent_kubeconfig(str(path))
+
+    data = yaml.safe_load(path.read_text())
+    assert data["users"][0]["user"]["token"] == "secret"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_kubernetes_proxy_removes_owned_kubeconfig_on_stop(tmp_path):
+    proxy = KubernetesAPIProxy.__new__(KubernetesAPIProxy)
+    proxy.listen_port = 16443
+    proxy._agent_token = "secret"
+    proxy._temp_files = []
+    proxy.server = None
+    proxy.server_thread = None
+    proxy._agent_kubeconfig_path = None
+    path = proxy.generate_agent_kubeconfig()
+
+    try:
+        assert Path(path).is_file()
+        proxy.stop()
+        assert not Path(path).exists()
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/api/v1/namespaces/demo/pods", True),
+        ("/api/v1/namespaces/demo/%70ods", True),
+        ("/api/v1/namespaces/demo/%2570ods", True),
+        ("/apis/batch/v1/namespaces/demo/jobs", True),
+        ("/apis/apps/v1/namespaces/demo/deployments", True),
+        ("/apis/apps/v1/namespaces/demo/deployments/demo", False),
+        ("/api/v1/namespaces/demo/services", False),
+    ],
+)
+def test_filtered_proxy_blocks_workload_creation_paths(path, expected):
+    assert _is_workload_create_path(path) is expected
+
+
 def test_filtered_mode_disables_claude_web_search(monkeypatch):
     monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
     assert "WebFetch" in ClaudeCodeAgent.allowed_tools()
@@ -252,3 +362,13 @@ def test_filtered_mode_rejects_non_container_agent():
 
 def test_conductor_config_defaults_to_filtered_internet():
     assert ConductorConfig().internet_policy.is_filtered
+
+
+def test_agent_launcher_cleanup_resets_container_runner():
+    launcher = AgentLauncher()
+    runner = ContainerRunner()
+    launcher._container_runner = runner
+
+    launcher.cleanup_all()
+
+    assert launcher._container_runner is None

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -166,6 +166,31 @@ def test_filtered_runner_rewrites_loopback_kubeconfig(tmp_path):
         runner.cleanup_credential_tmps()
 
 
+def test_filtered_runner_does_not_mount_unproxied_kubeconfig(tmp_path, monkeypatch):
+    source = tmp_path / "config"
+    source.write_text("apiVersion: v1\nkind: Config\n")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    runner = ContainerRunner(
+        ContainerConfig(
+            internet_policy=InternetPolicy.from_mode("filtered"),
+            kubeconfig_path=source,
+        )
+    )
+    runner._egress_network_name = "private-network"
+    runner._egress_proxy_ca = tmp_path / "proxy-ca.pem"
+    runner._egress_ca_bundle = tmp_path / "ca-bundle.pem"
+    runner._egress_proxy_ca.touch()
+    runner._egress_ca_bundle.touch()
+
+    try:
+        args = runner._build_base_docker_args()
+        assert "/root/.kube/config:ro" in " ".join(args)
+        assert "/root/.kube/real-config:ro" not in " ".join(args)
+        assert "SREGYM_REAL_KUBECONFIG" not in args
+    finally:
+        runner.cleanup_credential_tmps()
+
+
 def test_filtered_mode_disables_claude_web_search(monkeypatch):
     monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
     assert "WebFetch" in ClaudeCodeAgent.allowed_tools()


### PR DESCRIPTION
Containerized agents currently have unrestricted internet access during evaluations. This allows an agent to read the SREGym repository and learn fault implementation details instead of diagnosing the deployed system.

This change makes filtered internet access the default. Agents can still contact model providers and use the public internet, but requests to the SREGym repository are blocked through a per-run network proxy. Provider-side web and GitHub tools that could bypass this proxy are also disabled. The previous unrestricted behavior remains available through `--internet-access open`.

Kubernetes access remains available through an authenticated TLS proxy. The unfiltered kubeconfig is no longer mounted inside agent containers, and filtered agents cannot create temporary workloads to access the repository through the cluster network. They can still inspect and modify existing workloads during diagnosis and mitigation.

The proxy, temporary credentials, Docker network, and audit files are cleaned after each run. Run results now record the selected internet policy and the number of blocked requests. The README also explains how local model servers must be exposed to filtered agent containers.

This prevents direct access to the benchmark repository. It is not intended to block every possible public copy of the source. We can later expand this to block other sites if needed.

The implementation was tested with Claude Code and Codex on Kind and a live Kubernetes cluster.

Closes #911