### PR TITLE
Protect Helm release secrets from agents

### DIFF
--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -23,9 +23,10 @@ import ssl
 import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, unquote, urlparse, urlsplit
 
 import urllib3
+import yaml
 from kubernetes import config
 
 logger = logging.getLogger("all.infra.k8s_proxy")
@@ -42,6 +43,230 @@ HIDDEN_LABELS: dict[str, set[str]] = {
     "job": {"workload"},
     "opentelemetry.io/name": {"load-generator"},
 }
+
+# Helm stores each release revision in a Secret by default. These Secrets contain
+# the complete rendered chart, including the application's pre-fault manifests.
+HELM_RELEASE_SECRET_TYPE = "helm.sh/release.v1"
+HELM_RELEASE_SECRET_NAME_PREFIX = "sh.helm.release.v1."
+WORKLOAD_RESOURCES = {
+    "cronjobs",
+    "daemonsets",
+    "deployments",
+    "jobs",
+    "pods",
+    "replicasets",
+    "replicationcontrollers",
+    "statefulsets",
+}
+STRUCTURED_KUBERNETES_CONTENT_TYPES = {
+    "application/apply-patch+yaml",
+    "application/json",
+    "application/json-patch+json",
+    "application/merge-patch+json",
+    "application/strategic-merge-patch+json",
+    "application/yaml",
+}
+
+
+def _decode_path_parts(path: str) -> list[str]:
+    """Return normalized path segments after decoding nested URL encoding."""
+    decoded_path = urlsplit(path).path
+    for _ in range(3):
+        next_path = unquote(decoded_path)
+        if next_path == decoded_path:
+            break
+        decoded_path = next_path
+
+    parts: list[str] = []
+    for part in decoded_path.split("/"):
+        if not part or part == ".":
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    return parts
+
+
+def _resource_request(path: str) -> tuple[str | None, str | None]:
+    """Return the Kubernetes resource and optional object name in an API path."""
+    parts = _decode_path_parts(path)
+    if len(parts) >= 2 and parts[0] == "api":
+        resource_index = 2
+    elif len(parts) >= 3 and parts[0] == "apis":
+        resource_index = 3
+    else:
+        return None, None
+
+    if len(parts) <= resource_index:
+        return None, None
+
+    # A namespaced resource path contains /namespaces/{namespace}/{resource}.
+    # /api/v1/namespaces and /api/v1/namespaces/{name} are Namespace paths.
+    if parts[resource_index] == "namespaces" and len(parts) >= resource_index + 3:
+        resource_index += 2
+
+    resource = parts[resource_index]
+    name = parts[resource_index + 1] if len(parts) > resource_index + 1 else None
+    return resource, name
+
+
+def _is_watch_request(path: str) -> bool:
+    """Return whether a Kubernetes request asks for a watch stream."""
+    query = urlsplit(path).query
+    for _ in range(3):
+        next_query = unquote(query)
+        if next_query == query:
+            break
+        query = next_query
+    values = parse_qs(query, keep_blank_values=True).get("watch", [])
+    return any(value.lower() in {"1", "true"} for value in values)
+
+
+def _is_helm_release_secret(resource: dict) -> bool:
+    """Return whether a Kubernetes object is Helm's stored release record."""
+    metadata = resource.get("metadata") or {}
+    name = metadata.get("name") or ""
+    return resource.get("type") == HELM_RELEASE_SECRET_TYPE or name.startswith(HELM_RELEASE_SECRET_NAME_PREFIX)
+
+
+def _has_hidden_label(metadata: dict, hidden_labels: dict[str, set[str]]) -> bool:
+    """Return whether resource metadata contains a configured hidden label."""
+    labels = metadata.get("labels") or {}
+    return any(labels.get(key) in values for key, values in hidden_labels.items())
+
+
+def _is_hidden_resource(
+    resource: dict,
+    hidden_namespaces: set[str],
+    hidden_labels: dict[str, set[str]],
+) -> bool:
+    """Return whether a Kubernetes object must not be visible to an agent."""
+    metadata = resource.get("metadata") or {}
+    return (
+        metadata.get("namespace") in hidden_namespaces
+        or _has_hidden_label(metadata, hidden_labels)
+        or _is_helm_release_secret(resource)
+    )
+
+
+def _filter_namespace_list(data: dict, hidden_namespaces: set[str]) -> dict:
+    """Remove hidden namespaces from standard and Table list responses."""
+    if "items" in data:
+        data["items"] = [
+            item for item in data["items"] if item.get("metadata", {}).get("name") not in hidden_namespaces
+        ]
+    if "rows" in data:
+        data["rows"] = [
+            row
+            for row in data["rows"]
+            if isinstance(row.get("object"), dict)
+            and row["object"].get("metadata", {}).get("name") not in hidden_namespaces
+        ]
+    return data
+
+
+def _filter_resource_list(
+    data: dict,
+    hidden_namespaces: set[str],
+    hidden_labels: dict[str, set[str]],
+) -> dict:
+    """Remove hidden objects from standard and Table list responses."""
+    if "items" in data:
+        data["items"] = [
+            item for item in data["items"] if not _is_hidden_resource(item, hidden_namespaces, hidden_labels)
+        ]
+    if "rows" in data:
+        data["rows"] = [
+            row
+            for row in data["rows"]
+            if isinstance(row.get("object"), dict)
+            and not _is_hidden_resource(row["object"], hidden_namespaces, hidden_labels)
+        ]
+    return data
+
+
+def _is_hidden_namespace_request(path: str, hidden_namespaces: set[str]) -> bool:
+    """Return whether a decoded API path addresses a hidden namespace."""
+    parts = _decode_path_parts(path)
+    for index, part in enumerate(parts):
+        if part == "namespaces" and index + 1 < len(parts) and parts[index + 1] in hidden_namespaces:
+            return True
+    return False
+
+
+def _response_filter_type(path: str) -> str | None:
+    """Return the list-response filter required for a Kubernetes API path."""
+    resource, name = _resource_request(path)
+    if resource == "namespaces" and name is None:
+        return "namespaces"
+    if resource is not None and name is None:
+        return "resources"
+    return None
+
+
+def _is_helm_release_secret_request(path: str) -> bool:
+    """Return whether a path directly addresses a Helm release Secret."""
+    resource, name = _resource_request(path)
+    return resource == "secrets" and bool(name and name.startswith(HELM_RELEASE_SECRET_NAME_PREFIX))
+
+
+def _is_secret_collection_delete(path: str, method: str) -> bool:
+    """Return whether a request can bulk-delete Helm release Secrets."""
+    resource, name = _resource_request(path)
+    return method == "DELETE" and resource == "secrets" and name is None
+
+
+def _is_secret_watch_request(path: str) -> bool:
+    """Return whether a request can stream Helm release Secret events."""
+    resource, _ = _resource_request(path)
+    return resource == "secrets" and _is_watch_request(path)
+
+
+def _requires_json_secret_response(path: str, method: str) -> bool:
+    """Return whether the proxy must inspect a Secret response as JSON."""
+    resource, _ = _resource_request(path)
+    return method == "GET" and resource == "secrets"
+
+
+def _contains_helm_release_secret_name(value) -> bool:
+    """Return whether structured request data refers to a Helm release Secret."""
+    if isinstance(value, str):
+        return value.startswith(HELM_RELEASE_SECRET_NAME_PREFIX)
+    if isinstance(value, list):
+        return any(_contains_helm_release_secret_name(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_helm_release_secret_name(item) for item in value.values())
+    return False
+
+
+def _inspect_workload_request(path: str, method: str, body: bytes | None, content_type: str) -> str | None:
+    """Inspect workload mutations for references to a protected Helm Secret.
+
+    Returns ``forbidden`` for a Helm Secret reference, ``unsupported`` when a
+    workload body cannot be inspected safely, and ``None`` when it is safe.
+    """
+    resource, _ = _resource_request(path)
+    if method not in {"POST", "PUT", "PATCH"} or resource not in WORKLOAD_RESOURCES or not body:
+        return None
+
+    media_type = content_type.partition(";")[0].strip().lower()
+    if media_type not in STRUCTURED_KUBERNETES_CONTENT_TYPES:
+        return "unsupported"
+
+    try:
+        if media_type.endswith("+yaml") or media_type == "application/yaml":
+            data = yaml.safe_load(body)
+        else:
+            data = json.loads(body)
+    except (UnicodeDecodeError, ValueError, yaml.YAMLError):
+        return "unsupported"
+
+    if _contains_helm_release_secret_name(data):
+        return "forbidden"
+    return None
+
 
 # Disable SSL warnings for self-signed certs
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -100,8 +325,6 @@ class KubernetesAPIProxy:
         cluster_name = active_context["context"]["cluster"]
         user_name = active_context["context"]["user"]
         with open(kubeconfig_path) as f:
-            import yaml
-
             kubeconfig = yaml.safe_load(f)
 
         # Find cluster config
@@ -208,112 +431,65 @@ class KubernetesAPIProxy:
 
                 return http.client.HTTPSConnection(api_host, api_port, context=context)
 
-            def _is_hidden_namespace_request(self, path: str) -> bool:
-                """Check if request is for a hidden namespace."""
-                # Direct namespace access: /api/v1/namespaces/{namespace}
-                # Resources in namespace: /api/v1/namespaces/{namespace}/...
-                # or /apis/{group}/{version}/namespaces/{namespace}/...
-                parts = path.split("/")
-                for i, part in enumerate(parts):
-                    if part == "namespaces" and i + 1 < len(parts):
-                        ns = parts[i + 1].split("?")[0]  # Remove query params
-                        if ns in hidden_namespaces:
-                            return True
-                return False
-
-            def _filter_namespace_list(self, data: dict) -> dict:
-                """Filter hidden namespaces from namespace list response."""
-                # Handle standard List format
-                if "items" in data:
-                    data["items"] = [
-                        item for item in data["items"] if item.get("metadata", {}).get("name") not in hidden_namespaces
-                    ]
-                # Handle Table format (kubectl's default)
-                if "rows" in data:
-                    data["rows"] = [
-                        row
-                        for row in data["rows"]
-                        if row.get("object", {}).get("metadata", {}).get("name") not in hidden_namespaces
-                    ]
-                return data
-
-            def _has_hidden_label(self, metadata: dict) -> bool:
-                """Check if a resource's metadata contains any hidden labels."""
-                labels = metadata.get("labels") or {}
-                return any(labels.get(key) in values for key, values in hidden_labels.items())
-
-            def _filter_resource_list(self, data: dict) -> dict:
-                """Filter resources in hidden namespaces or with hidden labels from list responses."""
-                # Handle standard List format
-                if "items" in data:
-                    data["items"] = [
-                        item
-                        for item in data["items"]
-                        if item.get("metadata", {}).get("namespace") not in hidden_namespaces
-                        and not self._has_hidden_label(item.get("metadata", {}))
-                    ]
-                # Handle Table format (kubectl's default)
-                if "rows" in data:
-                    data["rows"] = [
-                        row
-                        for row in data["rows"]
-                        if row.get("object", {}).get("metadata", {}).get("namespace") not in hidden_namespaces
-                        and not self._has_hidden_label(row.get("object", {}).get("metadata", {}))
-                    ]
-                return data
-
-            def _should_filter_response(self, path: str) -> str | None:
-                """
-                Determine if response should be filtered and return filter type.
-                Returns: 'namespaces', 'resources', or None
-                """
-                # Namespace list: /api/v1/namespaces
-                if path.rstrip("/") == "/api/v1/namespaces" or path.startswith("/api/v1/namespaces?"):
-                    return "namespaces"
-
-                # Cluster-wide resource listings (not namespaced)
-                # e.g., /api/v1/pods, /api/v1/events, /apis/apps/v1/deployments
-                if "/namespaces/" not in path:
-                    # Check if this is a list of namespaced resources
-                    resource_patterns = [
-                        "/api/v1/pods",
-                        "/api/v1/services",
-                        "/api/v1/events",
-                        "/api/v1/configmaps",
-                        "/api/v1/secrets",
-                        "/api/v1/endpoints",
-                        "/api/v1/persistentvolumeclaims",
-                        "/apis/apps/v1/deployments",
-                        "/apis/apps/v1/replicasets",
-                        "/apis/apps/v1/statefulsets",
-                        "/apis/apps/v1/daemonsets",
-                        "/apis/batch/v1/jobs",
-                        "/apis/batch/v1/cronjobs",
-                    ]
-                    for pattern in resource_patterns:
-                        if path.startswith(pattern):
-                            return "resources"
-
-                return None
-
             def _proxy_request(self, method: str):
                 """Proxy request to upstream API and filter response."""
                 path = self.path
 
                 # Block direct access to hidden namespaces
-                if self._is_hidden_namespace_request(path):
+                if _is_hidden_namespace_request(path, hidden_namespaces):
                     self.send_error(403, "Forbidden: Access to this namespace is not allowed")
+                    return
+
+                # A Helm release Secret is benchmark source data, not runtime
+                # evidence. Block direct access before forwarding so an agent
+                # cannot read, relabel, replace, or delete the stored manifest.
+                if _is_helm_release_secret_request(path):
+                    self.send_error(403, "Forbidden: Access to this resource is not allowed")
+                    return
+
+                # A Secret watch would stream the filtered records as events.
+                if _is_secret_watch_request(path):
+                    self.send_error(403, "Forbidden: Watching Secrets is not allowed")
+                    return
+
+                # DELETE on a Secret collection can target Helm records through
+                # a label or field selector without putting their names in the URL.
+                if _is_secret_collection_delete(path, method):
+                    self.send_error(403, "Forbidden: Bulk deletion of Secrets is not allowed")
                     return
 
                 # Read request body if present
                 content_length = int(self.headers.get("Content-Length", 0))
                 body = self.rfile.read(content_length) if content_length > 0 else None
 
+                workload_inspection = _inspect_workload_request(
+                    path,
+                    method,
+                    body,
+                    self.headers.get("Content-Type", ""),
+                )
+                if workload_inspection == "forbidden":
+                    self.send_error(403, "Forbidden: Workloads cannot reference this Secret")
+                    return
+                if workload_inspection == "unsupported":
+                    self.send_error(415, "Unsupported Media Type: Workload request body cannot be inspected")
+                    return
+
                 # Forward request to upstream
                 try:
                     conn = self._get_upstream_connection()
+                    filter_type = _response_filter_type(path)
+                    requires_json = _requires_json_secret_response(path, method) or (
+                        method == "GET" and filter_type is not None and not _is_watch_request(path)
+                    )
                     # Forward headers (except Host and Accept-Encoding to avoid gzip)
-                    headers = {k: v for k, v in self.headers.items() if k.lower() not in ("host", "accept-encoding")}
+                    excluded_headers = {"host", "accept-encoding"}
+                    if requires_json:
+                        excluded_headers.add("accept")
+                    headers = {k: v for k, v in self.headers.items() if k.lower() not in excluded_headers}
+                    if requires_json:
+                        # The proxy cannot safely filter Kubernetes' protobuf form.
+                        headers["Accept"] = "application/json"
                     # In-cluster mode: authenticate to the API server with the ServiceAccount bearer token
                     if bearer_token:
                         headers["Authorization"] = f"Bearer {bearer_token}"
@@ -331,24 +507,32 @@ class KubernetesAPIProxy:
 
                         response_body = gzip.decompress(response_body)
 
-                    # Filter JSON responses if needed
-                    filter_type = self._should_filter_response(path)
+                    # Filter successful JSON responses. Secret reads and resource
+                    # lists fail closed if the upstream does not return usable JSON.
+                    if response.status == 200 and requires_json and "application/json" not in content_type:
+                        self.send_error(502, "Bad Gateway: Kubernetes returned an unsupported response format")
+                        conn.close()
+                        return
+
                     if response.status == 200 and "application/json" in content_type:
                         try:
                             data = json.loads(response_body)
                             if filter_type == "namespaces":
-                                data = self._filter_namespace_list(data)
+                                data = _filter_namespace_list(data, hidden_namespaces)
                                 response_body = json.dumps(data).encode()
                             elif filter_type == "resources":
-                                data = self._filter_resource_list(data)
+                                data = _filter_resource_list(data, hidden_namespaces, hidden_labels)
                                 response_body = json.dumps(data).encode()
-                            elif filter_type is None and self._has_hidden_label(data.get("metadata", {})):
+                            elif filter_type is None and _is_hidden_resource(data, hidden_namespaces, hidden_labels):
                                 # Block direct access to individual hidden resources
                                 self.send_error(403, "Forbidden: Access to this resource is not allowed")
                                 conn.close()
                                 return
                         except json.JSONDecodeError:
-                            pass  # Not valid JSON, pass through as-is
+                            if requires_json:
+                                self.send_error(502, "Bad Gateway: Kubernetes returned invalid JSON")
+                                conn.close()
+                                return
 
                     # Send response to client
                     self.send_response(response.status)

--- a/tests/service/test_k8s_proxy.py
+++ b/tests/service/test_k8s_proxy.py
@@ -1,0 +1,337 @@
+import copy
+import http.client
+import json
+
+import pytest
+
+from sregym.service.k8s_proxy import (
+    HELM_RELEASE_SECRET_NAME_PREFIX,
+    HELM_RELEASE_SECRET_TYPE,
+    KubernetesAPIProxy,
+    _filter_resource_list,
+    _inspect_workload_request,
+    _is_helm_release_secret,
+    _is_helm_release_secret_request,
+    _is_hidden_namespace_request,
+    _is_secret_collection_delete,
+    _is_secret_watch_request,
+    _requires_json_secret_response,
+    _response_filter_type,
+)
+
+HELM_SECRET_NAME = f"{HELM_RELEASE_SECRET_NAME_PREFIX}astronomy-shop.v1"
+HELM_SECRET = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+        "name": HELM_SECRET_NAME,
+        "namespace": "astronomy-shop",
+        "labels": {"owner": "helm"},
+    },
+    "type": HELM_RELEASE_SECRET_TYPE,
+    "data": {"release": "pre-fault-manifest"},
+}
+ORDINARY_SECRET = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {"name": "checkout-credentials", "namespace": "astronomy-shop"},
+    "type": "Opaque",
+    "data": {"password": "runtime-secret"},
+}
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, content_type: str = "application/json", status: int = 200):
+        self.status = status
+        self._body = body
+        self._headers = [("Content-Type", content_type), ("Content-Length", str(len(body)))]
+
+    def read(self) -> bytes:
+        return self._body
+
+    def getheader(self, name: str, default: str = "") -> str:
+        return dict(self._headers).get(name, default)
+
+    def getheaders(self) -> list[tuple[str, str]]:
+        return self._headers
+
+
+class FakeHTTPSConnection:
+    requests: list[tuple[str, str, dict[str, str]]] = []
+    response = FakeResponse(b"{}")
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def request(self, method: str, path: str, body=None, headers=None):
+        self.requests.append((method, path, headers or {}))
+
+    def getresponse(self) -> FakeResponse:
+        return self.response
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def proxy(monkeypatch):
+    FakeHTTPSConnection.requests = []
+    FakeHTTPSConnection.response = FakeResponse(b"{}")
+    monkeypatch.setattr(http.client, "HTTPSConnection", FakeHTTPSConnection)
+
+    instance = object.__new__(KubernetesAPIProxy)
+    instance.hidden_namespaces = {"chaos-mesh", "khaos"}
+    instance.hidden_labels = {"app": {"load-generator"}}
+    instance.listen_port = 0
+    instance.server = None
+    instance.server_thread = None
+    instance._temp_files = []
+    instance._bearer_token = None
+    instance.ca_cert = None
+    instance.client_cert = None
+    instance.client_key = None
+    instance.api_host = "kubernetes.example"
+    instance.api_port = 443
+    instance.start()
+    try:
+        yield instance
+    finally:
+        instance.stop()
+
+
+def request(
+    proxy: KubernetesAPIProxy,
+    path: str,
+    method: str = "GET",
+    headers: dict | None = None,
+    body: bytes | None = None,
+):
+    port = proxy.server.server_address[1]
+    connection = http.client.HTTPConnection("127.0.0.1", port)
+    connection.request(method, path, body=body, headers=headers or {})
+    response = connection.getresponse()
+    result = response.status, response.headers, response.read()
+    connection.close()
+    return result
+
+
+def test_helm_release_detection_does_not_depend_on_labels():
+    secret = copy.deepcopy(HELM_SECRET)
+    secret["metadata"]["labels"] = {}
+
+    assert _is_helm_release_secret(secret)
+    assert not _is_helm_release_secret(ORDINARY_SECRET)
+
+
+def test_helm_release_type_is_hidden_even_with_an_unexpected_name():
+    secret = copy.deepcopy(HELM_SECRET)
+    secret["metadata"]["name"] = "unexpected-name"
+
+    assert _is_helm_release_secret(secret)
+
+
+def test_resource_lists_hide_helm_records_but_keep_ordinary_secrets():
+    result = _filter_resource_list(
+        {"items": [copy.deepcopy(HELM_SECRET), copy.deepcopy(ORDINARY_SECRET)]},
+        hidden_namespaces=set(),
+        hidden_labels={},
+    )
+
+    assert result["items"] == [ORDINARY_SECRET]
+
+
+def test_resource_lists_still_hide_configured_labels_and_namespaces():
+    ordinary_pod = {"metadata": {"name": "frontend", "namespace": "astronomy-shop"}}
+    load_generator = {
+        "metadata": {"name": "load-generator", "namespace": "astronomy-shop", "labels": {"app": "load-generator"}}
+    }
+    chaos_pod = {"metadata": {"name": "chaos", "namespace": "chaos-mesh"}}
+
+    result = _filter_resource_list(
+        {"items": [ordinary_pod, load_generator, chaos_pod]},
+        hidden_namespaces={"chaos-mesh"},
+        hidden_labels={"app": {"load-generator"}},
+    )
+
+    assert result["items"] == [ordinary_pod]
+
+
+def test_table_responses_hide_helm_records():
+    result = _filter_resource_list(
+        {"rows": [{"object": copy.deepcopy(HELM_SECRET)}, {"object": copy.deepcopy(ORDINARY_SECRET)}]},
+        hidden_namespaces=set(),
+        hidden_labels={},
+    )
+
+    assert result["rows"] == [{"object": ORDINARY_SECRET}]
+
+
+def test_uninspectable_table_rows_fail_closed():
+    result = _filter_resource_list(
+        {"rows": [{"cells": [HELM_SECRET_NAME], "object": None}]},
+        hidden_namespaces=set(),
+        hidden_labels={},
+    )
+
+    assert result["rows"] == []
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"/api/v1/namespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}",
+        f"/api/v1/namespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}/status",
+        f"/api/v1/%6eamespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}",
+        f"/api/v1/%256eamespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}",
+        f"/api/v1/namespaces/astronomy-shop/%73ecrets/{HELM_SECRET_NAME}",
+    ],
+)
+def test_direct_helm_release_paths_are_recognized_after_decoding(path):
+    assert _is_helm_release_secret_request(path)
+
+
+def test_namespaced_and_encoded_lists_are_filtered():
+    assert _response_filter_type("/api/v1/namespaces/astronomy-shop/secrets") == "resources"
+    assert _response_filter_type("/api/v1/%6eamespaces/astronomy-shop/secrets") == "resources"
+    assert _response_filter_type("/apis/apps/v1/namespaces/default/deployments") == "resources"
+
+
+def test_encoded_hidden_namespace_path_is_blocked():
+    path = "/api/v1/%6eamespaces/chaos-mesh/pods"
+    assert _is_hidden_namespace_request(path, {"chaos-mesh"})
+
+
+@pytest.mark.parametrize("watch_value", ["true", "TRUE", "1"])
+def test_secret_watches_are_recognized(watch_value):
+    path = f"/api/v1/namespaces/astronomy-shop/secrets?watch={watch_value}"
+    assert _is_secret_watch_request(path)
+
+
+def test_encoded_secret_watch_is_recognized():
+    assert _is_secret_watch_request("/api/v1/namespaces/default/%73ecrets?w%61tch=true")
+
+
+def test_only_secret_collection_deletes_are_blocked():
+    path = "/api/v1/namespaces/astronomy-shop/secrets?labelSelector=owner%3Dhelm"
+    assert _is_secret_collection_delete(path, "DELETE")
+    assert not _is_secret_collection_delete(path, "GET")
+    direct_path = f"/api/v1/namespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}"
+    assert not _is_secret_collection_delete(direct_path, "DELETE")
+
+
+def test_secret_gets_require_json_but_other_methods_do_not():
+    path = "/api/v1/namespaces/astronomy-shop/secrets"
+    assert _requires_json_secret_response(path, "GET")
+    assert not _requires_json_secret_response(path, "POST")
+
+
+@pytest.mark.parametrize(
+    ("content_type", "body"),
+    [
+        (
+            "application/json",
+            json.dumps({"spec": {"volumes": [{"secret": {"secretName": HELM_SECRET_NAME}}]}}).encode(),
+        ),
+        (
+            "application/apply-patch+yaml",
+            f"spec:\n  volumes:\n    - secret:\n        secretName: {HELM_SECRET_NAME}\n".encode(),
+        ),
+        (
+            "application/json-patch+json",
+            json.dumps([{"op": "add", "path": "/spec/volumes/0", "value": {"secretName": HELM_SECRET_NAME}}]).encode(),
+        ),
+    ],
+)
+def test_workload_secret_references_are_rejected(content_type, body):
+    path = "/api/v1/namespaces/astronomy-shop/pods"
+    assert _inspect_workload_request(path, "POST", body, content_type) == "forbidden"
+
+
+def test_ordinary_workload_secret_reference_is_allowed():
+    path = "/apis/apps/v1/namespaces/astronomy-shop/deployments/frontend"
+    body = json.dumps({"spec": {"volumes": [{"secret": {"secretName": "checkout-credentials"}}]}}).encode()
+
+    assert _inspect_workload_request(path, "PATCH", body, "application/strategic-merge-patch+json") is None
+
+
+def test_uninspectable_workload_body_is_rejected():
+    path = "/api/v1/namespaces/astronomy-shop/pods"
+    assert _inspect_workload_request(path, "POST", b"protobuf", "application/vnd.kubernetes.protobuf") == "unsupported"
+
+
+@pytest.mark.parametrize("method", ["GET", "PATCH", "PUT", "DELETE"])
+def test_direct_helm_release_access_is_blocked_before_forwarding(proxy, method):
+    status, _, _ = request(
+        proxy,
+        f"/api/v1/namespaces/astronomy-shop/secrets/{HELM_SECRET_NAME}",
+        method=method,
+    )
+
+    assert status == 403
+    assert FakeHTTPSConnection.requests == []
+
+
+def test_secret_list_forces_json_and_filters_the_release(proxy):
+    response = {"apiVersion": "v1", "kind": "SecretList", "items": [HELM_SECRET, ORDINARY_SECRET]}
+    FakeHTTPSConnection.response = FakeResponse(json.dumps(response).encode())
+
+    status, headers, body = request(
+        proxy,
+        "/api/v1/%6eamespaces/astronomy-shop/secrets",
+        headers={"Accept": "application/vnd.kubernetes.protobuf"},
+    )
+
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(body)["items"] == [ORDINARY_SECRET]
+    assert FakeHTTPSConnection.requests[0][2]["Accept"] == "application/json"
+
+
+def test_secret_list_fails_closed_if_upstream_returns_protobuf(proxy):
+    FakeHTTPSConnection.response = FakeResponse(b"protobuf-data", "application/vnd.kubernetes.protobuf")
+
+    status, _, body = request(proxy, "/api/v1/namespaces/astronomy-shop/secrets")
+
+    assert status == 502
+    assert b"protobuf-data" not in body
+
+
+def test_secret_watch_is_blocked_before_forwarding(proxy):
+    status, _, _ = request(proxy, "/api/v1/namespaces/astronomy-shop/secrets?watch=true")
+
+    assert status == 403
+    assert FakeHTTPSConnection.requests == []
+
+
+def test_bulk_secret_delete_is_blocked_before_forwarding(proxy):
+    status, _, _ = request(
+        proxy,
+        "/api/v1/namespaces/astronomy-shop/secrets?labelSelector=owner%3Dhelm",
+        method="DELETE",
+    )
+
+    assert status == 403
+    assert FakeHTTPSConnection.requests == []
+
+
+def test_pod_cannot_mount_a_helm_release_secret(proxy):
+    pod = {"spec": {"volumes": [{"secret": {"secretName": HELM_SECRET_NAME}}]}}
+    status, _, _ = request(
+        proxy,
+        "/api/v1/namespaces/astronomy-shop/pods",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        body=json.dumps(pod).encode(),
+    )
+
+    assert status == 403
+    assert FakeHTTPSConnection.requests == []
+
+
+def test_ordinary_secret_remains_accessible(proxy):
+    FakeHTTPSConnection.response = FakeResponse(json.dumps(ORDINARY_SECRET).encode())
+
+    status, _, body = request(proxy, "/api/v1/namespaces/astronomy-shop/secrets/checkout-credentials")
+
+    assert status == 200
+    assert json.loads(body) == ORDINARY_SECRET


### PR DESCRIPTION
Fixes #955.

Helm stores each release revision in a Kubernetes Secret. These Secrets contain the complete rendered application manifests. Agents could read them and recover the pre-fault configuration without diagnosing the problem.

This change filters Helm release Secrets through the Kubernetes API proxy. Agents cannot list, read, modify, delete, or watch these records. They also cannot expose them through workload mounts or updates.

The proxy requests JSON when it must inspect a response. It rejects the response if it cannot filter the data safely. Normal application Secrets and other Kubernetes operations remain available.

Live testing covered authentication, normal Secret access, Helm Secret filtering, token rotation, and workload bypass attempts. Also did a codex run on the secret-based `secret_rotation_stale_env_credentials_astronomy_shop` fault. The run completed the normal deployment, proxy, evaluation, and cleanup lifecycle while ordinary application Secrets remained available.