### PR TITLE
Reply to evaluation commands with visual reports

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -222,36 +222,38 @@ jobs:
             });
 
       - name: Post running evaluation comment
+        id: report_comment
         if: needs.resolve.outputs.pr_number != ''
         continue-on-error: true
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          COMMENT_ID: ${{ needs.resolve.outputs.comment_id }}
           PROBLEM_ID: ${{ needs.resolve.outputs.problem_id }}
           ATTEMPTS: ${{ needs.resolve.outputs.attempts }}
           ZAI_MODEL: ${{ needs.resolve.outputs.model }}
         with:
           script: |
-            const marker = '<!-- problem-difficulty-evaluation -->';
+            const marker = `<!-- problem-difficulty-evaluation:${context.runId} -->`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const commandUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/` +
+              `${process.env.PR_NUMBER}#issuecomment-${process.env.COMMENT_ID}`;
             const body =
-              `${marker}\n## Problem Difficulty Evaluation\n\n` +
-              `**Status: Running** for \`${process.env.PROBLEM_ID}\` ` +
+              `${marker}\n> In response to [this command](${commandUrl}).\n\n` +
+              `## ⏳ Problem Difficulty Evaluation\n\n` +
+              `Running for \`${process.env.PROBLEM_ID}\` ` +
               `(${process.env.ATTEMPTS} attempts, \`${process.env.ZAI_MODEL}\`)\n\n` +
               `The secret-bearing evaluator runs trusted code from the default branch.\n\n` +
               `_[Live workflow run](${runUrl})_`;
 
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            const response = await github.rest.issues.createComment({
               owner, repo, issue_number,
+              body,
             });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+            core.setOutput('comment_id', response.data.id);
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -492,33 +494,40 @@ jobs:
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          COMMENT_ID: ${{ needs.resolve.outputs.comment_id }}
+          REPORT_COMMENT_ID: ${{ steps.report_comment.outputs.comment_id }}
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- problem-difficulty-evaluation -->';
+            const marker = `<!-- problem-difficulty-evaluation:${context.runId} -->`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const commandUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/` +
+              `${process.env.PR_NUMBER}#issuecomment-${process.env.COMMENT_ID}`;
+            const replyHeader = `> In response to [this command](${commandUrl}).`;
             let body;
             try {
-              body = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/evaluation-report.md`, 'utf8');
-              body = `${marker}\n${body}\n_[Workflow run](${runUrl})_`;
+              const report = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/evaluation-report.md`, 'utf8');
+              body = `${marker}\n${replyHeader}\n\n${report}\n_[Workflow run](${runUrl})_`;
             } catch (error) {
               body =
-                `${marker}\n## Problem Difficulty Evaluation\n\n` +
-                `**Status: Failed** before a pass-rate report was produced.\n\n` +
+                `${marker}\n${replyHeader}\n\n## Problem Difficulty Evaluation\n\n` +
+                `❌ **Failed** before a pass-rate report was produced.\n\n` +
                 `Inspect the [workflow run](${runUrl}) for the preflight or infrastructure error.`;
             }
 
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            const reportCommentId = Number(process.env.REPORT_COMMENT_ID);
+            if (Number.isInteger(reportCommentId) && reportCommentId > 0) {
+              try {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: reportCommentId, body });
+                return;
+              } catch (error) {
+                core.warning(`Could not update running comment ${reportCommentId}: ${error.message}`);
+              }
             }
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
 
       - name: React to triggering comment with final result
         if: always() && needs.resolve.outputs.comment_id != ''

--- a/sregym/problem_evaluation_report.py
+++ b/sregym/problem_evaluation_report.py
@@ -52,7 +52,7 @@ def build_report(
     for attempt in range(1, requested_attempts + 1):
         row = attempts.get(attempt)
         if row is None:
-            table_rows.append(f"| {attempt} | — | — | Incomplete | not run |")
+            table_rows.append(f"| {attempt} | — | — | ⚠️ | not run |")
             continue
 
         diagnosis = _as_bool(row.get("Diagnosis.success"))
@@ -77,15 +77,15 @@ def build_report(
                 missing.append("mitigation")
             detail = f"missing {' and '.join(missing)} result"
 
-        diagnosis_text = "Pass" if diagnosis is True else "Fail" if diagnosis is False else "—"
-        mitigation_text = "Pass" if mitigation is True else "Fail" if mitigation is False else "—"
+        diagnosis_text = "✅" if diagnosis is True else "❌" if diagnosis is False else "—"
+        mitigation_text = "✅" if mitigation is True else "❌" if mitigation is False else "—"
         if diagnosis is None or mitigation is None:
-            overall_text = "Incomplete"
+            overall_text = "⚠️"
         else:
             complete_attempts += 1
             overall = diagnosis and mitigation
             overall_passes += int(overall)
-            overall_text = "Pass" if overall else "Fail"
+            overall_text = "✅" if overall else "❌"
         table_rows.append(f"| {attempt} | {diagnosis_text} | {mitigation_text} | {overall_text} | {detail or '—'} |")
 
     if complete_attempts != requested_attempts:

--- a/tests/test_problem_evaluation_report.py
+++ b/tests/test_problem_evaluation_report.py
@@ -32,6 +32,7 @@ def test_report_keeps_mixed_result_as_not_saturated():
     )
 
     assert "**Overall pass rate:** 2/3 (67%)" in report
+    assert "| 2 | ✅ | ❌ | ❌ | — |" in report
     assert "🟢 **Not saturated**" in report
 
 
@@ -47,6 +48,6 @@ def test_report_does_not_count_infrastructure_failure_as_model_failure():
 
     assert "**Complete attempts:** 1" in report
     assert "**Overall pass rate:** 1/1 (100%)" in report
-    assert "| 2 | — | — | Incomplete | deployment failed |" in report
-    assert "| 3 | — | — | Incomplete | not run |" in report
+    assert "| 2 | — | — | ⚠️ | deployment failed |" in report
+    assert "| 3 | — | — | ⚠️ | not run |" in report
     assert "⚠️ **Inconclusive**" in report


### PR DESCRIPTION
## Summary

- create a fresh bot comment for each `/evaluate-problem` command instead of updating the oldest report in the PR
- link that comment directly to the triggering command and update it from ⏳ running to the final report
- render attempt outcomes as ✅, ❌, or ⚠️ instead of Pass, Fail, or Incomplete
- fall back to a new result comment if the running comment could not be updated

## Why

The first successful real-agent run produced the correct report, but the workflow updated a bot comment originally created two days earlier. That left the latest result above the triggering command in the flat PR timeline and made it easy to miss.

Successful run used for verification: https://github.com/SREGym/SREGym/actions/runs/33137268669

## Validation

- `actionlint .github/workflows/problem-difficulty-evaluation.yml`
- `uv run pytest -p no:cacheprovider tests/test_problem_evaluation_report.py -q` (3 passed)
- repository hooks passed for all changed files
- regenerated the report from run 33137268669's real result CSV; it rendered one ❌ attempt and two ✅ attempts with the original 2/3 pass rates
