### PR TITLE
Add manual problem difficulty evaluator

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -1,0 +1,245 @@
+name: Problem Difficulty Evaluation
+
+# Opt-in only: a core team member starts this workflow from the Actions UI.
+# Codex requires the Responses API, so a local LiteLLM proxy translates its
+# requests to Z.ai's Anthropic-compatible GLM Coding Plan endpoint.
+
+on:
+  workflow_dispatch:
+    inputs:
+      problem_id:
+        description: "Problem ID (key in problems/registry.py)"
+        required: true
+        type: string
+      attempts:
+        description: "Number of independent evaluations"
+        required: true
+        default: "5"
+        type: choice
+        options:
+          - "5"
+          - "3"
+      model:
+        description: "Z.ai Coding Plan model"
+        required: true
+        default: glm-4.7
+        type: choice
+        options:
+          - glm-4.7
+          - glm-5.1
+
+concurrency:
+  group: problem-difficulty-${{ inputs.problem_id }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+    env:
+      PROBLEM_ID: ${{ inputs.problem_id }}
+      ATTEMPTS: ${{ inputs.attempts }}
+      ZAI_MODEL: ${{ inputs.model }}
+      LITELLM_PORT: "4000"
+    steps:
+      - name: Require Z.ai Coding Plan secret
+        env:
+          ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
+        run: |
+          if [ -z "$ZCODE_API_KEY" ]; then
+            echo "::error::Repository secret ZCODE_API_KEY is not configured."
+            exit 1
+          fi
+
+      - name: Preflight Z.ai Coding Plan quota
+        env:
+          ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
+        run: |
+          set -euo pipefail
+          response_file="$RUNNER_TEMP/zai-preflight.json"
+          request_body=$(jq -cn --arg model "$ZAI_MODEL" '{
+            model: $model,
+            messages: [{role: "user", content: "Reply with OK."}],
+            thinking: {type: "disabled"},
+            max_tokens: 1,
+            stream: false
+          }')
+          http_status=$(curl --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url https://api.z.ai/api/coding/paas/v4/chat/completions \
+            --header "Authorization: Bearer $ZCODE_API_KEY" \
+            --header 'Content-Type: application/json' \
+            --data "$request_body")
+
+          case "$http_status" in
+            2??)
+              echo "Z.ai Coding Plan preflight passed for $ZAI_MODEL."
+              echo "ZAI_PREFLIGHT_PASSED=true" >> "$GITHUB_ENV"
+              ;;
+            *)
+              error_code=$(jq -r '.error.code // .code // "unknown"' "$response_file" 2>/dev/null || true)
+              error_message=$(jq -r '.error.message // .message // "unknown error"' "$response_file" 2>/dev/null || true)
+              printf 'Z.ai Coding Plan preflight failed: HTTP %s, code %s: %s\n' \
+                "$http_status" "${error_code:-unknown}" "${error_message:-unknown error}"
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync --locked
+
+      - name: Start Codex-to-Z.ai bridge
+        env:
+          ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
+        run: |
+          set -euo pipefail
+          proxy_key="sk-local-$(openssl rand -hex 24)"
+          echo "::add-mask::$proxy_key"
+          echo "LITELLM_MASTER_KEY=$proxy_key" >> "$GITHUB_ENV"
+          export LITELLM_MASTER_KEY="$proxy_key"
+
+          cat > "$RUNNER_TEMP/zai-litellm.yaml" <<EOF
+          model_list:
+            - model_name: $ZAI_MODEL
+              litellm_params:
+                model: anthropic/$ZAI_MODEL
+                api_base: https://api.z.ai/api/anthropic
+                api_key: os.environ/ZCODE_API_KEY
+          litellm_settings:
+            drop_params: true
+            modify_params: true
+          general_settings:
+            master_key: os.environ/LITELLM_MASTER_KEY
+          EOF
+
+          # The proxy extra conflicts with SREGym's intentionally pinned web
+          # stack, so run the matching LiteLLM proxy in an isolated uv tool env.
+          nohup uvx --from 'litellm[proxy]==1.91.0' litellm \
+            --config "$RUNNER_TEMP/zai-litellm.yaml" \
+            --host 0.0.0.0 \
+            --port "$LITELLM_PORT" \
+            > "$RUNNER_TEMP/litellm.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/litellm.pid"
+
+          for _ in $(seq 1 90); do
+            if curl --fail --silent --show-error \
+              -H "Authorization: Bearer $proxy_key" \
+              "http://127.0.0.1:$LITELLM_PORT/health/liveliness" > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "::error::LiteLLM bridge did not become ready."
+          tail -200 "$RUNNER_TEMP/litellm.log" || true
+          exit 1
+
+      - name: Install Kind
+        run: |
+          curl -Lo /tmp/kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+          kind version
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Pre-pull kind node image
+        run: docker pull jacksonarthurclark/aiopslab-kind-x86:latest
+
+      - name: Prepare /run/udev for OpenEBS NDM
+        run: sudo mkdir -p /run/udev
+
+      - name: Create kind cluster with Calico
+        run: bash kind/setup_kind_cluster.sh x86
+
+      - name: Run repeated Codex evaluation
+        env:
+          AGENT_API_BASE: http://127.0.0.1:4000/v1
+          JUDGE_API_BASE: http://127.0.0.1:4000/v1
+        run: |
+          set -euo pipefail
+          export AGENT_API_KEY="$LITELLM_MASTER_KEY"
+          export JUDGE_API_KEY="$LITELLM_MASTER_KEY"
+          uv run main.py \
+            --problem "$PROBLEM_ID" \
+            --agent codex \
+            --model "$ZAI_MODEL" \
+            --judge-model "openai/$ZAI_MODEL" \
+            --n-attempts "$ATTEMPTS" \
+            --agent-timeout 1800 \
+            --internet-access filtered \
+            2>&1 | tee benchmark.log
+
+      - name: Dump cluster diagnostics
+        if: failure() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        run: |
+          kubectl get nodes -o wide || true
+          kubectl get pods -A -o wide || true
+          kubectl get events -A --sort-by='.lastTimestamp' | tail -100 || true
+          kind export logs /tmp/kind-logs || true
+
+      - name: Build pass-rate report
+        if: always() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        run: |
+          set -euo pipefail
+          result_csv=$(find results -type f -name '*_codex_results.csv' ! -name 'codex_ALL_results.csv' 2>/dev/null \
+            | sort | tail -n1 || true)
+          if [ -z "$result_csv" ]; then
+            result_csv=$(find . -maxdepth 1 -type f -name '_running_*_codex_results.csv' \
+              | sort | tail -n1 || true)
+          fi
+
+          if [ -z "$result_csv" ]; then
+            {
+              echo "# Z.ai Problem Difficulty Evaluation"
+              echo
+              echo "No result CSV was produced. Inspect the benchmark and cluster logs."
+            } | tee evaluation-report.md >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          uv run python -m sregym.problem_evaluation_report \
+            --csv "$result_csv" \
+            --problem "$PROBLEM_ID" \
+            --model "$ZAI_MODEL" \
+            --attempts "$ATTEMPTS" \
+            --output evaluation-report.md \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload evaluation artifacts
+        if: always() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: problem-difficulty-evaluation-${{ github.run_attempt }}
+          path: |
+            evaluation-report.md
+            benchmark.log
+            results/
+            _running_*_codex_results.csv
+            ${{ runner.temp }}/litellm.log
+            /tmp/kind-logs/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Stop Codex-to-Z.ai bridge
+        if: always() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        run: |
+          if [ -f "$RUNNER_TEMP/litellm.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/litellm.pid")" 2>/dev/null || true
+          fi

--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -1,10 +1,14 @@
 name: Problem Difficulty Evaluation
 
-# Opt-in only: a core team member starts this workflow from the Actions UI.
+# Opt-in only: a core team member starts this workflow from the Actions UI or
+# comments "/evaluate-problem <id> [3|5] [glm-5.3-flash]" on a pull request.
 # Codex requires the Responses API, so a local LiteLLM proxy translates its
 # requests to Z.ai's Anthropic-compatible GLM Coding Plan endpoint.
+# Secret-bearing comment runs execute the default branch, never PR code.
 
 on:
+  issue_comment:
+    types: [created, edited]
   workflow_dispatch:
     inputs:
       problem_id:
@@ -22,26 +26,137 @@ on:
       model:
         description: "Z.ai Coding Plan model"
         required: true
-        default: glm-4.7
+        default: glm-5.3-flash
         type: choice
         options:
-          - glm-4.7
-          - glm-5.1
+          - glm-5.3-flash
 
 concurrency:
-  group: problem-difficulty-${{ inputs.problem_id }}
+  group: problem-difficulty-${{ github.event_name }}-${{ github.event.inputs.problem_id || github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  resolve:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/evaluate-problem'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.parse.outputs.should_run }}
+      problem_id: ${{ steps.parse.outputs.problem_id }}
+      attempts: ${{ steps.parse.outputs.attempts }}
+      model: ${{ steps.parse.outputs.model }}
+      checkout_ref: ${{ steps.parse.outputs.checkout_ref }}
+      pr_number: ${{ steps.parse.outputs.pr_number }}
+      comment_id: ${{ steps.parse.outputs.comment_id }}
+      skip_reason: ${{ steps.parse.outputs.skip_reason }}
+    steps:
+      - name: Resolve evaluation request
+        id: parse
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_ID: ${{ github.event.inputs.problem_id }}
+          DISPATCH_ATTEMPTS: ${{ github.event.inputs.attempts }}
+          DISPATCH_MODEL: ${{ github.event.inputs.model }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ASSOC: ${{ github.event.comment.author_association }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          problem_id=""
+          attempts=""
+          model=""
+          checkout_ref=""
+          pr_number=""
+          comment_id=""
+          skip_reason=""
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              problem_id="$DISPATCH_ID"
+              attempts="$DISPATCH_ATTEMPTS"
+              model="$DISPATCH_MODEL"
+              checkout_ref="$DISPATCH_REF"
+              ;;
+            issue_comment)
+              pr_number="$ISSUE_NUMBER"
+              comment_id="$COMMENT_ID"
+              # This job receives ZCODE_API_KEY later. Never execute code from
+              # the PR head or merge ref in this privileged workflow.
+              checkout_ref="$DEFAULT_BRANCH"
+              case "$COMMENT_ASSOC" in
+                OWNER|MEMBER|COLLABORATOR) ;;
+                *)
+                  skip_reason="comment ignored: author association '$COMMENT_ASSOC' lacks write access"
+                  ;;
+              esac
+              if [ -z "$skip_reason" ]; then
+                raw=$(printf '%s\n' "$COMMENT_BODY" \
+                  | grep -iE '^[[:space:]]*/evaluate-problem[[:space:]:]+' \
+                  | head -n1 \
+                  | sed -E 's#^[[:space:]]*/evaluate-problem[[:space:]:]+##I' || true)
+                raw=$(printf '%s' "$raw" | tr -d '\r')
+                problem_id=$(printf '%s' "$raw" | awk '{print $1}')
+                attempts=$(printf '%s' "$raw" | awk '{print $2}')
+                model=$(printf '%s' "$raw" | awk '{print $3}')
+                attempts=${attempts:-5}
+              model=${model:-glm-5.3-flash}
+              fi
+              ;;
+          esac
+
+          problem_id=${problem_id//\`/}
+          problem_id=${problem_id//\"/}
+          problem_id=${problem_id//\'/}
+
+          if [ -z "$skip_reason" ]; then
+            if ! [[ "$problem_id" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+              skip_reason="problem ID must contain only letters, numbers, dots, underscores, or hyphens"
+            elif [ "$attempts" != "3" ] && [ "$attempts" != "5" ]; then
+              skip_reason="attempts must be 3 or 5"
+            elif [ "$model" != "glm-5.3-flash" ]; then
+              skip_reason="model must be glm-5.3-flash"
+            else
+              should_run=true
+            fi
+          fi
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "problem_id=$problem_id" >> "$GITHUB_OUTPUT"
+          echo "attempts=$attempts" >> "$GITHUB_OUTPUT"
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "comment_id=$comment_id" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=$skip_reason" >> "$GITHUB_OUTPUT"
+
+          if [ "$should_run" = "true" ]; then
+            echo "::notice::Difficulty evaluation will run for '$problem_id' ($attempts attempts, $model)"
+          else
+            echo "::notice::Difficulty evaluation skipped: $skip_reason"
+          fi
+
   evaluate:
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
       contents: read
+      pull-requests: write
+      issues: write
     env:
-      PROBLEM_ID: ${{ inputs.problem_id }}
-      ATTEMPTS: ${{ inputs.attempts }}
-      ZAI_MODEL: ${{ inputs.model }}
+      PROBLEM_ID: ${{ needs.resolve.outputs.problem_id }}
+      ATTEMPTS: ${{ needs.resolve.outputs.attempts }}
+      ZAI_MODEL: ${{ needs.resolve.outputs.model }}
       LITELLM_PORT: "4000"
     steps:
       - name: Require Z.ai Coding Plan secret
@@ -91,11 +206,66 @@ jobs:
               ;;
           esac
 
+      - name: React to triggering comment
+        if: needs.resolve.outputs.comment_id != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ needs.resolve.outputs.comment_id }}
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: Number(process.env.COMMENT_ID),
+              content: 'eyes',
+            });
+
+      - name: Post running evaluation comment
+        if: needs.resolve.outputs.pr_number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          PROBLEM_ID: ${{ needs.resolve.outputs.problem_id }}
+          ATTEMPTS: ${{ needs.resolve.outputs.attempts }}
+          ZAI_MODEL: ${{ needs.resolve.outputs.model }}
+        with:
+          script: |
+            const marker = '<!-- problem-difficulty-evaluation -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body =
+              `${marker}\n## Problem Difficulty Evaluation\n\n` +
+              `**Status: Running** for \`${process.env.PROBLEM_ID}\` ` +
+              `(${process.env.ATTEMPTS} attempts, \`${process.env.ZAI_MODEL}\`)\n\n` +
+              `The secret-bearing evaluator runs trusted code from the default branch.\n\n` +
+              `_[Live workflow run](${runUrl})_`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Require registered problem ID
+        run: |
+          if ! grep -Fq "\"$PROBLEM_ID\":" sregym/conductor/problems/registry.py; then
+            echo "::error::Problem '$PROBLEM_ID' is not registered on the checked-out branch."
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -243,3 +413,53 @@ jobs:
           if [ -f "$RUNNER_TEMP/litellm.pid" ]; then
             kill "$(cat "$RUNNER_TEMP/litellm.pid")" 2>/dev/null || true
           fi
+
+      - name: Post evaluation result comment
+        if: always() && needs.resolve.outputs.pr_number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- problem-difficulty-evaluation -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let body;
+            try {
+              body = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/evaluation-report.md`, 'utf8');
+              body = `${marker}\n${body}\n_[Workflow run](${runUrl})_`;
+            } catch (error) {
+              body =
+                `${marker}\n## Problem Difficulty Evaluation\n\n` +
+                `**Status: Failed** before a pass-rate report was produced.\n\n` +
+                `Inspect the [workflow run](${runUrl}) for the preflight or infrastructure error.`;
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: React to triggering comment with final result
+        if: always() && needs.resolve.outputs.comment_id != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ needs.resolve.outputs.comment_id }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: Number(process.env.COMMENT_ID),
+              content: process.env.JOB_STATUS === 'success' ? '+1' : '-1',
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,17 @@ To add a new problem:
 
    Automated validation does not replace human review.
 
+6. **Screen validated problems for difficulty (core team).** From the Actions
+   tab, run **Problem Difficulty Evaluation** with the problem ID. This manual
+   workflow runs the Codex harness three or five times against the Z.ai Coding
+   Plan and publishes diagnosis, mitigation, and overall pass rates in the run
+   summary. A problem is marked saturated only when every requested attempt
+   completes and passes. The workflow requires the repository secret
+   `ZCODE_API_KEY`. Before checking out the repository or creating a cluster,
+   it makes a minimal request to the selected Z.ai model and stops if the key,
+   model access, or Coding Plan quota is unavailable. The workflow is never
+   triggered automatically.
+
 ### Adding New Oracles
 
 Custom oracles allow for specialized evaluation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,16 +312,27 @@ To add a new problem:
 
    Automated validation does not replace human review.
 
-6. **Screen validated problems for difficulty (core team).** From the Actions
-   tab, run **Problem Difficulty Evaluation** with the problem ID. This manual
-   workflow runs the Codex harness three or five times against the Z.ai Coding
-   Plan and publishes diagnosis, mitigation, and overall pass rates in the run
-   summary. A problem is marked saturated only when every requested attempt
-   completes and passes. The workflow requires the repository secret
-   `ZCODE_API_KEY`. Before checking out the repository or creating a cluster,
-   it makes a minimal request to the selected Z.ai model and stops if the key,
-   model access, or Coding Plan quota is unavailable. The workflow is never
-   triggered automatically.
+6. **Screen validated problems for difficulty (core team).** Run **Problem
+   Difficulty Evaluation** from the Actions tab, or have an owner, member, or
+   collaborator post this PR comment:
+
+   ```text
+   /evaluate-problem <problem_id> [3|5] [glm-5.3-flash]
+   ```
+
+   The optional values default to five attempts and `glm-5.3-flash`. The workflow
+   runs the Codex harness against the Z.ai Coding Plan and publishes diagnosis,
+   mitigation, and overall pass rates in the run summary and PR conversation.
+   A problem is marked saturated only when every requested attempt completes
+   and passes.
+
+   The workflow requires the repository secret `ZCODE_API_KEY`. Before checking
+   out the repository or creating a cluster, it makes a minimal request to the
+   selected Z.ai model and stops if the key, model access, or Coding Plan quota
+   is unavailable. To keep that secret isolated from untrusted PR code, comment
+   runs always evaluate the default branch, so the problem must already be in
+   the default branch's registry. The workflow is never triggered
+   automatically.
 
 ### Adding New Oracles
 

--- a/clients/codex/codex_agent.py
+++ b/clients/codex/codex_agent.py
@@ -9,10 +9,41 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("all.codex.agent")
+
+_CUSTOM_PROVIDER_ID = "sregym_custom"
+
+
+def custom_provider_args(env: Mapping[str, str] | None = None) -> list[str]:
+    """Build Codex CLI overrides for an OpenAI Responses-compatible endpoint."""
+    source = os.environ if env is None else env
+    api_base = source.get("AGENT_API_BASE", "").strip()
+    if not api_base:
+        return []
+
+    if not source.get("AGENT_API_KEY", "").strip():
+        raise RuntimeError("AGENT_API_KEY is required when AGENT_API_BASE configures Codex")
+
+    # json.dumps emits a quoted string that is valid TOML and safely escapes the
+    # endpoint without placing the credential itself on the command line.
+    return [
+        "-c",
+        f"model_provider={json.dumps(_CUSTOM_PROVIDER_ID)}",
+        "-c",
+        f"model_providers.{_CUSTOM_PROVIDER_ID}.name={json.dumps('SREGym custom endpoint')}",
+        "-c",
+        f"model_providers.{_CUSTOM_PROVIDER_ID}.base_url={json.dumps(api_base)}",
+        "-c",
+        f"model_providers.{_CUSTOM_PROVIDER_ID}.env_key={json.dumps('AGENT_API_KEY')}",
+        "-c",
+        f"model_providers.{_CUSTOM_PROVIDER_ID}.wire_api={json.dumps('responses')}",
+        "-c",
+        f"model_providers.{_CUSTOM_PROVIDER_ID}.requires_openai_auth=false",
+    ]
 
 
 class CodexAgent:
@@ -195,12 +226,19 @@ class CodexAgent:
     def _setup_auth(self) -> bool:
         """Set up authentication for Codex.
 
-        Checks subscription credentials first (mounted ~/.codex/auth.json),
-        then falls back to OPENAI_API_KEY env var.
+        Uses the custom provider credential when AGENT_API_BASE is set. Otherwise,
+        checks subscription credentials first (mounted ~/.codex/auth.json), then
+        falls back to OPENAI_API_KEY.
 
         Returns:
-            True if API key auth was set up, False if using subscription auth.
+            True if an OpenAI auth file was created; False for subscription or
+            custom-provider auth.
         """
+        if os.environ.get("AGENT_API_BASE", "").strip():
+            custom_provider_args()
+            logger.info("Using AGENT_API_KEY with the configured Codex endpoint")
+            return False
+
         # Prefer subscription auth (OAuth tokens in mounted ~/.codex)
         mounted_auth = Path("/root/.codex/auth.json")
         if mounted_auth.exists():
@@ -292,6 +330,7 @@ class CodexAgent:
             "--enable",
             "unified_exec",
         ]
+        command.extend(custom_provider_args())
         reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
         if reasoning_effort:
             command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
@@ -317,7 +356,9 @@ class CodexAgent:
         logger.info(f"Using reasoning effort: {reasoning_effort or 'Codex default'}")
 
         # Setup authentication
+        using_custom_provider = bool(os.environ.get("AGENT_API_BASE", "").strip())
         using_api_key = self._setup_auth()
+        env = os.environ.copy()
 
         try:
             command = self._build_command(instruction)
@@ -325,9 +366,8 @@ class CodexAgent:
             logger.info(f"Executing command: {' '.join(command)}")
 
             # Set environment variables
-            env = os.environ.copy()
-            if using_api_key:
-                # Use logs_dir as CODEX_HOME for API key auth (auth.json written there).
+            if using_custom_provider or using_api_key:
+                # Keep provider-specific state and API-key auth in the run directory.
                 env["CODEX_HOME"] = str(self.codex_home)
             else:
                 # For subscription auth, use the mounted ~/.codex dir so the CLI finds

--- a/clients/codex/driver.py
+++ b/clients/codex/driver.py
@@ -22,7 +22,7 @@ from logger import init_logger  # noqa: E402
 
 init_logger()
 
-from clients.codex.codex_agent import CodexAgent  # noqa: E402
+from clients.codex.codex_agent import CodexAgent, custom_provider_args  # noqa: E402
 from clients.harness.problem_id import resolve_problem_id  # noqa: E402
 
 logger = logging.getLogger("all.codex.driver")
@@ -35,12 +35,13 @@ def run_preflight() -> None:
     home = Path(os.environ.get("CODEX_HOME", "/root/.codex"))
     auth = home / "auth.json"
     key = os.environ.get("OPENAI_API_KEY", "")
+    provider_args = custom_provider_args()
 
-    if not auth.exists() and not key:
+    if not provider_args and not auth.exists() and not key:
         print(f"missing {auth} and OPENAI_API_KEY")
         sys.exit(1)
 
-    if not auth.exists():
+    if not provider_args and not auth.exists():
         home.mkdir(parents=True, exist_ok=True)
         auth.write_text(json.dumps({"OPENAI_API_KEY": key}))
 
@@ -56,6 +57,7 @@ def run_preflight() -> None:
         "--dangerously-bypass-approvals-and-sandbox",
         "--skip-git-repo-check",
     ]
+    command.extend(provider_args)
     reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
     if reasoning_effort:
         command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])

--- a/sregym/problem_evaluation_report.py
+++ b/sregym/problem_evaluation_report.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build a Markdown difficulty report from one SREGym results CSV."""
+
+import argparse
+import csv
+import os
+from pathlib import Path
+
+
+def _as_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value or "").strip().lower()
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def _rate(passes: int, evaluated: int) -> str:
+    if evaluated == 0:
+        return "n/a"
+    return f"{passes}/{evaluated} ({passes / evaluated:.0%})"
+
+
+def build_report(
+    rows: list[dict[str, str]],
+    *,
+    problem_id: str,
+    model: str,
+    requested_attempts: int,
+) -> str:
+    """Return a report whose saturation decision requires every requested run."""
+    selected = [row for row in rows if row.get("problem_id") == problem_id]
+    attempts: dict[int, dict[str, str]] = {}
+    for fallback_attempt, row in enumerate(selected, start=1):
+        try:
+            attempt = int(row.get("attempt", ""))
+        except (TypeError, ValueError):
+            attempt = fallback_attempt
+        attempts[attempt] = row
+
+    diagnosis_evaluated = 0
+    diagnosis_passes = 0
+    mitigation_evaluated = 0
+    mitigation_passes = 0
+    complete_attempts = 0
+    overall_passes = 0
+    table_rows: list[str] = []
+
+    for attempt in range(1, requested_attempts + 1):
+        row = attempts.get(attempt)
+        if row is None:
+            table_rows.append(f"| {attempt} | — | — | Incomplete | not run |")
+            continue
+
+        diagnosis = _as_bool(row.get("Diagnosis.success"))
+        mitigation = _as_bool(row.get("Mitigation.success"))
+        if diagnosis is not None:
+            diagnosis_evaluated += 1
+            diagnosis_passes += int(diagnosis)
+        if mitigation is not None:
+            mitigation_evaluated += 1
+            mitigation_passes += int(mitigation)
+
+        detail = ""
+        if _as_bool(row.get("deploy_failed")):
+            detail = "deployment failed"
+        elif _as_bool(row.get("timed_out")):
+            detail = "agent timed out"
+        elif diagnosis is None or mitigation is None:
+            missing = []
+            if diagnosis is None:
+                missing.append("diagnosis")
+            if mitigation is None:
+                missing.append("mitigation")
+            detail = f"missing {' and '.join(missing)} result"
+
+        diagnosis_text = "Pass" if diagnosis is True else "Fail" if diagnosis is False else "—"
+        mitigation_text = "Pass" if mitigation is True else "Fail" if mitigation is False else "—"
+        if diagnosis is None or mitigation is None:
+            overall_text = "Incomplete"
+        else:
+            complete_attempts += 1
+            overall = diagnosis and mitigation
+            overall_passes += int(overall)
+            overall_text = "Pass" if overall else "Fail"
+        table_rows.append(f"| {attempt} | {diagnosis_text} | {mitigation_text} | {overall_text} | {detail or '—'} |")
+
+    if complete_attempts != requested_attempts:
+        decision = "⚠️ **Inconclusive** — one or more requested attempts did not produce both stage results; rerun it."
+    elif overall_passes == requested_attempts:
+        decision = "🔴 **Saturated** — every requested attempt passed; do not keep it as a difficulty candidate."
+    elif overall_passes == 0:
+        decision = (
+            "🟠 **Unsolved** — no complete attempt passed; review whether the problem is too difficult or broken."
+        )
+    else:
+        decision = "🟢 **Not saturated** — at least one attempt passed and at least one failed; keep it as a candidate."
+
+    lines = [
+        "# Z.ai Problem Difficulty Evaluation",
+        "",
+        f"- **Problem:** `{problem_id}`",
+        f"- **Model:** `{model}` via the Codex harness",
+        f"- **Requested attempts:** {requested_attempts}",
+        f"- **Complete attempts:** {complete_attempts}",
+        f"- **Diagnosis pass rate:** {_rate(diagnosis_passes, diagnosis_evaluated)}",
+        f"- **Mitigation pass rate:** {_rate(mitigation_passes, mitigation_evaluated)}",
+        f"- **Overall pass rate:** {_rate(overall_passes, complete_attempts)}",
+        "",
+        "Overall requires both diagnosis and mitigation to pass. Infrastructure-incomplete attempts are not counted as model failures.",
+        "",
+        "| Attempt | Diagnosis | Mitigation | Overall | Notes |",
+        "| ---: | :---: | :---: | :---: | --- |",
+        *table_rows,
+        "",
+        "## Screening decision",
+        "",
+        decision,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, type=Path, help="SREGym results CSV")
+    parser.add_argument("--problem", required=True, help="Problem ID to report")
+    parser.add_argument("--model", required=True, help="Z.ai model used by Codex")
+    parser.add_argument("--attempts", required=True, type=int, help="Number of requested attempts")
+    parser.add_argument("--output", required=True, type=Path, help="Markdown report path")
+    parser.add_argument(
+        "--github-summary",
+        type=Path,
+        default=Path(os.environ["GITHUB_STEP_SUMMARY"]) if os.environ.get("GITHUB_STEP_SUMMARY") else None,
+        help="Optional GitHub step-summary file to append",
+    )
+    args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be positive")
+
+    with args.csv.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    report = build_report(
+        rows,
+        problem_id=args.problem,
+        model=args.model,
+        requested_attempts=args.attempts,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report, encoding="utf-8")
+    if args.github_summary is not None:
+        with args.github_summary.open("a", encoding="utf-8") as handle:
+            handle.write(report)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_codex_custom_provider.py
+++ b/tests/test_codex_custom_provider.py
@@ -1,0 +1,34 @@
+import pytest
+
+from clients.codex.codex_agent import CodexAgent, custom_provider_args
+
+
+def test_custom_provider_is_disabled_without_agent_api_base(monkeypatch):
+    monkeypatch.delenv("AGENT_API_BASE", raising=False)
+    monkeypatch.delenv("AGENT_API_KEY", raising=False)
+
+    assert custom_provider_args() == []
+
+
+def test_custom_provider_requires_api_key(monkeypatch):
+    monkeypatch.setenv("AGENT_API_BASE", "https://proxy.example.test/v1")
+    monkeypatch.delenv("AGENT_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="AGENT_API_KEY is required"):
+        custom_provider_args()
+
+
+def test_custom_provider_uses_responses_wire_api_without_exposing_key(monkeypatch, tmp_path):
+    api_key = "secret-provider-key"
+    monkeypatch.setenv("AGENT_API_BASE", "https://proxy.example.test/v1")
+    monkeypatch.setenv("AGENT_API_KEY", api_key)
+    agent = CodexAgent(logs_dir=tmp_path, model_name="glm-4.7")
+
+    command = agent._build_command("inspect the cluster")
+    joined = " ".join(command)
+
+    assert 'model_provider="sregym_custom"' in command
+    assert 'model_providers.sregym_custom.base_url="https://proxy.example.test/v1"' in command
+    assert 'model_providers.sregym_custom.env_key="AGENT_API_KEY"' in command
+    assert 'model_providers.sregym_custom.wire_api="responses"' in command
+    assert api_key not in joined

--- a/tests/test_problem_evaluation_report.py
+++ b/tests/test_problem_evaluation_report.py
@@ -1,0 +1,52 @@
+from sregym.problem_evaluation_report import build_report
+
+
+def _row(attempt: int, diagnosis: object = True, mitigation: object = True, **extra):
+    return {
+        "problem_id": "example_problem",
+        "attempt": str(attempt),
+        "Diagnosis.success": str(diagnosis),
+        "Mitigation.success": str(mitigation),
+        **extra,
+    }
+
+
+def test_report_marks_five_complete_passes_as_saturated():
+    report = build_report(
+        [_row(attempt) for attempt in range(1, 6)],
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=5,
+    )
+
+    assert "**Overall pass rate:** 5/5 (100%)" in report
+    assert "🔴 **Saturated**" in report
+
+
+def test_report_keeps_mixed_result_as_not_saturated():
+    report = build_report(
+        [_row(1), _row(2, mitigation=False), _row(3)],
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=3,
+    )
+
+    assert "**Overall pass rate:** 2/3 (67%)" in report
+    assert "🟢 **Not saturated**" in report
+
+
+def test_report_does_not_count_infrastructure_failure_as_model_failure():
+    rows = [_row(1), {"problem_id": "example_problem", "attempt": "2", "deploy_failed": "True"}]
+
+    report = build_report(
+        rows,
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=3,
+    )
+
+    assert "**Complete attempts:** 1" in report
+    assert "**Overall pass rate:** 1/1 (100%)" in report
+    assert "| 2 | — | — | Incomplete | deployment failed |" in report
+    assert "| 3 | — | — | Incomplete | not run |" in report
+    assert "⚠️ **Inconclusive**" in report


### PR DESCRIPTION
## Summary

- add an opt-in Problem Difficulty Evaluation workflow for three or five Codex runs on kind
- connect the Codex harness to Z.ai Coding Plan models through a local Responses-compatible bridge
- report diagnosis, mitigation, and overall pass rates with explicit saturation and infrastructure-incomplete decisions
- preflight the selected Z.ai model and quota before checkout or cluster setup

## Testing

- focused provider and report tests: 6 passed
- repository hooks: passed
- actionlint 1.7.7: passed
- Codex Responses bridge smoke-tested against a mock Anthropic endpoint

Closes #977