### PR TITLE
Fix Z.ai judge model routing in problem validation

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -293,6 +293,13 @@ jobs:
                 model: openai/chat_completions/$ZAI_MODEL
                 api_base: https://api.z.ai/api/coding/paas/v4
                 api_key: os.environ/ZCODE_API_KEY
+            - model_name: $ZAI_MODEL-judge
+              litellm_params:
+                # The judge already speaks Chat Completions, so it must use the
+                # unmodified upstream model ID rather than the Responses bridge.
+                model: openai/$ZAI_MODEL
+                api_base: https://api.z.ai/api/coding/paas/v4
+                api_key: os.environ/ZCODE_API_KEY
           litellm_settings:
             drop_params: true
             modify_params: true
@@ -322,37 +329,67 @@ jobs:
           tail -200 "$RUNNER_TEMP/litellm.log" || true
           exit 1
 
-      - name: Preflight Codex-to-Z.ai bridge
+      - name: Preflight Codex and judge bridges
         run: |
           set -euo pipefail
-          response_file="$RUNNER_TEMP/zai-bridge-preflight.json"
-          request_body=$(jq -cn --arg model "$ZAI_MODEL" '{
+          codex_response_file="$RUNNER_TEMP/zai-codex-bridge-preflight.json"
+          codex_request_body=$(jq -cn --arg model "$ZAI_MODEL" '{
             model: $model,
             input: "Reply with OK.",
             max_output_tokens: 16,
             stream: false
           }')
-          http_status=$(curl --silent --show-error \
+          codex_http_status=$(curl --silent --show-error \
             --connect-timeout 10 \
             --max-time 60 \
-            --output "$response_file" \
+            --output "$codex_response_file" \
             --write-out '%{http_code}' \
             --request POST \
             --url "http://127.0.0.1:$LITELLM_PORT/v1/responses" \
             --header "Authorization: Bearer $LITELLM_MASTER_KEY" \
             --header 'Content-Type: application/json' \
-            --data "$request_body")
+            --data "$codex_request_body")
 
-          if [[ "$http_status" != 2* ]]; then
+          if [[ "$codex_http_status" != 2* ]]; then
             error_message=$(jq -r '.error.message // .message // "unknown error"' \
-              "$response_file" 2>/dev/null || true)
+              "$codex_response_file" 2>/dev/null || true)
             printf 'Codex-to-Z.ai bridge preflight failed: HTTP %s: %s\n' \
-              "$http_status" "${error_message:-unknown error}"
+              "$codex_http_status" "${error_message:-unknown error}"
             tail -200 "$RUNNER_TEMP/litellm.log" || true
             exit 1
           fi
 
           echo "Codex-to-Z.ai Responses bridge preflight passed for $ZAI_MODEL."
+
+          judge_model="$ZAI_MODEL-judge"
+          judge_response_file="$RUNNER_TEMP/zai-judge-bridge-preflight.json"
+          judge_request_body=$(jq -cn --arg model "$judge_model" '{
+            model: $model,
+            messages: [{role: "user", content: "Reply with OK."}],
+            max_tokens: 16,
+            stream: false
+          }')
+          judge_http_status=$(curl --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --output "$judge_response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url "http://127.0.0.1:$LITELLM_PORT/v1/chat/completions" \
+            --header "Authorization: Bearer $LITELLM_MASTER_KEY" \
+            --header 'Content-Type: application/json' \
+            --data "$judge_request_body")
+
+          if [[ "$judge_http_status" != 2* ]]; then
+            error_message=$(jq -r '.error.message // .message // "unknown error"' \
+              "$judge_response_file" 2>/dev/null || true)
+            printf 'Judge-to-Z.ai bridge preflight failed: HTTP %s: %s\n' \
+              "$judge_http_status" "${error_message:-unknown error}"
+            tail -200 "$RUNNER_TEMP/litellm.log" || true
+            exit 1
+          fi
+
+          echo "Judge-to-Z.ai Chat Completions bridge preflight passed for $judge_model."
 
       - name: Install Kind
         run: |
@@ -385,7 +422,7 @@ jobs:
             --problem "$PROBLEM_ID" \
             --agent codex \
             --model "$ZAI_MODEL" \
-            --judge-model "openai/$ZAI_MODEL" \
+            --judge-model "openai/${ZAI_MODEL}-judge" \
             --n-attempts "$ATTEMPTS" \
             --agent-timeout 1800 \
             --internet-access filtered \


### PR DESCRIPTION
## Summary

- give the evaluator judge a dedicated LiteLLM alias that maps directly to Z.ai Chat Completions
- keep the `openai/chat_completions/` translation alias only for Codex requests sent through the Responses API
- preflight both routes before Kind setup so invalid model routing fails before expensive runner work

## Why

The follow-up run after #981 showed that Codex successfully reached Z.ai through `/v1/responses`, but the judge sent the translated alias directly through `/v1/chat/completions`. Z.ai consequently rejected `openai/chat_completions/glm-5.3-flash` with `modelCode: does not exist`.

Failed run: https://github.com/SREGym/SREGym/actions/runs/33125981183

## Validation

- `actionlint .github/workflows/problem-difficulty-evaluation.yml`
- `prek run --files .github/workflows/problem-difficulty-evaluation.yml`
- `uv run pytest -p no:cacheprovider tests/test_codex_custom_provider.py tests/llm_as_a_judge/test_content_normalization.py tests/test_problem_evaluation_report.py -q` (8 passed)
- pinned LiteLLM 1.91.0 smoke test: Codex `/v1/responses` and judge `/v1/chat/completions` both returned `OK` and both reached the mock Z.ai upstream at `/v4/chat/completions`
