### PR TITLE
Stream MCP SSE in filtered mode

### DIFF
--- a/docker/egress_proxy.py
+++ b/docker/egress_proxy.py
@@ -12,6 +12,7 @@ from internet_policy import (
     DEFAULT_BLOCKED_GITHUB_REPOSITORIES,
     DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
     blocked_github_owner,
+    should_stream_response,
 )
 from mitmproxy import ctx, http
 
@@ -35,6 +36,12 @@ BLOCKED_REPOSITORIES = tuple(
     if repository.strip()
 )
 BLOCK_LOG = Path(os.environ.get("BLOCKED_REQUEST_LOG", "/state/blocked-requests.jsonl"))
+
+
+def responseheaders(flow: http.HTTPFlow) -> None:
+    """Forward long-lived SSE responses instead of buffering them forever."""
+    if should_stream_response(flow.response.headers.get("content-type")):
+        flow.response.stream = True
 
 
 def request(flow: http.HTTPFlow) -> None:

--- a/sregym/service/internet_policy.py
+++ b/sregym/service/internet_policy.py
@@ -46,6 +46,14 @@ class InternetPolicy:
         return self.mode == InternetAccessMode.FILTERED
 
 
+def should_stream_response(content_type: str | None) -> bool:
+    """Return whether a response must bypass mitmproxy body buffering."""
+    if not content_type:
+        return False
+    media_type = content_type.partition(";")[0].strip().casefold()
+    return media_type == "text/event-stream"
+
+
 def blocked_github_owner(
     host: str,
     request_target: str,

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -19,7 +19,7 @@ from sregym.service.container_runner import (
     ContainerRunner,
     _find_host_ca_bundle,
 )
-from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
+from sregym.service.internet_policy import InternetPolicy, blocked_github_owner, should_stream_response
 from sregym.service.k8s_proxy import KubernetesAPIProxy, _is_workload_create_path, is_valid_bearer_token
 
 
@@ -69,6 +69,19 @@ def test_resolves_dot_segments_before_applying_github_policy(target):
 
 def test_allows_unconfigured_numeric_github_repository_id():
     assert blocked_github_owner("api.github.com", "/repositories/12345/contents/README.md", None) is None
+
+
+@pytest.mark.parametrize(
+    ("content_type", "expected"),
+    [
+        ("text/event-stream", True),
+        ("Text/Event-Stream; charset=utf-8", True),
+        ("application/json", False),
+        (None, False),
+    ],
+)
+def test_only_event_stream_responses_are_streamed(content_type, expected):
+    assert should_stream_response(content_type) is expected
 
 
 def test_ignores_unrelated_query_and_json_text():


### PR DESCRIPTION
Filtered agent containers send HTTP traffic through mitmproxy. The proxy buffered long-lived MCP SSE responses, causing Stratus to time out when connecting to tools such as Jaeger.

This change streams only `text/event-stream` responses. Normal HTTP behavior, GitHub filtering, and open-internet runs remain unchanged.
