### PR TITLE
Support capability-gated Khaos deployment on kind

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -26,7 +26,7 @@ from sregym.service.cluster_state import ClusterStateManager
 from sregym.service.dm_flakey_manager import DmFlakeyManager
 from sregym.service.internet_policy import InternetPolicy
 from sregym.service.k8s_proxy import KubernetesAPIProxy
-from sregym.service.khaos import KhaosController
+from sregym.service.khaos import KhaosController, KhaosUnsupportedError
 from sregym.service.kubectl import KubeCtl
 from sregym.service.mcp_server import MCPServer
 from sregym.service.telemetry.loki import Loki
@@ -424,14 +424,6 @@ class Conductor:
         self.logger.info(f"[Session Start] Problem ID: {self.problem_id}")
         self.logger.info(f"[STAGE] Start testing on problem: {self.problem_id}")
 
-        if self.problem.requires_khaos() and self.kubectl.is_emulated_cluster():
-            self.logger.warning(
-                f"Problem '{self.problem_id}' requires Khaos for eBPF-based fault injection, "
-                "but Khaos cannot be deployed on emulated clusters (kind, minikube, k3d, etc.). "
-                "Skipping this problem."
-            )
-            return StartProblemResult.SKIPPED_KHAOS_REQUIRED
-
         self.fix_kubernetes()
 
         self.get_problem_stages()
@@ -441,7 +433,14 @@ class Conductor:
         self.undeploy_app()  # Cleanup any leftovers
         self.logger.info("App leftovers undeployed.")
         self.logger.info("Deploying app...")
-        self.deploy_app()
+        try:
+            self.deploy_app()
+        except KhaosUnsupportedError as exc:
+            self.logger.warning(
+                f"Problem '{self.problem_id}' requires host capabilities that are unavailable: {exc}. "
+                "Skipping this problem."
+            )
+            return StartProblemResult.SKIPPED_KHAOS_REQUIRED
         self.logger.info("App deployed.")
 
         # Update NoiseManager with problem context
@@ -816,7 +815,7 @@ class Conductor:
         # Only deploy Khaos if the problem requires it
         if problem.requires_khaos():
             self.logger.info("[DEPLOY] Deploying Khaos DaemonSet...")
-            self.khaos.ensure_deployed()
+            self.khaos.ensure_deployed(problem.khaos_capabilities())
 
         self.logger.info("[DEPLOY] Setting up OpenEBS…")
         self._preflight_openebs_udev_mount()

--- a/sregym/conductor/problems/base.py
+++ b/sregym/conductor/problems/base.py
@@ -2,6 +2,8 @@
 
 from abc import ABC, abstractmethod
 
+from sregym.service.khaos_capabilities import KhaosCapability
+
 
 class Problem(ABC):
     run_default_workload = True
@@ -20,6 +22,12 @@ class Problem(ABC):
     def requires_khaos(self) -> bool:
         """Override this method to return True if the problem requires Khaos for fault injection."""
         return False
+
+    def khaos_capabilities(self) -> frozenset[KhaosCapability]:
+        """Return the host features this problem needs from the Khaos node agent."""
+        if self.requires_khaos():
+            return frozenset({KhaosCapability.EBPF_SYSCALL})
+        return frozenset()
 
     @classmethod
     def build_structured_root_cause(

--- a/sregym/conductor/problems/silent_data_corruption.py
+++ b/sregym/conductor/problems/silent_data_corruption.py
@@ -7,6 +7,7 @@ from sregym.conductor.problems.base import Problem
 from sregym.generators.fault.inject_kernel import KernelInjector
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.dm_flakey_manager import DM_FLAKEY_DEVICE_NAME, DmFlakeyManager
+from sregym.service.khaos_capabilities import KhaosCapability
 from sregym.service.kubectl import KubeCtl
 from sregym.utils.decorators import mark_fault_injected
 
@@ -60,6 +61,9 @@ class SilentDataCorruption(Problem):
     def requires_khaos(self) -> bool:
         """This problem requires Khaos for dm-flakey infrastructure setup."""
         return True
+
+    def khaos_capabilities(self) -> frozenset[KhaosCapability]:
+        return frozenset({KhaosCapability.DM_FLAKEY})
 
     def _discover_node_for_deploy(self) -> str | None:
         """Return the node where the target deployment is running."""

--- a/sregym/generators/fault/inject_hw.py
+++ b/sregym/generators/fault/inject_hw.py
@@ -87,12 +87,10 @@ class HWFaultInjector(FaultInjector):
 
         self.recover(target_pods, fault_type)
 
-        # Sweep any leftover BPF pins for this fault. The reinjection monitor
-        # pins a fresh probe per restarted container, but `khaos --recover` only
-        # detaches one — leaving the rest as stale pins under /sys/fs/bpf that
-        # accumulate across runs and eventually leak kernel resources. We
-        # observed 14 leftover pins on node1 after a single failed
-        # latent_sector_error run.
+        # Sweep any leftover BPF pins for this fault. Current Khaos releases
+        # recover every matching pin; keep this as a compatibility cleanup for
+        # older images and interrupted recoveries. Stale pins accumulate kernel
+        # resources across runs.
         try:
             self._cleanup_pinned_bpf_for_fault(target_node, fault_type)
         except Exception as e:

--- a/sregym/service/khaos.py
+++ b/sregym/service/khaos.py
@@ -1,34 +1,81 @@
 import json
+import shlex
 import time
+from collections.abc import Iterable
 
 from sregym.paths import KHAOS_DS
+from sregym.service.khaos_capabilities import KhaosCapability
 from sregym.service.kubectl import KubeCtl
 
 KHAOS_NS = "khaos"
 KHAOS_DS_NAME = "khaos"
 
 
+class KhaosUnsupportedError(RuntimeError):
+    """Raised when a node kernel cannot provide a problem's Khaos capability."""
+
+
 class KhaosController:
     def __init__(self, kubectl: KubeCtl):
         self.kubectl = kubectl
 
-    def ensure_deployed(self):
-        if self.kubectl.is_emulated_cluster():
-            raise RuntimeError("Khaos cannot be deployed on emulated clusters (kind, minikube, k3d, etc.).")
-
-        rc = self.kubectl.exec_command(f"kubectl get ns {KHAOS_NS} >/dev/null 2>&1 || kubectl create ns {KHAOS_NS}")
-
-        cmd = f"kubectl apply -f {KHAOS_DS}"
-        out = self.kubectl.exec_command(cmd)
-        if isinstance(out, tuple):
-            stdout, stderr, rc = (out + ("",))[:3]
-            if rc not in (0, None):
-                raise RuntimeError(f"kubectl apply failed (rc={rc}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")
+    def ensure_deployed(self, required_capabilities: Iterable[KhaosCapability] = ()):
+        self.kubectl.exec_command_checked(f"kubectl get ns {KHAOS_NS} >/dev/null 2>&1 || kubectl create ns {KHAOS_NS}")
+        self.kubectl.exec_command_checked(f"kubectl apply -f {KHAOS_DS}")
 
         # Wait for both DaemonSets to be ready (control-plane and worker)
         # The YAML file contains two DaemonSets: khaos-control-plane and khaos-worker
-        self.kubectl.exec_command(f"kubectl -n {KHAOS_NS} rollout status ds/khaos-control-plane --timeout=3m")
-        self.kubectl.exec_command(f"kubectl -n {KHAOS_NS} rollout status ds/khaos-worker --timeout=3m")
+        self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} rollout status ds/khaos-control-plane --timeout=3m")
+        self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} rollout status ds/khaos-worker --timeout=3m")
+        self._check_capabilities(frozenset(required_capabilities))
+
+    def _running_pods(self, profile: str | None = None) -> list[dict]:
+        selector = "app=khaos"
+        if profile:
+            selector += f",profile={profile}"
+        out = self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} get pods -l {shlex.quote(selector)} -o json")
+        data = json.loads(out or "{}")
+        return [item for item in data.get("items", []) if item.get("status", {}).get("phase") == "Running"]
+
+    def _check_capabilities(self, required_capabilities: frozenset[KhaosCapability]) -> None:
+        for capability in sorted(required_capabilities, key=str):
+            profile = "worker" if capability == KhaosCapability.DM_FLAKEY else None
+            pods = self._running_pods(profile=profile)
+            if not pods:
+                target = "worker nodes" if profile else "cluster nodes"
+                raise KhaosUnsupportedError(f"Khaos capability {capability.value!r} has no running pod on {target}")
+
+            for pod in pods:
+                pod_name = pod["metadata"]["name"]
+                node_name = pod.get("spec", {}).get("nodeName", "unknown")
+                try:
+                    self._check_pod_capability(pod_name, capability)
+                except RuntimeError as exc:
+                    raise KhaosUnsupportedError(
+                        f"Node {node_name!r} does not support Khaos capability {capability.value!r}: {exc}"
+                    ) from exc
+
+    def _check_pod_capability(self, pod_name: str, capability: KhaosCapability) -> None:
+        pod = shlex.quote(pod_name)
+        if capability == KhaosCapability.EBPF_SYSCALL:
+            self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} exec {pod} -- /khaos/khaos --check")
+            return
+
+        if capability == KhaosCapability.DM_FLAKEY:
+            script = """
+set -e
+command -v dmsetup >/dev/null
+command -v losetup >/dev/null
+command -v mkfs.ext4 >/dev/null
+modprobe dm_flakey
+dmsetup targets | grep -qw flakey
+""".strip()
+            self.kubectl.exec_command_checked(
+                f"kubectl -n {KHAOS_NS} exec {pod} -- nsenter -t 1 -m -u -i -n -p sh -ec {shlex.quote(script)}"
+            )
+            return
+
+        raise KhaosUnsupportedError(f"Unknown Khaos capability: {capability}")
 
     def teardown(self):
         self.kubectl.exec_command(f"kubectl delete ns {KHAOS_NS} --ignore-not-found")

--- a/sregym/service/khaos.yaml
+++ b/sregym/service/khaos.yaml
@@ -37,9 +37,15 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: khaos
-          image: ghcr.io/sregym/khaos:latest
-          imagePullPolicy: IfNotPresent
-          command: ["sleep", "infinity"]
+          image: ghcr.io/xlab-uiuc/khaos:latest
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              if [ "$(stat -f -c %t /sys/fs/bpf)" != "cafe4a11" ]; then
+                mount -t bpf bpf /sys/fs/bpf
+              fi
+              exec sleep infinity
           securityContext:
             privileged: true
           volumeMounts:
@@ -53,7 +59,7 @@ spec:
             - { name: var-run,      mountPath: /var/run, readOnly: true }
             - { name: host-dev,     mountPath: /dev }
       volumes:
-        - { name: sys-bpf,     hostPath: { path: /sys/fs/bpf, type: Directory } }
+        - { name: sys-bpf,     hostPath: { path: /sys/fs/bpf, type: DirectoryOrCreate } }
         - { name: sys-debug,   hostPath: { path: /sys/kernel/debug, type: Directory } }
         - { name: host-proc,   hostPath: { path: /proc, type: Directory } }
         - { name: host-cgroup, hostPath: { path: /sys/fs/cgroup, type: Directory } }
@@ -93,9 +99,15 @@ spec:
         node-role.kubernetes.io/worker: ""   # explicit worker targeting
       containers:
         - name: khaos
-          image: ghcr.io/sregym/khaos:latest
-          imagePullPolicy: IfNotPresent
-          command: ["sleep", "infinity"]
+          image: ghcr.io/xlab-uiuc/khaos:latest
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              if [ "$(stat -f -c %t /sys/fs/bpf)" != "cafe4a11" ]; then
+                mount -t bpf bpf /sys/fs/bpf
+              fi
+              exec sleep infinity
           securityContext:
             privileged: true
           volumeMounts:
@@ -110,7 +122,7 @@ spec:
             - { name: openebs,      mountPath: /var/openebs }
             - { name: host-dev,     mountPath: /dev }
       volumes:
-        - { name: sys-bpf,     hostPath: { path: /sys/fs/bpf, type: Directory } }
+        - { name: sys-bpf,     hostPath: { path: /sys/fs/bpf, type: DirectoryOrCreate } }
         - { name: sys-debug,   hostPath: { path: /sys/kernel/debug, type: Directory } }
         - { name: host-proc,   hostPath: { path: /proc, type: Directory } }
         - { name: host-cgroup, hostPath: { path: /sys/fs/cgroup, type: Directory } }

--- a/sregym/service/khaos_capabilities.py
+++ b/sregym/service/khaos_capabilities.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+
+class KhaosCapability(StrEnum):
+    """Host capabilities required by Khaos-backed problems."""
+
+    EBPF_SYSCALL = "ebpf-syscall"
+    DM_FLAKEY = "dm-flakey"

--- a/tests/integration/validate_problem.py
+++ b/tests/integration/validate_problem.py
@@ -112,13 +112,6 @@ def validate(problem_id: str, inject_timeout: int, recover_timeout: int, poll_in
         conductor.problem = problem
         conductor.app = problem.app
 
-        if problem.requires_khaos() and conductor.kubectl.is_emulated_cluster():
-            raise ValidationError(
-                "this problem requires Khaos / a real (non-emulated) cluster for fault "
-                "injection and cannot be validated on the CI kind cluster. Validate it "
-                "manually on a supported cluster and have a maintainer confirm."
-            )
-
         oracle = getattr(problem, "mitigation_oracle", None)
         if oracle is None:
             raise ValidationError(

--- a/tests/problems/test_problem_base.py
+++ b/tests/problems/test_problem_base.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from sregym.conductor.problems.base import Problem
+from sregym.service.khaos_capabilities import KhaosCapability
 from sregym.utils.decorators import mark_fault_injected
 
 
@@ -37,3 +38,23 @@ def test_explicit_empty_namespace_is_preserved():
     problem = ExampleProblem(app=app, namespace="")
 
     assert problem.namespace == ""
+
+
+def test_problem_without_khaos_has_no_host_capabilities():
+    app = SimpleNamespace(namespace="application-namespace")
+
+    problem = ExampleProblem(app=app)
+
+    assert problem.khaos_capabilities() == frozenset()
+
+
+def test_legacy_khaos_problem_defaults_to_ebpf_syscall_capability():
+    class LegacyKhaosProblem(ExampleProblem):
+        def requires_khaos(self) -> bool:
+            return True
+
+    app = SimpleNamespace(namespace="application-namespace")
+
+    problem = LegacyKhaosProblem(app=app)
+
+    assert problem.khaos_capabilities() == frozenset({KhaosCapability.EBPF_SYSCALL})

--- a/tests/service/test_khaos.py
+++ b/tests/service/test_khaos.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sregym.conductor.problems.silent_data_corruption import SilentDataCorruption
+from sregym.service.khaos import KhaosController, KhaosUnsupportedError
+from sregym.service.khaos_capabilities import KhaosCapability
+
+
+class FakeKubectl:
+    def __init__(self, *, fail_ebpf_check: bool = False):
+        self.commands: list[str] = []
+        self.fail_ebpf_check = fail_ebpf_check
+
+    def exec_command_checked(self, command: str, input_data=None, timeout=None):
+        self.commands.append(command)
+        if "get pods" in command:
+            pods = [
+                {
+                    "metadata": {"name": "khaos-control-plane-abc"},
+                    "spec": {"nodeName": "kind-control-plane"},
+                    "status": {"phase": "Running"},
+                },
+                {
+                    "metadata": {"name": "khaos-worker-abc"},
+                    "spec": {"nodeName": "kind-worker"},
+                    "status": {"phase": "Running"},
+                },
+            ]
+            if "profile=worker" in command:
+                pods = pods[1:]
+            return json.dumps({"items": pods})
+        if self.fail_ebpf_check and "/khaos/khaos --check" in command:
+            raise RuntimeError("UNSUPPORTED: kernel helper unavailable")
+        return ""
+
+    def exec_command(self, command: str, input_data=None):
+        self.commands.append(command)
+        return ""
+
+    def is_emulated_cluster(self):
+        raise AssertionError("Khaos support must be capability-based, not cluster-name-based")
+
+
+def test_ebpf_capability_is_checked_on_kind_nodes():
+    kubectl = FakeKubectl()
+
+    KhaosController(kubectl).ensure_deployed({KhaosCapability.EBPF_SYSCALL})
+
+    checks = [command for command in kubectl.commands if "/khaos/khaos --check" in command]
+    assert len(checks) == 2
+    assert any("khaos-control-plane-abc" in command for command in checks)
+    assert any("khaos-worker-abc" in command for command in checks)
+
+
+def test_failed_ebpf_preflight_reports_node_and_capability():
+    kubectl = FakeKubectl(fail_ebpf_check=True)
+
+    with pytest.raises(KhaosUnsupportedError, match="kind-control-plane.*ebpf-syscall"):
+        KhaosController(kubectl).ensure_deployed({KhaosCapability.EBPF_SYSCALL})
+
+
+def test_dm_flakey_preflight_only_targets_worker_nodes():
+    kubectl = FakeKubectl()
+
+    KhaosController(kubectl).ensure_deployed({KhaosCapability.DM_FLAKEY})
+
+    checks = [command for command in kubectl.commands if "modprobe dm_flakey" in command]
+    assert len(checks) == 1
+    assert "khaos-worker-abc" in checks[0]
+    assert "dmsetup targets" in checks[0]
+
+
+def test_daemonsets_bootstrap_bpffs_with_privileged_xlab_image():
+    manifest = Path("sregym/service/khaos.yaml").read_text()
+    daemonsets = list(yaml.safe_load_all(manifest))
+
+    assert len(daemonsets) == 2
+    for daemonset in daemonsets:
+        pod_spec = daemonset["spec"]["template"]["spec"]
+        container = pod_spec["containers"][0]
+        assert pod_spec["hostPID"] is True
+        assert container["securityContext"]["privileged"] is True
+        assert container["image"] == "ghcr.io/xlab-uiuc/khaos:latest"
+        assert container["imagePullPolicy"] == "Always"
+        assert "mount -t bpf" in container["args"][0]
+
+
+def test_silent_data_corruption_requests_dm_flakey_instead_of_ebpf():
+    assert SilentDataCorruption.khaos_capabilities(object()) == frozenset({KhaosCapability.DM_FLAKEY})


### PR DESCRIPTION
## Summary

- replace the blanket kind and emulated-cluster Khaos rejection with runtime capability checks
- classify Khaos-backed problems by the host feature they actually need: ebpf-syscall or dm-flakey
- run the Khaos --check verifier and attach preflight on every applicable node
- probe dm-flakey separately on worker nodes through the host namespaces
- bootstrap bpffs in the privileged hostPID DaemonSets and use ghcr.io/xlab-uiuc/khaos:latest
- preserve the existing skipped_khaos_required result while reporting the concrete unsupported node and capability
- allow integration validation to run Khaos problems on kind when the host kernel supports them

## Dependency

This PR depends on xlab-uiuc/khaos#37. That PR adds nested PID-namespace resolution and the --check command used here. Merge and publish the Khaos image before merging or exercising this PR.

Khaos remains in the xlab-uiuc organization for now. The manifest uses imagePullPolicy: Always so the coordinated main-branch image is fetched during this transition.

/validate-problem skip: this is an infrastructure and base-capability refactor whose dependent Khaos image is not published yet; the post-publication kind validation is documented below.

## Behavior

Existing syscall-fault problems default to the ebpf-syscall capability. SilentDataCorruption explicitly requests dm-flakey instead. Unsupported hosts are skipped based on the actual failed capability rather than the cluster implementation name.

The DaemonSets remain privileged and hostPID because kind support still relies on the node kernel; this is not an unprivileged eBPF implementation.

## Validation

- 138 tests passed across tests/conductor, tests/problems, tests/generators, and tests/service/test_khaos.py
- Ruff checks passed
- all repository pre-commit hooks passed
- manifest tests verify hostPID, privileged execution, bpffs bootstrap, image source, and pull policy
- controller tests cover kind node checks, detailed eBPF failure reporting, worker-only dm-flakey probing, and problem capability selection

## Remaining live validation

After xlab-uiuc/khaos#37 publishes its image, run one privileged end-to-end injection and recovery on a disposable kind cluster before release.
