### PR TITLE
Fix mitigation results being lost

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -458,7 +458,7 @@ jobs:
             exit 1
           fi
 
-          uv run python -m sregym.problem_evaluation_report \
+          uv run python -m sregym.results.report \
             --csv "$result_csv" \
             --problem "$PROBLEM_ID" \
             --model "$ZAI_MODEL" \

--- a/.gitignore
+++ b/.gitignore
@@ -244,7 +244,7 @@ python-database
 # Keep committed test fixtures (session logs the trace converter reads).
 !tests/**/fixtures/**/*.jsonl
 sregym/generators/noise/noise_config.yaml
-results/
+/results/
 logs/
 
 docker/agents/build-context/

--- a/cli.py
+++ b/cli.py
@@ -115,9 +115,8 @@ class HumanAgent:
                 continue
             try:
                 resp = await self.conductor.submit(sol)
-                # Wait for background evaluation to finish before re-prompting,
-                if self.conductor._submit_future is not None:
-                    await asyncio.wrap_future(self.conductor._submit_future)
+                # Wait for grading and any chained cleanup before re-prompting.
+                await self.conductor.wait_for_submission_work(timeout=None)
             except Exception as e:
                 env = f"[❌] Grading error: {e}"
             else:

--- a/clients/autosubmit/autosubmit_agent.py
+++ b/clients/autosubmit/autosubmit_agent.py
@@ -1,6 +1,7 @@
 import os
-import subprocess
 from time import sleep
+
+import requests
 
 api_hostname = os.getenv("API_HOSTNAME", "localhost")
 api_port = os.getenv("API_PORT", "8000")
@@ -10,20 +11,21 @@ server_url = f"http://{api_hostname}:{api_port}"
 def automatic_submit():
     ctr = 0
     while ctr < 10000:
-        subprocess.run(
-            [
-                "curl",
-                "-X",
-                "POST",
-                f"{server_url}/submit",
-                "-H",
-                "Content-Type: application/json",
-                "-d",
-                '{"solution":"yes"}',
-            ],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            stage_response = requests.get(f"{server_url}/status", timeout=10)
+            stage_response.raise_for_status()
+            stage = stage_response.json().get("stage")
+            if stage == "done":
+                return
+            if stage in {"diagnosis", "mitigation"}:
+                response = requests.post(
+                    f"{server_url}/submit",
+                    json={"stage": stage, "solution": "yes" if stage == "diagnosis" else ""},
+                    timeout=310,
+                )
+                response.raise_for_status()
+        except requests.RequestException:
+            pass
         sleep(60)
         ctr += 1
 

--- a/clients/demo/driver.py
+++ b/clients/demo/driver.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import json
 import logging
@@ -54,7 +55,44 @@ def get_current_datetime_formatted():
     return formatted_datetime
 
 
-async def manual_submit_tool(ans: str) -> str:
+def parse_submit_command(command: str) -> tuple[str | None, str] | None:
+    """Parse preferred staged and legacy one-argument demo submissions."""
+    try:
+        expression = ast.parse(command, mode="eval").body
+    except SyntaxError:
+        return None
+    if not isinstance(expression, ast.Call):
+        return None
+    if not isinstance(expression.func, ast.Name) or expression.func.id != "submit":
+        return None
+    if expression.keywords:
+        return None
+    try:
+        arguments = [ast.literal_eval(argument) for argument in expression.args]
+    except (ValueError, TypeError):
+        return None
+    if len(arguments) == 1 and isinstance(arguments[0], str):
+        return None, arguments[0]
+    if (
+        len(arguments) == 2
+        and isinstance(arguments[0], str)
+        and arguments[0] in {"diagnosis", "mitigation"}
+        and isinstance(arguments[1], str)
+    ):
+        return arguments[0], arguments[1]
+    return None
+
+
+def resolve_demo_submission_stage(explicit_stage: str | None, previous_accepted_stage: str | None) -> str | None:
+    """Resolve legacy demo calls without racing diagnosis evaluation."""
+    if explicit_stage is not None:
+        return explicit_stage
+    if previous_accepted_stage == "diagnosis":
+        return "mitigation"
+    return None
+
+
+async def manual_submit_tool(ans: str, *, stage: str | None = None) -> str:
     ltc = LanggraphToolConfig()
     logging.info(f"_manually_ submitting to benchmark, answer: {ans}")
 
@@ -63,14 +101,16 @@ async def manual_submit_tool(ans: str) -> str:
         ClientSession(read_stream, write_stream) as session,
     ):
         await session.initialize()
-        await session.call_tool(
-            "submit",
-            arguments={
-                "ans": ans,
-            },
-        )
+        arguments = {"ans": ans}
+        if stage is not None:
+            arguments["stage"] = stage
+        result = await session.call_tool("submit", arguments=arguments)
+        result = ast.literal_eval(result.content[0].text)
+        if result.get("status") not in {"200", "done"}:
+            stage_label = stage or "current-stage"
+            raise RuntimeError(f"Benchmark rejected the {stage_label} submission: {result}")
         logger.info("Submission complete. No further action is needed.")
-        return "Submitted"
+        return result.get("stage") or stage or "done"
 
 
 def save_trajectory(events, problem_id, output_dir=None):
@@ -129,6 +169,10 @@ async def run_demo_agent():
     )
 
     events = []
+    # A legacy demo file uses submit("answer") twice. After the first call is
+    # accepted as diagnosis, explicitly target mitigation on the next call so
+    # it can wait safely while diagnosis grading is still running.
+    previous_accepted_stage: str | None = None
 
     # Ensure any stale trigger files are removed
     for f in [NEXT_FILE, SKIP_FILE, QUIT_FILE]:
@@ -158,18 +202,20 @@ async def run_demo_agent():
                 continue
 
             # Check if the command is a deterministic submission
-            # Matches: submit("text") or submit('text')
-            import re
+            # Prefer submit("diagnosis", "text") / submit("mitigation", ""),
+            # but keep the legacy submit("text") form for old demo scripts.
+            submission = parse_submit_command(cmd)
 
-            submit_match = re.match(r"^submit\([\"\'](.*)[\"\']\)$", cmd)
-
-            if submit_match:
-                ans = submit_match.group(1)
-                logger.info(f"[Turn {idx + 1}] Performing deterministic submission: {ans}")
+            if submission:
+                stage, ans = submission
+                requested_stage = resolve_demo_submission_stage(stage, previous_accepted_stage)
+                stage_label = requested_stage or "current-stage"
+                logger.info(f"[Turn {idx + 1}] Performing deterministic {stage_label} submission: {ans}")
                 start_time = time.perf_counter()
                 try:
-                    await manual_submit_tool(ans)
-                    text_result = f"Submitted answer: {ans}"
+                    accepted_stage = await manual_submit_tool(ans, stage=requested_stage)
+                    previous_accepted_stage = accepted_stage
+                    text_result = f"Submitted {stage_label} answer: {ans}"
                     status = "success"
                 except Exception as e:
                     logger.error(f"[Turn {idx + 1}] Submission failed: {e}")
@@ -218,13 +264,6 @@ async def run_demo_agent():
             events.append(event)
 
             await asyncio.sleep(0.5)
-
-    # Manual submission at the end
-    logger.info("All commands executed. Submitting results.")
-    try:
-        await manual_submit_tool("Demo agent execution completed.")
-    except Exception as e:
-        logger.error(f"Failed to submit: {e}")
 
     save_trajectory(events, problem_id)
     logger.info("Demo Agent run finished.")

--- a/clients/demo/kubectl_cmds.txt
+++ b/clients/demo/kubectl_cmds.txt
@@ -1,4 +1,4 @@
 kubectl scale deployment user-service --replicas=1 -n social-network
-submit("Root cause")
+submit("diagnosis", "Root cause")
 kubectl patch deployment user-service -n social-network -p '{"spec":{"replicas":1}}'
-submit("end")
+submit("mitigation", "")

--- a/clients/stratus/stratus_agent/base_agent.py
+++ b/clients/stratus/stratus_agent/base_agent.py
@@ -83,7 +83,7 @@ class BaseAgent:
             plain_response = self.llm.inference(messages=state["messages"] + [prompt, ai_message, plain_prompt])
             ans = plain_response.content if isinstance(plain_response, AIMessage) else ""
 
-        await manual_submit_tool(ans=ans)
+        await manual_submit_tool(ans=ans, stage="diagnosis")
         self.logger.info(f"Force submitted with answer: {ans!r}")
         return {"submitted": True, "messages": [prompt]}
 

--- a/clients/stratus/stratus_agent/driver/driver.py
+++ b/clients/stratus/stratus_agent/driver/driver.py
@@ -557,14 +557,14 @@ async def mitigation_task_main(diagnosis_summary):
 
             if has_succeeded:
                 logger.info("Oracles succeeded; making real submission.")
-                await manual_submit_tool("")
+                await manual_submit_tool("", stage="mitigation")
                 break
 
             # Oracles failed — decide whether to retry or submit
             is_last_attempt = (curr_attempt + 1) >= mitigation_agent_max_retry_attempts
             if is_last_attempt:
                 logger.info("Last attempt reached; making real submission regardless of oracle results.")
-                await manual_submit_tool("")
+                await manual_submit_tool("", stage="mitigation")
                 break
 
             if mitigation_submission_requested(last_state):
@@ -666,7 +666,7 @@ async def mitigation_task_main(diagnosis_summary):
 
             if has_succeeded:
                 logger.info("Oracles succeeded; making real submission.")
-                await manual_submit_tool("")
+                await manual_submit_tool("", stage="mitigation")
                 break
 
             # Oracles failed — decide whether to retry (with rollback) or submit
@@ -702,7 +702,7 @@ async def mitigation_task_main(diagnosis_summary):
                 curr_attempt += 1
             else:
                 logger.info("Last attempt reached; making real submission regardless of oracle results.")
-                await manual_submit_tool("")
+                await manual_submit_tool("", stage="mitigation")
                 break
 
         agent_exec_stats["agent_name"] = agent_names_lst
@@ -776,53 +776,55 @@ async def main():
 
     # Collect all trajectories from this run
     all_trajectories = []
-
-    # run diagnosis agent 1 time for diagnosis (formerly called localization)
-    # here, running the file's main function should suffice
-    logger.info("*" * 25 + " Starting [diagnosis agent] for [diagnosis] " + "*" * 25)
-    (
-        diagnosis_agent_exec_stats,
-        diagnosis_agent_last_state,
-        diagnosis_graph_events,
-    ) = await diagnosis_with_localization_task_main()
-    all_trajectories.append({"stage": "diagnosis", "events": diagnosis_graph_events})
-    agent_names.append("diagnosis_agent")
-    agent_in_tokens.append(diagnosis_agent_exec_stats["input_tokens"])
-    agent_out_tokens.append(diagnosis_agent_exec_stats["output_tokens"])
-    agent_total_tokens.append(diagnosis_agent_exec_stats["total_tokens"])
-    agent_times.append(diagnosis_agent_exec_stats["time"])
-    agent_steps.append(diagnosis_agent_exec_stats["steps"])
-    agent_retry_attempts.append(diagnosis_agent_exec_stats["num_retry_attempts"])
-    agent_rollback_stack.append(diagnosis_agent_exec_stats["rollback_stack"])
-    agent_oracle_results.append(diagnosis_agent_exec_stats["oracle_results"])
-    logger.info("*" * 25 + " Finished [diagnosis agent] " + "*" * 25)
-
-    file_parent_dir = Path(__file__).resolve().parent.parent
-    diagnosis_agent_config_path = file_parent_dir.parent / "configs" / "diagnosis_agent_config.yaml"
-    diagnosis_agent_config = yaml.safe_load(diagnosis_agent_config_path.read_text())
-    diagnosis_agent_prompt_path = file_parent_dir.parent / "configs" / diagnosis_agent_config["prompts_path"]
-    diagnosis_agent_prompts = yaml.safe_load(diagnosis_agent_prompt_path.read_text())
-
-    # Check if diagnosis prompts have the summary prompt, otherwise use a default key
-    summary_prompt_key = (
-        "diagnosis_summary_prompt"
-        if "diagnosis_summary_prompt" in diagnosis_agent_prompts
-        else "localization_summary_prompt"
+    benchmark_status = await wait_for_stage_switch(
+        current_stage="setup",
+        target_stages={"diagnosis", "mitigation", "done"},
     )
-    diagnosis_fault_summary = generate_run_summary(
-        diagnosis_agent_last_state, diagnosis_agent_prompts[summary_prompt_key]
-    )
+    diagnosis_fault_summary = "No diagnosis summary is available because this benchmark starts at mitigation."
 
-    # Diagnosis submission is graded asynchronously, so poll for the next stage
-    # instead of sampling status once and racing the stage transition.
-    try:
-        benchmark_status = await wait_for_stage_switch(
-            current_stage="diagnosis",
-            target_stages={"mitigation", "done"},
+    if benchmark_status == "diagnosis":
+        logger.info("*" * 25 + " Starting [diagnosis agent] for [diagnosis] " + "*" * 25)
+        (
+            diagnosis_agent_exec_stats,
+            diagnosis_agent_last_state,
+            diagnosis_graph_events,
+        ) = await diagnosis_with_localization_task_main()
+        all_trajectories.append({"stage": "diagnosis", "events": diagnosis_graph_events})
+        agent_names.append("diagnosis_agent")
+        agent_in_tokens.append(diagnosis_agent_exec_stats["input_tokens"])
+        agent_out_tokens.append(diagnosis_agent_exec_stats["output_tokens"])
+        agent_total_tokens.append(diagnosis_agent_exec_stats["total_tokens"])
+        agent_times.append(diagnosis_agent_exec_stats["time"])
+        agent_steps.append(diagnosis_agent_exec_stats["steps"])
+        agent_retry_attempts.append(diagnosis_agent_exec_stats["num_retry_attempts"])
+        agent_rollback_stack.append(diagnosis_agent_exec_stats["rollback_stack"])
+        agent_oracle_results.append(diagnosis_agent_exec_stats["oracle_results"])
+        logger.info("*" * 25 + " Finished [diagnosis agent] " + "*" * 25)
+
+        file_parent_dir = Path(__file__).resolve().parent.parent
+        diagnosis_agent_config_path = file_parent_dir.parent / "configs" / "diagnosis_agent_config.yaml"
+        diagnosis_agent_config = yaml.safe_load(diagnosis_agent_config_path.read_text())
+        diagnosis_agent_prompt_path = file_parent_dir.parent / "configs" / diagnosis_agent_config["prompts_path"]
+        diagnosis_agent_prompts = yaml.safe_load(diagnosis_agent_prompt_path.read_text())
+        summary_prompt_key = (
+            "diagnosis_summary_prompt"
+            if "diagnosis_summary_prompt" in diagnosis_agent_prompts
+            else "localization_summary_prompt"
         )
-    except TimeoutError as e:
-        logger.warning("Timed out waiting for post-diagnosis stage switch: %s", e)
-        benchmark_status = get_benchmark_status()
+        diagnosis_fault_summary = generate_run_summary(
+            diagnosis_agent_last_state, diagnosis_agent_prompts[summary_prompt_key]
+        )
+
+        try:
+            benchmark_status = await wait_for_stage_switch(
+                current_stage="diagnosis",
+                target_stages={"mitigation", "done"},
+            )
+        except TimeoutError as e:
+            logger.warning("Timed out waiting for post-diagnosis stage switch: %s", e)
+            benchmark_status = get_benchmark_status()
+    elif benchmark_status == "mitigation":
+        logger.info("Benchmark starts at mitigation; skipping diagnosis agent")
     logger.info(f"Benchmark status after diagnosis polling: {benchmark_status}")
 
     mitigation_last_state = None

--- a/clients/stratus/tools/submit_tool.py
+++ b/clients/stratus/tools/submit_tool.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 langgraph_tool_config = LanggraphToolConfig()
 
 
+def _require_accepted_submission(result: dict, stage: str) -> None:
+    if result.get("status") not in {"200", "done"}:
+        raise RuntimeError(f"Benchmark rejected the {stage} submission: {result}")
+
+
 def get_benchmark_status() -> str:
     """
     Check the current status of the benchmark.
@@ -73,6 +78,7 @@ async def submit_tool(
         "submit",
         arguments={
             "ans": ans,
+            "stage": "diagnosis",
         },
     )
     result = result.content[0].text
@@ -152,7 +158,7 @@ async def rollback_submit_tool(tool_call_id: Annotated[str, InjectedToolCallId])
     )
 
 
-async def manual_submit_tool(ans: str) -> str:
+async def manual_submit_tool(ans: str, *, stage: str) -> str:
     # makes http call to benchmark submission server
     logging.info(f"_manually_ submitting to benchmark, answer: {ans}")
 
@@ -164,15 +170,18 @@ async def manual_submit_tool(ans: str) -> str:
 
     await session.initialize()
 
-    await session.call_tool(
+    result = await session.call_tool(
         "submit",
         arguments={
             "ans": ans,
+            "stage": stage,
         },
     )
+    result = ast.literal_eval(result.content[0].text)
     try:
         await exit_stack.aclose()
     except Exception as e:
         logger.debug(f"{type(e).__name__} ignored, as it's expected")
+    _require_accepted_submission(result, stage)
     logger.info("Submission complete. No further action is needed.")
     return "Submitted"

--- a/clients/tierzero/driver.py
+++ b/clients/tierzero/driver.py
@@ -184,12 +184,12 @@ def wait_for_stage(target_stages: set[str], timeout: int = 300) -> str:
     raise TimeoutError(f"Conductor did not reach {target_stages} within {timeout}s")
 
 
-def submit_to_conductor(solution: str) -> None:
+def submit_to_conductor(solution: str, stage: str) -> None:
     """POST /submit to conductor."""
     logger.info(f"Submitting to conductor ({len(solution)} chars)")
     resp = requests.post(
         f"{CONDUCTOR_URL}/submit",
-        json={"solution": solution},
+        json={"stage": stage, "solution": solution},
         timeout=30,
     )
     if not resp.ok:
@@ -263,11 +263,11 @@ def main():
         logger.error("TIERZERO_ORG_API_KEY is not set")
         sys.exit(1)
 
-    # ---- Wait for conductor to be ready for diagnosis ----
+    # ---- Wait for conductor to be ready for an agent stage ----
     try:
-        stage = wait_for_stage({"diagnosis"}, timeout=300)
+        stage = wait_for_stage({"diagnosis", "mitigation"}, timeout=300)
     except TimeoutError:
-        logger.error("Timed out waiting for conductor to reach diagnosis stage")
+        logger.error("Timed out waiting for conductor to reach an agent stage")
         sys.exit(1)
 
     # ---- Get problem info ----
@@ -284,43 +284,41 @@ def main():
     # ================================================================
     # PHASE 1: DIAGNOSIS
     # ================================================================
-    logger.info("=" * 40 + " DIAGNOSIS " + "=" * 40)
-
-    diagnosis_prompt = DIAGNOSIS_PROMPT.format(**params)
     diagnosis_interaction_id = None
     diagnosis_text = ""
+    if stage == "diagnosis":
+        logger.info("=" * 40 + " DIAGNOSIS " + "=" * 40)
+        diagnosis_prompt = DIAGNOSIS_PROMPT.format(**params)
 
-    try:
-        diagnosis_interaction_id = create_interaction(diagnosis_prompt)
-        result = poll_interaction(diagnosis_interaction_id)
+        try:
+            diagnosis_interaction_id = create_interaction(diagnosis_prompt)
+            result = poll_interaction(diagnosis_interaction_id)
 
-        if result.get("status") == "COMPLETED":
-            diagnosis_text = extract_content(result)
-            logger.info(f"Diagnosis result ({len(diagnosis_text)} chars): {diagnosis_text[:300]}...")
-        else:
-            logger.error(f"Diagnosis interaction status: {result.get('status')}")
+            if result.get("status") == "COMPLETED":
+                diagnosis_text = extract_content(result)
+                logger.info(f"Diagnosis result ({len(diagnosis_text)} chars): {diagnosis_text[:300]}...")
+            else:
+                logger.error(f"Diagnosis interaction status: {result.get('status')}")
+                diagnosis_text = "Unable to complete diagnosis"
+        except Exception as e:
+            logger.error(f"Diagnosis phase failed: {e}")
             diagnosis_text = "Unable to complete diagnosis"
-    except Exception as e:
-        logger.error(f"Diagnosis phase failed: {e}")
-        diagnosis_text = "Unable to complete diagnosis"
 
-    # Submit diagnosis to conductor
-    submit_to_conductor(diagnosis_text)
+        submit_to_conductor(diagnosis_text, "diagnosis")
+        _save_stage_result(logs_dir, "diagnosis", diagnosis_interaction_id, diagnosis_text)
 
-    # Save diagnosis result
-    _save_stage_result(logs_dir, "diagnosis", diagnosis_interaction_id, diagnosis_text)
+        try:
+            stage = wait_for_stage({"mitigation", "done"}, timeout=300)
+        except TimeoutError:
+            logger.error("Timed out waiting for mitigation stage")
+            sys.exit(1)
 
-    # ---- Wait for conductor to transition to mitigation ----
-    try:
-        stage = wait_for_stage({"mitigation", "done"}, timeout=300)
-    except TimeoutError:
-        logger.error("Timed out waiting for mitigation stage")
-        sys.exit(1)
-
-    if stage == "done":
-        logger.info("Conductor went straight to done after diagnosis")
-        _finish(logs_dir, problem_id)
-        return
+        if stage == "done":
+            logger.info("Conductor went straight to done after diagnosis")
+            _finish(logs_dir, problem_id)
+            return
+    else:
+        logger.info("Benchmark starts at mitigation; skipping diagnosis")
 
     # ================================================================
     # PHASE 2: MITIGATION
@@ -348,7 +346,7 @@ def main():
         logger.error(f"Mitigation phase failed: {e}")
 
     # Submit empty string for mitigation (fix has been applied via kubectl)
-    submit_to_conductor("")
+    submit_to_conductor("", "mitigation")
 
     # Save mitigation result
     _save_stage_result(logs_dir, "mitigation", mitigation_interaction_id, mitigation_text)
@@ -358,7 +356,7 @@ def main():
         stage = wait_for_stage({"resolution", "done", "tearing_down"}, timeout=300)
         if stage == "resolution":
             logger.info("Resolution stage reached, submitting empty string")
-            submit_to_conductor("")
+            submit_to_conductor("", "mitigation")
             wait_for_stage({"done", "tearing_down"}, timeout=300)
     except TimeoutError:
         logger.warning("Timed out waiting for done stage")

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from sregym.conductor.conductor import Conductor, ConductorConfig
 from sregym.conductor.conductor_api import request_shutdown, run_api
 from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.problem_sets import PROBLEM_SETS
+from sregym.results.resume import complete_resume_rows
 from sregym.run_artifacts import ArtifactFinalizationError, RunArtifacts
 from sregym.service.container_runner import ContainerRunner, ExecInput, get_container_host_bind_address
 from sregym.service.internet_policy import InternetPolicy
@@ -40,6 +41,16 @@ LAUNCHER = AgentLauncher()
 logger = logging.getLogger(__name__)
 _driver_results: list[dict] = []
 _driver_base_dir: Path | None = None
+_driver_error: BaseException | None = None
+SUBMISSION_DRAIN_TIMEOUT_SECONDS = float(os.getenv("SUBMISSION_DRAIN_TIMEOUT_SECONDS", "300"))
+
+
+class BenchmarkCampaignAborted(RuntimeError):
+    """The campaign stopped safely after persisting its partial results."""
+
+    def __init__(self, message: str, partial_results: list[dict]):
+        super().__init__(message)
+        self.partial_results = partial_results
 
 
 def run_preflight_check(
@@ -236,6 +247,28 @@ def driver_loop(
 
         all_results_for_agent = []
 
+        async def finish_problem_with_deadline(timeout_reason: str) -> bool:
+            """Run safety cleanup without letting a stuck Kubernetes call hang the campaign."""
+            try:
+                conductor.finish_problem_in_background()
+                await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                conductor.abandon_submission_work()
+                conductor.results["cleanup_timed_out"] = True
+                conductor.record_incomplete_attempt(timeout_reason)
+                console.log(
+                    "⛔ Conductor cleanup did not finish before the drain deadline; "
+                    "aborting without starting another attempt"
+                )
+                return False
+            except Exception as exc:
+                conductor.results["cleanup_failed"] = True
+                conductor.results["cleanup_error"] = f"{type(exc).__name__}: {exc}"
+                conductor.record_incomplete_attempt("cleanup_failed")
+                console.log(f"⛔ Conductor cleanup raised: {exc}")
+                return False
+            return not conductor.results.get("cleanup_failed", False)
+
         # Get all problem IDs and apply an explicit CLI selection when supplied.
         problem_ids = conductor.problems.get_problem_ids()
         all_problem_ids = conductor.problems.get_problem_ids(all=True)
@@ -266,20 +299,25 @@ def driver_loop(
         from collections import Counter
 
         completed_problems: set[str] = set()
+        completed_attempts: dict[str, set[int]] = {}
         attempt_counts: Counter[str] = Counter()
         if resume_csv:
             try:
                 with open(resume_csv, newline="") as f:
                     reader = csv.DictReader(f)
                     resume_rows = list(reader)
-                # Group by problem_id and count attempts
-                attempt_counts = Counter(r["problem_id"] for r in resume_rows)
-                completed_problems = {pid for pid, count in attempt_counts.items() if count >= n_attempts}
 
-                for row in resume_rows:
+                complete_rows = complete_resume_rows(resume_rows, n_attempts)
+
+                for (pid, attempt_number), row in complete_rows.items():
+                    completed_attempts.setdefault(pid, set()).add(attempt_number)
                     all_results_for_agent.append(row)
+
+                attempt_counts = Counter({pid: len(attempts) for pid, attempts in completed_attempts.items()})
+                completed_problems = {pid for pid, count in attempt_counts.items() if count >= n_attempts}
                 console.log(
-                    f"📋 Resuming from {resume_csv}: {len(completed_problems)} problems already done, skipping them"
+                    f"📋 Resuming from {resume_csv}: {len(completed_problems)} problems already done; "
+                    "incomplete attempts will be rerun"
                 )
             except Exception as e:
                 console.log(f"⚠️  Failed to load resume CSV: {e}")
@@ -306,7 +344,6 @@ def driver_loop(
         for pid in problem_ids:
             if pid in completed_problems:
                 console.log(f"⏭️  Skipping already-completed problem: {pid}")
-                progress.advance(task_id, n_attempts)
                 continue
 
             conductor.problem_id = pid
@@ -314,7 +351,11 @@ def driver_loop(
             # Keep a record of results for this problem in a temp file in case an attempt fails
             tmp_path = f"_running_{pid}_{agent_to_run}_results.csv"
 
-            for attempt in range(1, n_attempts + 1):
+            attempts_to_run = [
+                attempt for attempt in range(1, n_attempts + 1) if attempt not in completed_attempts.get(pid, set())
+            ]
+            for attempt_position, attempt in enumerate(attempts_to_run):
+                abort_campaign_after_attempt = False
                 progress.update(
                     task_id,
                     description=f"[cyan]Benchmarking {agent_to_run or 'agent'} — {pid} (attempt {attempt}/{n_attempts})",
@@ -324,6 +365,7 @@ def driver_loop(
                 # Retry start_problem up to 3 times to handle transient deploy failures
                 max_deploy_retries = 3
                 result = None
+                deploy_cleanup_failed = False
                 for deploy_attempt in range(1, max_deploy_retries + 1):
                     try:
                         result = await conductor.start_problem()
@@ -335,10 +377,13 @@ def driver_loop(
                         )
                         if deploy_attempt < max_deploy_retries:
                             console.log("🧹 Cleaning up before retry...")
-                            try:
-                                conductor._finish_problem()
-                            except Exception as cleanup_err:
-                                console.log(f"⚠️  Cleanup error (non-fatal): {cleanup_err}")
+                            cleanup_succeeded = await finish_problem_with_deadline(
+                                "cleanup_timeout_after_deploy_failure"
+                            )
+                            if not cleanup_succeeded:
+                                deploy_cleanup_failed = True
+                                console.log("⛔ Cleanup failed; refusing to retry deployment against uncertain state")
+                                break
                             console.log(f"🔄 Retrying start_problem for '{pid}'...")
                         else:
                             console.log(
@@ -350,29 +395,59 @@ def driver_loop(
                     # The inner retry loop already logged the failure. Don't crash the
                     # entire driver — record the failure, clean up cluster state, and
                     # move on to the next problem so the benchmark can keep making progress.
-                    try:
-                        conductor._finish_problem()
-                    except Exception as cleanup_err:
-                        console.log(f"⚠️  Cleanup after exhausted deploy retries failed (non-fatal): {cleanup_err}")
+                    if not deploy_cleanup_failed:
+                        deploy_cleanup_failed = not await finish_problem_with_deadline(
+                            "cleanup_timeout_after_deploy_failure"
+                        )
+                    if deploy_cleanup_failed and conductor.results.get("run_status") != "incomplete":
+                        conductor.record_incomplete_attempt("cleanup_failed")
                     snapshot = {
                         "problem_id": pid,
                         "attempt": attempt,
                         "deploy_failed": True,
                     }
+                    for stage, outcome in conductor.results.items():
+                        if isinstance(outcome, dict):
+                            for key, value in outcome.items():
+                                snapshot[f"{stage}.{key}"] = value
+                        else:
+                            snapshot[stage] = outcome
                     all_results_for_agent.append(snapshot)
                     fieldnames = sorted({key for row in all_results_for_agent for key in row})
                     with open(tmp_path, "w", newline="") as csvfile:
                         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
                         writer.writeheader()
                         writer.writerows(all_results_for_agent)
+                    if deploy_cleanup_failed:
+                        final_csv_path = base_dir / str(agent_to_run) / pid / f"{pid}_{agent_to_run}_results.csv"
+                        final_csv_path.parent.mkdir(parents=True, exist_ok=True)
+                        os.replace(tmp_path, final_csv_path)
+                        progress.advance(task_id, len(attempts_to_run) - attempt_position)
+                        progress.stop()
+                        if not use_external_harness:
+                            conductor.stop_k8s_proxy()
+                        if conductor.results.get("cleanup_timed_out"):
+                            deploy_abort_reason = (
+                                "Benchmark cleanup did not terminate during deployment; "
+                                "later attempts were not started against uncertain state."
+                            )
+                        else:
+                            deploy_abort_reason = (
+                                "Benchmark cleanup failed during deployment; "
+                                "later attempts were not started against uncertain state."
+                            )
+                        raise BenchmarkCampaignAborted(
+                            deploy_abort_reason,
+                            [{agent_to_run: all_results_for_agent}],
+                        )
                     console.log(f"⏭️  Skipping remaining attempts for '{pid}' and moving to next problem")
                     # Account for this attempt + remaining skipped attempts on the bar.
-                    progress.advance(task_id, n_attempts - attempt + 1)
+                    progress.advance(task_id, len(attempts_to_run) - attempt_position)
                     break
 
                 if result == StartProblemResult.SKIPPED_KHAOS_REQUIRED:
                     console.log(f"⏭️  Skipping problem '{pid}': requires Khaos but running on emulated cluster")
-                    progress.advance(task_id, n_attempts - attempt + 1)
+                    progress.advance(task_id, len(attempts_to_run) - attempt_position)
                     break  # Skip to next problem
 
                 # If using external harness, fault is injected - exit now
@@ -392,25 +467,68 @@ def driver_loop(
                 )
                 agent_proc = None
 
-                with _artifact_environment(run):
-                    reg = get_agent(
-                        agent_to_run,
-                        path=Path(os.path.dirname(os.path.abspath(__file__))) / "agents.yaml",
-                    )
-                    if reg:
-                        agent_proc = await LAUNCHER.ensure_started(reg)
+                if conductor.stage_sequence:
+                    with _artifact_environment(run):
+                        reg = get_agent(
+                            agent_to_run,
+                            path=Path(os.path.dirname(os.path.abspath(__file__))) / "agents.yaml",
+                        )
+                        if reg:
+                            agent_proc = await LAUNCHER.ensure_started(reg)
+                else:
+                    console.log("⏩ No agent stages are configured; waiting only for bounded cleanup")
+                    if conductor.close_submissions():
+                        try:
+                            await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                        except TimeoutError:
+                            abort_campaign_after_attempt = True
+                            conductor.abandon_submission_work()
+                            conductor.results["cleanup_timed_out"] = True
+                            conductor.record_incomplete_attempt("cleanup_timeout_without_agent_stages")
+                        except Exception as exc:
+                            abort_campaign_after_attempt = True
+                            conductor.results["cleanup_failed"] = True
+                            conductor.results["cleanup_error"] = f"{type(exc).__name__}: {exc}"
+                            conductor.record_incomplete_attempt("cleanup_failed")
 
                 timed_out = False
                 agent_start_time = time.time()
-                while conductor.submission_stage != "done":
+                while not abort_campaign_after_attempt and conductor.submission_stage != "done":
                     if time.time() - agent_start_time > agent_timeout:
                         timed_out = True
                         console.log(f"⏰ Agent timeout ({agent_timeout}s) exceeded, killing agent")
+                        submission_work = conductor.close_submissions()
                         LAUNCHER.cleanup_agent(agent_to_run)
                         conductor.results["timed_out"] = True
                         conductor.results["agent_timeout_seconds"] = agent_timeout
-                        console.log("🧹 Running conductor cleanup after agent timeout...")
-                        conductor._finish_problem()
+                        evaluation_failed = False
+                        if submission_work:
+                            console.log("⏳ Waiting for the accepted submission evaluation to complete...")
+                            try:
+                                await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                            except TimeoutError:
+                                evaluation_failed = True
+                                abort_campaign_after_attempt = True
+                                conductor.abandon_submission_work()
+                                console.log(
+                                    "⛔ Submission evaluation did not finish before the drain deadline; "
+                                    "aborting the campaign without concurrent cluster cleanup"
+                                )
+                            except Exception as e:
+                                evaluation_failed = True
+                                console.log(f"⚠️  Conductor evaluation raised: {e}")
+                        if abort_campaign_after_attempt:
+                            reason = "evaluation_timeout_after_agent_timeout"
+                        else:
+                            reason = "evaluation_failed_after_agent_timeout" if evaluation_failed else "agent_timeout"
+                        if evaluation_failed or conductor.missing_submission_stages():
+                            conductor.record_incomplete_attempt(reason)
+                        if not abort_campaign_after_attempt:
+                            console.log("🧹 Running conductor cleanup after agent timeout...")
+                            cleanup_succeeded = await finish_problem_with_deadline(
+                                "cleanup_timeout_after_agent_timeout"
+                            )
+                            abort_campaign_after_attempt = not cleanup_succeeded
                         break
 
                     tracked_proc = LAUNCHER._procs.get(agent_to_run) or agent_proc
@@ -419,28 +537,71 @@ def driver_loop(
                         if tracked_proc.proc.returncode is not None:
                             agent_proc = tracked_proc
                             console.log(f"⚠️  Agent process exited with return code {tracked_proc.proc.returncode}")
-                            if conductor._submit_future is not None and not conductor._submit_future.done():
+                            submission_work = conductor.close_submissions()
+                            evaluation_failed = False
+                            if submission_work:
                                 console.log("⏳ Waiting for conductor evaluation to complete...")
                                 try:
-                                    await asyncio.wait_for(
-                                        asyncio.wrap_future(conductor._submit_future),
-                                        timeout=300,
-                                    )
+                                    await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
                                 except TimeoutError:
-                                    console.log("⚠️  Conductor evaluation did not finish within 300s")
+                                    evaluation_failed = True
+                                    abort_campaign_after_attempt = True
+                                    conductor.abandon_submission_work()
+                                    console.log(
+                                        "⛔ Submission evaluation did not finish before the drain deadline; "
+                                        "aborting the campaign without concurrent cluster cleanup"
+                                    )
                                 except Exception as e:
+                                    evaluation_failed = True
                                     console.log(f"⚠️  Conductor evaluation raised: {e}")
-                            console.log("🧹 Running conductor cleanup after agent exit...")
-                            conductor._finish_problem()
+                            if conductor.submission_stage != "done":
+                                if abort_campaign_after_attempt:
+                                    reason = "evaluation_timeout_after_agent_exit"
+                                elif evaluation_failed:
+                                    reason = "evaluation_failed_after_agent_exit"
+                                else:
+                                    reason = "agent_exited_before_all_stages_completed"
+                                conductor.record_incomplete_attempt(
+                                    reason,
+                                    agent_return_code=tracked_proc.proc.returncode,
+                                )
+                            if not abort_campaign_after_attempt:
+                                console.log("🧹 Running conductor cleanup after agent exit...")
+                                cleanup_succeeded = await finish_problem_with_deadline(
+                                    "cleanup_timeout_after_agent_exit"
+                                )
+                                abort_campaign_after_attempt = not cleanup_succeeded
                             break
                     await asyncio.sleep(1)
 
-                console.log(f"✅ Completed {pid}: results={conductor.results}", markup=False)
+                # The final evaluator sets stage=done during cleanup just
+                # before its worker future returns. Consume that future before
+                # freezing the attempt snapshot or starting another attempt.
+                if not abort_campaign_after_attempt and conductor.close_submissions():
+                    try:
+                        await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                    except TimeoutError:
+                        abort_campaign_after_attempt = True
+                        conductor.abandon_submission_work()
+                        conductor.record_incomplete_attempt("evaluation_timeout_after_stage_completion")
+                        console.log(
+                            "⛔ Submission evaluation did not finish before the drain deadline; "
+                            "aborting the campaign without concurrent cluster cleanup"
+                        )
+                    except Exception as e:
+                        console.log(f"⚠️  Conductor evaluation raised after stage completion: {e}")
+                        conductor.record_incomplete_attempt("evaluation_failed_after_stage_completion")
+
+                run_status = conductor.finalize_attempt_status()
+                if conductor.results.get("cleanup_failed"):
+                    abort_campaign_after_attempt = True
+                status_icon = "✅" if run_status == "complete" else "⚠️"
+                console.log(f"{status_icon} {run_status.capitalize()} {pid}: results={conductor.results}", markup=False)
                 # Wait for agent process to complete naturally before cleanup
                 # This allows the agent to finish saving trajectories and other cleanup tasks
                 if not use_external_harness:
                     agent_proc = LAUNCHER._procs.get(agent_to_run) or agent_proc
-                    if agent_proc and not timed_out:
+                    if agent_proc and not timed_out and not abort_campaign_after_attempt:
                         console.log("⏳ Waiting for agent process to complete...")
                         timeout = 60  # seconds
                         elapsed = 0
@@ -523,15 +684,41 @@ def driver_loop(
                     else:
                         logger.warning(f"⚠️ ATIF trajectory conversion skipped for {published_run_dir}")
 
-                if attempt == n_attempts:
+                if attempt == attempts_to_run[-1] or abort_campaign_after_attempt:
                     final_csv_path = base_dir / agent_to_run / pid / f"{pid}_{agent_to_run}_results.csv"
                     final_csv_path.parent.mkdir(parents=True, exist_ok=True)
                     os.replace(tmp_path, final_csv_path)
-                    logger.info(
-                        f"✅ Problem {pid} for agent {agent_to_run} complete! Results written to {final_csv_path}"
-                    )
+                    if abort_campaign_after_attempt:
+                        logger.error(
+                            f"⛔ Problem {pid} for agent {agent_to_run} stopped incomplete. "
+                            f"Partial results written to {final_csv_path}"
+                        )
+                    else:
+                        logger.info(
+                            f"✅ Problem {pid} for agent {agent_to_run} complete! Results written to {final_csv_path}"
+                        )
 
                 progress.advance(task_id)
+
+                if abort_campaign_after_attempt:
+                    if conductor.results.get("cleanup_failed"):
+                        abort_reason = (
+                            "Benchmark cleanup failed; later attempts were not started against uncertain state."
+                        )
+                    elif conductor.results.get("cleanup_timed_out"):
+                        abort_reason = "Benchmark cleanup did not terminate; later attempts were not started against uncertain state."
+                    else:
+                        abort_reason = (
+                            "A submission evaluator did not terminate safely. "
+                            "The next benchmark startup will clean the remaining fault state."
+                        )
+                    console.log(f"⛔ Benchmark stopped: {abort_reason}")
+                    progress.stop()
+                    conductor.stop_k8s_proxy()
+                    raise BenchmarkCampaignAborted(
+                        abort_reason,
+                        [{agent_to_run: all_results_for_agent}],
+                    )
 
         progress.stop()
 
@@ -555,6 +742,7 @@ def _run_driver_and_shutdown(
     resume_csv: str | None = None,
 ):
     """Run the benchmark driver, stash results, then tell the API to exit."""
+    global _driver_error, _driver_results
     try:
         results = driver_loop(
             conductor,
@@ -565,9 +753,13 @@ def _run_driver_and_shutdown(
             agent_timeout=agent_timeout,
             resume_csv=resume_csv,
         )
-        global _driver_results
         _driver_results = results
-    except Exception:
+    except BenchmarkCampaignAborted as exc:
+        _driver_results = exc.partial_results
+        _driver_error = exc
+        logger.error("Benchmark campaign aborted: %s", exc)
+    except BaseException as exc:
+        _driver_error = exc
         logger.exception("Driver thread crashed")
     finally:
         LAUNCHER.cleanup_all()
@@ -575,6 +767,10 @@ def _run_driver_and_shutdown(
 
 
 def main(args):
+    global _driver_error, _driver_results
+    _driver_error = None
+    _driver_results = []
+
     # set up the logger
     init_logger()
 
@@ -709,9 +905,17 @@ def main(args):
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
                 writer.writeheader()
                 writer.writerows(agent_results)
-            logger.info(f"✅ Benchmark complete! Results for {agent_name} written to {csv_path}")
+            if _driver_error is None:
+                logger.info(f"✅ Benchmark complete! Results for {agent_name} written to {csv_path}")
+            else:
+                logger.error(f"⛔ Partial benchmark results for {agent_name} written to {csv_path}")
     else:
         logger.warning("⚠️ No results to write.")
+
+    if _driver_error is not None:
+        if __name__ == "__main__":
+            raise SystemExit(1) from _driver_error
+        raise RuntimeError("Benchmark campaign did not complete") from _driver_error
 
     if __name__ == "__main__":
         # separate run, use exit

--- a/mcp_server/submit_server.py
+++ b/mcp_server/submit_server.py
@@ -13,7 +13,7 @@ mcp = FastMCP("Submission MCP Server")
 
 
 @mcp.tool(name="submit")
-def submit(ans: str) -> dict[str, str]:
+def submit(ans: str, stage: str | None = None) -> dict[str, str]:
     """Submit task result to benchmark
 
     Args:
@@ -29,9 +29,11 @@ def submit(ans: str) -> dict[str, str]:
     headers = {"Content-Type": "application/json"}
     # Match curl behavior: send "\"yes\"" when ans is "yes"
     payload = {"solution": f"{ans}"}
+    if stage is not None:
+        payload["stage"] = stage
 
     try:
-        response = requests.post(url, json=payload, headers=headers)
+        response = requests.post(url, json=payload, headers=headers, timeout=310)
         logger.info(f"[submit_mcp] Response status: {response.status_code}, text: {response.text}")
         return {"status": str(response.status_code), "text": str(response.text)}
 

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -4,6 +4,7 @@ import json
 import logging
 import shlex
 import shutil
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,6 +15,14 @@ from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.oracles.detection import DetectionOracle
 from sregym.conductor.oracles.diagnosis_oracle import DiagnosisOracle
 from sregym.conductor.problems.registry import ProblemRegistry
+from sregym.conductor.submission import (
+    SUBMISSION_STAGES,
+    EvaluationInProgress,
+    SubmissionAttemptClosed,
+    SubmissionAttemptMismatch,
+    SubmissionStage,
+    SubmissionStageMismatch,
+)
 from sregym.conductor.utils import is_ordered_subset
 from sregym.generators.fault.inject_remote_os import RemoteOSFaultInjector
 from sregym.generators.fault.inject_virtual import VirtualizationFaultInjector
@@ -84,6 +93,12 @@ class Conductor:
         self.submission_stage = None
         self.results = {}
         self._submit_future = None  # Future for the executor running _submit_evaluate_and_advance
+        self._submission_lock = threading.RLock()
+        self._pending_submission_stages: dict[tuple[int, str], int] = {}
+        self._submission_generation = 0
+        self._aborted_submission_generations: set[int] = set()
+        self._accepting_submissions = False
+        self._attempt_closed = True
 
         self.tasklist = None
         self.logger = logging.getLogger("all.sregym.conductor")
@@ -177,6 +192,7 @@ class Conductor:
         self.current_stage_index = 0
         self.waiting_for_agent = False
         self._evaluating = False
+        self._accepting_submissions = False
         self.fault_injected = False
 
         if not self.tasklist:
@@ -260,12 +276,9 @@ class Conductor:
             self.logger.exception("Diagnosis oracle raised; recording as failure to avoid a stuck stage.")
             r = {"success": False, "error": f"{type(e).__name__}: {e}"}
         r["submission"] = solution
-        self.results["Diagnosis"] = r
-        self.results["TTL"] = time.time() - self.execution_start_time
         self.logger.info(
-            f"[EVAL] Diagnosis "
-            f"{'Succeed' if self.results['Diagnosis'].get('success') else 'Failed'}\n "
-            f"TTL: {self.results['TTL']}"
+            f"[EVAL] Diagnosis {'Succeed' if r.get('success') else 'Failed'}\n "
+            f"TTL: {time.time() - self.execution_start_time}"
         )
         return r
 
@@ -279,12 +292,9 @@ class Conductor:
         except Exception as e:
             self.logger.exception("Mitigation oracle raised; recording as failure to avoid a stuck stage.")
             r = {"success": False, "error": f"{type(e).__name__}: {e}"}
-        self.results["Mitigation"] = r
-        self.results["TTM"] = time.time() - self.execution_start_time
         self.logger.info(
-            f"[EVAL] Mitigation "
-            f"{'Succeed' if self.results['Mitigation'].get('success') else 'Failed'}\n "
-            f"TTM: {self.results['TTM']}"
+            f"[EVAL] Mitigation {'Succeed' if r.get('success') else 'Failed'}\n "
+            f"TTM: {time.time() - self.execution_start_time}"
         )
         return r
 
@@ -298,8 +308,8 @@ class Conductor:
         self.current_stage_index = start_index
 
         if not self.stage_sequence:
-            self.logger.info("No stages configured; finishing problem immediately.")
-            self._finish_problem()
+            self.logger.info("No stages configured; starting problem cleanup.")
+            self.finish_problem_in_background()
             return
 
         # Inject fault before the first stage if not already done
@@ -313,6 +323,7 @@ class Conductor:
             self.logger.debug(f"Advancing to stage '{stage_name}' and waiting for agent.")
             self.waiting_for_agent = True
             self.submission_stage = stage_name
+            self._accepting_submissions = not self._attempt_closed
             self.logger.info(f"[STAGE] Go to stage {self.submission_stage}")
 
             # Update NoiseManager stage
@@ -324,9 +335,9 @@ class Conductor:
                     self.logger.warning(f"Failed to set NoiseManager stage: {e}")
         else:
             # No more stages; finish the problem
-            self._finish_problem()
+            self.finish_problem_in_background()
 
-    def _cleanup_sync(self):
+    def _cleanup_sync(self, generation: int | None = None):
         """
         Blocking cleanup operations (fault recovery, app teardown, reconciliation).
         Captures self.problem at entry so that start_problem() can safely replace
@@ -335,6 +346,24 @@ class Conductor:
         # Snapshot the problem reference immediately so that any concurrent
         # replacement of self.problem by start_problem() does not affect this cleanup.
         problem = self.problem
+        cleanup_generation = self._submission_generation if generation is None else generation
+        cleanup_errors: list[str] = []
+
+        def cleanup_was_abandoned() -> bool:
+            with self._submission_lock:
+                return (
+                    cleanup_generation != self._submission_generation
+                    or cleanup_generation in self._aborted_submission_generations
+                )
+
+        def stop_late_cleanup() -> bool:
+            if not cleanup_was_abandoned():
+                return False
+            self.logger.warning(
+                "Stopping late cleanup work for aborted or replaced attempt generation %s",
+                cleanup_generation,
+            )
+            return True
 
         self.logger.info("[CLEANUP] Starting cleanup (fault recovery, undeploy, reconcile)")
 
@@ -347,17 +376,34 @@ class Conductor:
             except Exception as e:
                 self.logger.warning(f"Failed to stop NoiseManager: {e}")
 
+        if stop_late_cleanup():
+            return
+
         # Recover fault using the captured problem reference
         if problem:
             self.logger.info("[CLEANUP] Recovering fault...")
-            problem.recover_fault()
-            self.logger.info("[CLEANUP] Fault recovered")
+            try:
+                problem.recover_fault()
+                self.logger.info("[CLEANUP] Fault recovered")
+            except Exception as exc:
+                self.logger.exception("[CLEANUP] Fault recovery failed")
+                cleanup_errors.append(f"recover_fault: {type(exc).__name__}: {exc}")
+
+        if stop_late_cleanup():
+            return
 
         # Undeploy app using the captured problem reference
         self.logger.info("[CLEANUP] Undeploying app...")
         if problem:
-            problem.app.cleanup()
-        self.logger.info("[CLEANUP] App undeployed")
+            try:
+                problem.app.cleanup()
+                self.logger.info("[CLEANUP] App undeployed")
+            except Exception as exc:
+                self.logger.exception("[CLEANUP] App cleanup failed")
+                cleanup_errors.append(f"app_cleanup: {type(exc).__name__}: {exc}")
+
+        if stop_late_cleanup():
+            return
 
         # Reconcile cluster state to baseline
         if self._baseline_captured:
@@ -368,13 +414,29 @@ class Conductor:
                     self.logger.info(f"Cluster state reconciliation changes: {changes}")
                 self.logger.info("[CLEANUP] Cluster state reconciled")
             except Exception as e:
-                self.logger.warning(f"Failed to reconcile cluster state: {e}")
+                self.logger.exception("[CLEANUP] Failed to reconcile cluster state")
+                cleanup_errors.append(f"cluster_reconcile: {type(e).__name__}: {e}")
 
-        # Set to "done" after all cleanup is complete
-        self.submission_stage = "done"
+        if stop_late_cleanup():
+            return
+
+        # Set to "done" after all cleanup is complete.
+        with self._submission_lock:
+            if cleanup_was_abandoned():
+                self.logger.warning(
+                    "Ignoring late cleanup state for aborted or replaced attempt generation %s",
+                    cleanup_generation,
+                )
+                return
+            if cleanup_errors:
+                self.results["cleanup_failed"] = True
+                self.results["cleanup_error"] = "; ".join(cleanup_errors)
+            self.submission_stage = "done"
+            self._accepting_submissions = False
+            self._attempt_closed = True
         self.logger.info("[CLEANUP] Cleanup complete, stage set to 'done'")
 
-    def _finish_problem(self):
+    def _finish_problem(self, generation: int | None = None):
         """
         Runs problem teardown synchronously (fault recovery, app undeploy, cluster
         reconciliation) before returning.
@@ -385,15 +447,61 @@ class Conductor:
         resets the stage to ``"setup"``, so the deploy-retry path still cleans up
         each failed attempt.
         """
-        if self.submission_stage in ("done", "tearing_down"):
-            self.logger.info(
-                f"[STAGE] _finish_problem already ran/running (submission_stage={self.submission_stage!r}); skipping"
-            )
-            return
-        self.logger.info("[STAGE] Done, starting teardown")
-        self.submission_stage = "tearing_down"
-        self._cleanup_sync()
+        cleanup_generation = self._submission_generation if generation is None else generation
+        with self._submission_lock:
+            if (
+                cleanup_generation != self._submission_generation
+                or cleanup_generation in self._aborted_submission_generations
+            ):
+                self.logger.warning(
+                    "Skipping cleanup transition for aborted or replaced attempt generation %s",
+                    cleanup_generation,
+                )
+                return
+            if self.submission_stage in ("done", "tearing_down"):
+                self.logger.info(
+                    f"[STAGE] _finish_problem already ran/running (submission_stage={self.submission_stage!r}); skipping"
+                )
+                return
+            self.logger.info("[STAGE] Done, starting teardown")
+            self._accepting_submissions = False
+            self._attempt_closed = True
+            self.submission_stage = "tearing_down"
+        self._cleanup_sync(cleanup_generation)
         self.logger.info("[STAGE] Teardown complete")
+
+    def finish_problem_in_background(self) -> concurrent.futures.Future:
+        """Start safety cleanup on a daemon thread so the driver can enforce a deadline."""
+        with self._submission_lock:
+            if self._submit_future is not None:
+                raise RuntimeError("Cannot start cleanup while submission work is still active.")
+            if self.submission_stage == "tearing_down":
+                raise RuntimeError(
+                    "Cleanup stopped unexpectedly while tearing down; it cannot be treated as complete or retried safely."
+                )
+            generation = self._submission_generation
+            future: concurrent.futures.Future = concurrent.futures.Future()
+
+            def run_cleanup() -> None:
+                if not future.set_running_or_notify_cancel():
+                    return
+                try:
+                    self._finish_problem(generation)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        future.set_exception(exc)
+                    else:
+                        future.set_exception(RuntimeError(f"Cleanup terminated with {type(exc).__name__}: {exc}"))
+                else:
+                    future.set_result(None)
+
+            self._submit_future = future
+            threading.Thread(
+                target=run_cleanup,
+                name=f"sregym-cleanup-{generation}",
+                daemon=True,
+            ).start()
+            return future
 
     async def start_problem(self) -> StartProblemResult:
         """
@@ -406,21 +514,40 @@ class Conductor:
         if self.problem_id is None:
             raise RuntimeError("Cannot start problem: problem_id is not set")
 
-        # Wait for the previous problem's executor (evaluation + cleanup) to finish
-        # before starting a new problem. _finish_problem() is called synchronously
-        # from within _submit_evaluate_and_advance(), so awaiting the future here
-        # guarantees that fault recovery, undeploy, and reconciliation are all done.
-        if self._submit_future is not None and not self._submit_future.done():
-            self.logger.info("[WAIT] Waiting for previous problem's cleanup to finish...")
-            await asyncio.wrap_future(self._submit_future)
-            self.logger.info("[WAIT] Previous problem's cleanup finished")
-        self._submit_future = None
+        with self._submission_lock:
+            if self._submission_generation in self._aborted_submission_generations:
+                raise RuntimeError(
+                    "This Conductor abandoned a stuck evaluator and cannot be reused. "
+                    "Start a new benchmark process so late external side effects cannot overlap another attempt."
+                )
+
+        # Wait for every accepted evaluation and any API request that is waiting
+        # for the next stage. This prevents a late request from one attempt from
+        # being submitted against the next problem.
+        # Close the old attempt before taking the drain snapshot. A request
+        # that was already registered can finish, but no later request can
+        # cross this boundary into the new attempt.
+        self.close_submissions()
+        if self._submit_future is not None or self._pending_submission_stages:
+            self.logger.info("[WAIT] Waiting for previous problem's submission work to finish...")
+            await self.wait_for_submission_work(timeout=None)
+            self.logger.info("[WAIT] Previous problem's submission work finished")
+        with self._submission_lock:
+            self._submit_future = None
+            self._submission_generation += 1
+            self._accepting_submissions = False
+            self._attempt_closed = False
+            self.submission_stage = "setup"
+            self.waiting_for_agent = False
+            self._evaluating = False
+            self.problem = None
+            self.app = None
+            self.results = {}
 
         self.execution_start_time = time.time()
         self.problem = self.problems.get_problem_instance(self.problem_id)
         self.app = self.problem.app
         self.detection_oracle = DetectionOracle(self.problem)
-        self.results = {}
 
         self.dependency_check(["kubectl", "helm", "docker"])
         self.logger.debug("Dependency check passed: kubectl, helm")
@@ -475,7 +602,7 @@ class Conductor:
             )
         return StartProblemResult.SUCCESS
 
-    def _submit_evaluate_and_advance(self, sol, current_stage):
+    def _submit_evaluate_and_advance(self, sol, current_stage, generation: int):
         """
         Blocking work for a submission: evaluate the oracle, advance stage, manage noise.
         Runs in a background thread so the HTTP response is not blocked.
@@ -492,90 +619,341 @@ class Conductor:
             except Exception as e:
                 self.logger.warning(f"Failed to stop noise manager: {e}")
 
+        outcome = None
+        # Run the evaluation function for the current stage. The per-stage
+        # _evaluate_* methods catch their own oracle exceptions; this outer
+        # guard is defense in depth so an ordinary evaluation error still
+        # produces a failed stage result.
         try:
-            # Run the evaluation function for the current stage. The per-stage
-            # _evaluate_* methods catch their own oracle exceptions and record
-            # a failure result; this outer guard is defense in depth so the
-            # stage always advances even if something above the oracle blows up.
-            try:
-                current_stage["evaluation"](sol)
-            except Exception:
-                self.logger.exception(
-                    f"Stage '{stage_name}' evaluation raised unexpectedly; advancing anyway "
-                    "so the conductor doesn't get stuck waiting on a dead stage."
-                )
-                self.results.setdefault(
-                    stage_name.capitalize(), {"success": False, "error": "stage evaluation raised", "submission": sol}
-                )
-        finally:
-            self._evaluating = False
+            outcome = current_stage["evaluation"](sol)
+        except Exception:
+            self.logger.exception(
+                f"Stage '{stage_name}' evaluation raised unexpectedly; advancing anyway "
+                "so the conductor doesn't get stuck waiting on a dead stage."
+            )
+            outcome = {"success": False, "error": "stage evaluation raised", "submission": sol}
 
-        # After evaluation, advance to the next stage (if any)
         next_index = self.current_stage_index + 1
-        self._advance_to_next_stage(start_index=next_index)
+        next_stage_name: str | None = None
+        with self._submission_lock:
+            if generation != self._submission_generation or generation in self._aborted_submission_generations:
+                self.logger.warning(
+                    "Discarding %s result because attempt generation %s was aborted or replaced",
+                    stage_name,
+                    generation,
+                )
+                return
 
-        # Restart noise if there are more stages AND not in teardown
-        if self.config.enable_noise and self.submission_stage not in ("done", "tearing_down"):
+            if outcome is not None:
+                self.results[stage_name.capitalize()] = outcome
+                timing_key = "TTL" if stage_name == "diagnosis" else "TTM"
+                self.results[timing_key] = time.time() - self.execution_start_time
+
+            if next_index < len(self.stage_sequence):
+                next_stage_name = self.stage_sequence[next_index]["name"]
+
+        if next_stage_name is not None:
+            # Keep the old stage marked busy while noise is restarted. The
+            # API can wait for the next stage, but cannot submit into a
+            # partially completed transition. Do not hold the submission lock
+            # across NoiseManager I/O because a stuck noise backend must not
+            # prevent the driver from closing or abandoning the attempt.
+            if self.config.enable_noise:
+                nm = None
+                try:
+                    nm = get_noise_manager()
+                    self.logger.info("Restarting noise manager for next stage...")
+                    nm.start()
+                    with self._submission_lock:
+                        transition_aborted = (
+                            generation != self._submission_generation
+                            or generation in self._aborted_submission_generations
+                        )
+                    if not transition_aborted:
+                        nm.set_stage(next_stage_name)
+                except Exception as e:
+                    self.logger.warning(f"Failed to restart NoiseManager: {e}")
+
+                # A slow start/set_stage can finish after the driver abandons
+                # the evaluator and performs its global noise stop. Stop again
+                # so this late worker cannot leave noise running.
+                with self._submission_lock:
+                    transition_aborted = (
+                        generation != self._submission_generation or generation in self._aborted_submission_generations
+                    )
+                if transition_aborted and nm is not None:
+                    try:
+                        nm.stop()
+                    except Exception as e:
+                        self.logger.warning(f"Failed to stop late NoiseManager restart: {e}")
+                    return
+
+            with self._submission_lock:
+                if generation != self._submission_generation or generation in self._aborted_submission_generations:
+                    self.logger.warning(
+                        "Skipping %s stage transition because attempt generation %s was aborted or replaced",
+                        next_stage_name,
+                        generation,
+                    )
+                    return
+                self.current_stage_index = next_index
+                self.submission_stage = next_stage_name
+                self.waiting_for_agent = True
+                self._evaluating = False
+                self._accepting_submissions = not self._attempt_closed
+                self.logger.info(f"[STAGE] Go to stage {self.submission_stage}")
+            return
+
+        if next_index >= len(self.stage_sequence):
+            # Keep the accepted evaluation marked as active until teardown
+            # finishes. A concurrent submit observes ``tearing_down`` instead
+            # of a brief, invalid "idle mitigation" state.
             try:
-                nm = get_noise_manager()
-                self.logger.info("Restarting noise manager for next stage...")
-                nm.start()
-            except Exception as e:
-                self.logger.warning(f"Failed to restart noise manager: {e}")
+                self._finish_problem(generation)
+            finally:
+                with self._submission_lock:
+                    if generation == self._submission_generation:
+                        self._evaluating = False
 
-    async def submit(self, solution: str | None) -> dict:
+    async def submit(
+        self,
+        solution: str | None,
+        *,
+        expected_stage: str | None = None,
+        expected_generation: int | None = None,
+    ) -> dict:
         """
         Called by CLI or HTTP /submit.  Kicks off evaluation in the
         background and returns immediately.
         """
         sol = solution
 
-        # If all tasks are already completed, simply return the final snapshot.
-        if self.submission_stage == "done":
-            self.logger.info("All tasks already completed; ignoring new submission.")
-            return dict(self.results)
+        with self._submission_lock:
+            if expected_generation is not None and expected_generation != self._submission_generation:
+                raise SubmissionAttemptMismatch(expected_generation, self._submission_generation)
 
-        # If teardown is in progress, return current results without evaluation
-        if self.submission_stage == "tearing_down":
-            self.logger.info("Teardown in progress; returning current results without evaluation.")
-            return dict(self.results)
-
-        if not self.stage_sequence:
-            self.logger.warning("submit() called but no stages are configured; returning current results.")
-            return dict(self.results)
-
-        if not self.waiting_for_agent:
-            if self._evaluating:
-                self.logger.info(
-                    "submit() called while evaluation is already in progress for "
-                    f"stage '{self.submission_stage}'. Submission was already accepted."
-                )
-                return {"status": "ok", "message": "Submission already accepted; evaluation in progress."}
-            self.logger.error(
-                "submit() called when conductor is not waiting for a submission. "
-                f"Current submission_stage={self.submission_stage}"
+            registered_request = (
+                expected_generation is not None
+                and self._pending_submission_stages.get((expected_generation, expected_stage or ""), 0) > 0
             )
-            raise RuntimeError("Conductor is not currently waiting for an agent submission.")
+            if not self._accepting_submissions and not registered_request:
+                raise SubmissionAttemptClosed("This attempt no longer accepts new submissions.")
 
-        current_stage = self.stage_sequence[self.current_stage_index]
+            # If all tasks are already completed, simply return the final snapshot.
+            if self.submission_stage == "done":
+                self.logger.info("All tasks already completed; ignoring new submission.")
+                return dict(self.results)
 
-        # Mark that we're no longer waiting so duplicate submits are rejected
-        self.waiting_for_agent = False
-        self._evaluating = True
+            # If teardown is in progress, return current results without evaluation
+            if self.submission_stage == "tearing_down":
+                self.logger.info("Teardown in progress; returning current results without evaluation.")
+                return dict(self.results)
 
-        # Run evaluation and stage advancement in an executor thread so the HTTP
-        # response returns immediately.  Store the future so start_problem() can
-        # await it and guarantee cleanup is fully done before the next problem starts.
-        # Use concurrent.futures directly (not asyncio's run_in_executor) so the
-        # future is loop-independent.  submit() is called from the uvicorn API thread
-        # which has its own event loop; start_problem() runs in the main driver loop.
-        # asyncio.wrap_future() in start_problem() binds the future to whichever loop
-        # is running at await time, avoiding "Future attached to a different loop".
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        self._submit_future = executor.submit(self._submit_evaluate_and_advance, sol, current_stage)
-        executor.shutdown(wait=False)
+            if not self.stage_sequence:
+                self.logger.warning("submit() called but no stages are configured; returning current results.")
+                return dict(self.results)
 
-        return {"status": "ok", "message": "Submission received"}
+            if expected_stage is not None and self.submission_stage != expected_stage:
+                raise SubmissionStageMismatch(expected_stage, self.submission_stage)
+
+            if not self.waiting_for_agent:
+                if self._evaluating:
+                    self.logger.info(
+                        f"submit() called while evaluation is already in progress for stage '{self.submission_stage}'."
+                    )
+                    raise EvaluationInProgress(self.submission_stage)
+                self.logger.error(
+                    "submit() called when conductor is not waiting for a submission. "
+                    f"Current submission_stage={self.submission_stage}"
+                )
+                raise RuntimeError("Conductor is not currently waiting for an agent submission.")
+
+            current_stage = self.stage_sequence[self.current_stage_index]
+            accepted_stage: str = current_stage["name"]
+
+            # Mark that we're no longer waiting so duplicate submits are rejected.
+            self.waiting_for_agent = False
+            self._evaluating = True
+
+            # Run evaluation and stage advancement in an executor thread so the HTTP
+            # response returns immediately. Store the future so start_problem() can
+            # await it and guarantee cleanup is fully done before the next problem starts.
+            generation = self._submission_generation
+            future: concurrent.futures.Future = concurrent.futures.Future()
+
+            def run_evaluation() -> None:
+                if not future.set_running_or_notify_cancel():
+                    return
+                try:
+                    result = self._submit_evaluate_and_advance(sol, current_stage, generation)
+                except BaseException as exc:
+                    if isinstance(exc, Exception):
+                        future.set_exception(exc)
+                    else:
+                        future.set_exception(RuntimeError(f"Evaluator terminated with {type(exc).__name__}: {exc}"))
+                else:
+                    future.set_result(result)
+
+            self._submit_future = future
+            threading.Thread(
+                target=run_evaluation,
+                name=f"sregym-evaluate-{generation}-{accepted_stage}",
+                daemon=True,
+            ).start()
+
+        return {"status": "accepted", "message": "Submission received", "stage": accepted_stage}
+
+    def _register_pending_submission_locked(self, stage: str) -> int:
+        if self._attempt_closed or not self._accepting_submissions:
+            raise SubmissionAttemptClosed("This attempt no longer accepts new submissions.")
+        generation = self._submission_generation
+        key = (generation, stage)
+        self._pending_submission_stages[key] = self._pending_submission_stages.get(key, 0) + 1
+        return generation
+
+    def register_submission_request(
+        self,
+        solution: str,
+        stage: SubmissionStage | None = None,
+    ) -> tuple[SubmissionStage, int]:
+        """Resolve and register one request atomically.
+
+        Legacy clients omit the stage. Preserve the current-stage behavior and
+        recognize an empty request during diagnosis grading as early mitigation.
+        """
+        with self._submission_lock:
+            requested_stage = stage
+            if requested_stage is None:
+                if self.submission_stage == "mitigation":
+                    requested_stage = "mitigation"
+                elif self.submission_stage == "diagnosis":
+                    requested_stage = "mitigation" if self._evaluating and solution == "" else "diagnosis"
+                else:
+                    requested_stage = "mitigation" if solution == "" else "diagnosis"
+            if requested_stage not in SUBMISSION_STAGES:
+                raise ValueError(f"Unknown submission stage: {requested_stage!r}")
+            generation = self._register_pending_submission_locked(requested_stage)
+            return requested_stage, generation
+
+    def register_pending_submission(self, stage: str) -> int:
+        """Track a known-stage request and return its attempt generation."""
+        with self._submission_lock:
+            return self._register_pending_submission_locked(stage)
+
+    def submission_state(self) -> tuple[str | None, bool, int]:
+        """Return the agent-facing stage, evaluation flag, and attempt generation atomically."""
+        with self._submission_lock:
+            return self.submission_stage, self._evaluating, self._submission_generation
+
+    def unregister_pending_submission(self, stage: str, generation: int) -> None:
+        """Stop tracking an API request after it is accepted or rejected."""
+        with self._submission_lock:
+            key = (generation, stage)
+            remaining = self._pending_submission_stages.get(key, 0) - 1
+            if remaining > 0:
+                self._pending_submission_stages[key] = remaining
+            else:
+                self._pending_submission_stages.pop(key, None)
+
+    def close_submissions(self) -> bool:
+        """Atomically reject new requests and report whether registered work remains."""
+        with self._submission_lock:
+            self._accepting_submissions = False
+            self._attempt_closed = True
+            return self._submit_future is not None or bool(self._pending_submission_stages)
+
+    def abandon_submission_work(self) -> None:
+        """Detach a stuck evaluator and prevent it from mutating this or a later attempt."""
+        with self._submission_lock:
+            generation = self._submission_generation
+            self._aborted_submission_generations.add(generation)
+            self._attempt_closed = True
+            self._accepting_submissions = False
+            self.waiting_for_agent = False
+            self._evaluating = False
+            self.submission_stage = "aborted"
+            self._submit_future = None
+
+    async def wait_for_submission_work(self, timeout: float | None) -> None:
+        """Wait for all accepted evaluations and registered stage requests.
+
+        An early mitigation request can be waiting while diagnosis is graded.
+        When diagnosis finishes, that request creates a new evaluation future.
+        Looping until both sources are idle prevents cleanup between those two
+        evaluations.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout if timeout is not None else None
+
+        while True:
+            with self._submission_lock:
+                future = self._submit_future
+                pending = bool(self._pending_submission_stages)
+
+            if future is not None:
+                try:
+                    if future.done():
+                        future.result()
+                    elif deadline is None:
+                        await asyncio.shield(asyncio.wrap_future(future))
+                    else:
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            raise TimeoutError
+                        await asyncio.wait_for(
+                            asyncio.shield(asyncio.wrap_future(future)),
+                            timeout=remaining,
+                        )
+                finally:
+                    if future.done():
+                        with self._submission_lock:
+                            if self._submit_future is future:
+                                self._submit_future = None
+                continue
+
+            if pending:
+                if deadline is not None and loop.time() >= deadline:
+                    raise TimeoutError
+                await asyncio.sleep(0.05)
+                continue
+
+            return
+
+    def missing_submission_stages(self) -> list[str]:
+        """Return configured stages that did not produce an evaluation result."""
+        return [stage["name"] for stage in self.stage_sequence if stage["name"].capitalize() not in self.results]
+
+    def record_incomplete_attempt(
+        self,
+        reason: str,
+        *,
+        agent_return_code: int | None = None,
+    ) -> None:
+        """Record why an attempt ended without all configured stage results."""
+        missing = self.missing_submission_stages()
+        current_stage = self.submission_stage
+        if current_stage not in {"diagnosis", "mitigation", "tearing_down"}:
+            current_stage = missing[0] if missing else "run"
+
+        self.results["run_status"] = "incomplete"
+        self.results["incomplete_reason"] = reason
+        self.results["incomplete_stage"] = current_stage
+        self.results["missing_stages"] = ",".join(missing)
+        if agent_return_code is not None:
+            self.results["agent_return_code"] = agent_return_code
+
+    def finalize_attempt_status(self) -> str:
+        """Set an explicit complete or incomplete status before results are written."""
+        if self.results.get("run_status") == "incomplete":
+            return "incomplete"
+        if self.results.get("cleanup_failed"):
+            self.record_incomplete_attempt("cleanup_failed")
+            return "incomplete"
+        if self.missing_submission_stages():
+            self.record_incomplete_attempt("missing_stage_results")
+        else:
+            self.results["run_status"] = "complete"
+        return self.results["run_status"]
 
     @staticmethod
     def _q(value):

--- a/sregym/conductor/conductor_api.py
+++ b/sregym/conductor/conductor_api.py
@@ -14,14 +14,130 @@ from starlette.routing import Mount
 from uvicorn import Config, Server
 
 from logger import console
+from sregym.conductor.submission import (
+    SUBMISSION_STAGE_ORDER,
+    SUBMISSION_STAGES,
+    EvaluationInProgress,
+    SubmissionAttemptClosed,
+    SubmissionAttemptMismatch,
+    SubmissionStage,
+    SubmissionStageMismatch,
+)
 
 _conductor = None
 
 submit_mcp = FastMCP("Submit MCP Server")
 
+_SUBMISSION_WAIT_SECONDS = 300.0
+_SUBMISSION_POLL_SECONDS = 0.1
+
+
+class SubmissionRequestRejected(RuntimeError):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        super().__init__(message)
+
+
+async def _submit_when_stage_is_ready(solution: str, stage: str | None) -> dict:
+    conductor = _conductor
+    if conductor is None:
+        raise SubmissionRequestRejected(400, "No problem has been started")
+
+    try:
+        requested_stage, generation = conductor.register_submission_request(solution, stage)
+    except ValueError as exc:
+        raise SubmissionRequestRejected(400, str(exc)) from exc
+    except SubmissionAttemptClosed as exc:
+        raise SubmissionRequestRejected(409, str(exc)) from exc
+    try:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _SUBMISSION_WAIT_SECONDS
+
+        while True:
+            current_stage, evaluating, current_generation = conductor.submission_state()
+
+            if current_generation != generation:
+                raise SubmissionRequestRejected(409, "This submission belongs to an earlier benchmark attempt.")
+
+            if current_stage == "done":
+                raise SubmissionRequestRejected(409, "This benchmark attempt is already closed.")
+
+            if current_stage in {"setup", None}:
+                raise SubmissionRequestRejected(
+                    409,
+                    f"Cannot submit before an agent stage is ready; current stage is {current_stage!r}.",
+                )
+
+            if current_stage == "tearing_down":
+                if loop.time() >= deadline:
+                    raise SubmissionRequestRejected(
+                        503,
+                        f"Stage {requested_stage!r} did not become available before the submission timeout.",
+                    )
+                await asyncio.sleep(_SUBMISSION_POLL_SECONDS)
+                continue
+
+            if current_stage not in SUBMISSION_STAGES:
+                raise SubmissionRequestRejected(409, f"Cannot submit at stage: {current_stage!r}")
+
+            current_order = SUBMISSION_STAGE_ORDER[current_stage]
+            requested_order = SUBMISSION_STAGE_ORDER[requested_stage]
+            if current_order > requested_order:
+                raise SubmissionRequestRejected(
+                    409,
+                    f"Stage {requested_stage!r} has already passed; current stage is {current_stage!r}.",
+                )
+
+            if current_order < requested_order:
+                if not evaluating:
+                    raise SubmissionRequestRejected(
+                        409,
+                        f"Stage {requested_stage!r} is not ready; submit stage {current_stage!r} first.",
+                    )
+                if loop.time() >= deadline:
+                    raise SubmissionRequestRejected(
+                        503,
+                        f"Stage {requested_stage!r} did not become available before the submission timeout.",
+                    )
+                await asyncio.sleep(_SUBMISSION_POLL_SECONDS)
+                continue
+
+            try:
+                result = await conductor.submit(
+                    solution,
+                    expected_stage=requested_stage,
+                    expected_generation=generation,
+                )
+            except EvaluationInProgress as exc:
+                raise SubmissionRequestRejected(409, str(exc)) from exc
+            except SubmissionStageMismatch:
+                if loop.time() >= deadline:
+                    raise SubmissionRequestRejected(
+                        503,
+                        f"Stage {requested_stage!r} did not become available before the submission timeout.",
+                    ) from None
+                await asyncio.sleep(_SUBMISSION_POLL_SECONDS)
+                continue
+            except (SubmissionAttemptClosed, SubmissionAttemptMismatch) as exc:
+                raise SubmissionRequestRejected(409, str(exc)) from exc
+            except RuntimeError as exc:
+                if loop.time() >= deadline:
+                    raise SubmissionRequestRejected(503, str(exc)) from exc
+                await asyncio.sleep(_SUBMISSION_POLL_SECONDS)
+                continue
+
+            if result.get("status") != "accepted" or result.get("stage") != requested_stage:
+                raise SubmissionRequestRejected(
+                    409,
+                    f"Stage {requested_stage!r} did not accept the submission.",
+                )
+            return result
+    finally:
+        conductor.unregister_pending_submission(requested_stage, generation)
+
 
 @submit_mcp.tool(name="submit")
-async def submit_via_conductor(ans: str) -> dict[str, str]:
+async def submit_via_conductor(ans: str, stage: str | None = None) -> dict[str, str]:
     """Submit task result to benchmark
 
     Args:
@@ -30,27 +146,14 @@ async def submit_via_conductor(ans: str) -> dict[str, str]:
     Returns:
         dict[str]: acknowledgment of submission status
     """
-    if _conductor is None or _conductor.submission_stage not in {"diagnosis", "mitigation"}:
-        stage = _conductor.submission_stage if _conductor else None
-        if stage == "done" and _conductor is not None:
-            return {
-                "status": "done",
-                "text": "All stages have been completed and graded. No further submissions are needed.",
-            }
-        return {"status": "error", "text": f"Cannot submit at stage: {stage!r}"}
+    try:
+        result = await _submit_when_stage_is_ready(ans, stage)
+    except SubmissionRequestRejected as exc:
+        return {"status": "error", "text": str(exc)}
+    except Exception as exc:
+        return {"status": "error", "text": f"Grading error: {exc}"}
 
-    max_wait = 60
-    for attempt in range(max_wait):
-        try:
-            await _conductor.submit(ans)
-            return {"status": "200", "text": "Submission received"}
-        except RuntimeError:
-            if attempt < max_wait - 1:
-                await asyncio.sleep(1)
-                continue
-            return {"status": "error", "text": "Previous stage is still being evaluated. Try again later."}
-        except Exception as e:
-            return {"status": "error", "text": f"Grading error: {e}"}
+    return {"status": "200", "text": result["message"], "stage": result["stage"]}
 
 
 app = FastAPI(
@@ -109,51 +212,30 @@ def set_conductor(c):
 
 class SubmitRequest(BaseModel):
     solution: str
+    stage: SubmissionStage | None = None
 
 
 @app.post("/submit")
 async def submit_solution(req: SubmitRequest):
-    allowed = {"diagnosis", "mitigation"}
-    if _conductor is None or _conductor.submission_stage not in allowed:
-        stage = _conductor.submission_stage if _conductor else None
-        if stage == "done" and _conductor is not None:
-            logger.debug("Submit received at stage 'done' — problem already graded, returning final results")
-            return {
-                "status": "done",
-                "message": "All stages have been completed and graded. No further submissions are needed.",
-            }
-        logger.error(f"Cannot submit at stage: {stage!r}")
-        raise HTTPException(status_code=400, detail=f"Cannot submit at stage: {stage!r}")
+    try:
+        result = await _submit_when_stage_is_ready(req.solution, req.stage)
+    except SubmissionRequestRejected as exc:
+        logger.error("Submission rejected: %s", exc)
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Grading error: %s", exc)
+        raise HTTPException(status_code=400, detail=f"Grading error: {exc}") from exc
 
-    # The conductor evaluates submissions asynchronously. If a previous stage
-    # is still being evaluated, waiting_for_agent will be False and submit()
-    # raises RuntimeError.  Retry for up to 60s to handle this race.
-    max_wait = 60
-    for attempt in range(max_wait):
-        try:
-            await _conductor.submit(req.solution)
-            return {"status": "200", "message": "Submission received"}
-        except RuntimeError:
-            if attempt < max_wait - 1:
-                logger.debug("Conductor not ready for submission yet, retrying in 1s...")
-                await asyncio.sleep(1)
-                continue
-            logger.error("Conductor did not become ready for submission within timeout")
-            raise HTTPException(
-                status_code=503,
-                detail="Previous stage is still being evaluated. Try again later.",
-            ) from None
-        except Exception as e:
-            logger.error(f"Grading error: {e}")
-            raise HTTPException(status_code=400, detail=f"Grading error: {e}") from e
+    return {"status": "200", "message": result["message"], "stage": result["stage"]}
 
 
 @app.get("/status")
 async def get_status():
-    if _conductor is None:
+    conductor = _conductor
+    if conductor is None:
         logger.error("No problem has been started")
         raise HTTPException(status_code=400, detail="No problem has been started")
-    stage = _conductor.submission_stage
+    stage, _, _ = conductor.submission_state()
     logger.debug(f"API returns Current stage: {stage}")
     return {"stage": stage}
 
@@ -194,7 +276,7 @@ def run_api(conductor):
         Markdown(
             """
 **Available Endpoints**
-- **POST /submit**: `{ "solution": "<your-solution>" }` → grades the current stage
+- **POST /submit**: `{ "stage": "diagnosis", "solution": "<your-solution>" }` → grades the named stage
 - **GET /status**: returns `{ "stage": "setup" | "diagnosis" | "mitigation" | "tearing_down" | "done" }`
 """
         )

--- a/sregym/conductor/submission.py
+++ b/sregym/conductor/submission.py
@@ -1,0 +1,40 @@
+"""Shared submission-stage contract for the Conductor and its APIs."""
+
+from typing import Literal
+
+type SubmissionStage = Literal["diagnosis", "mitigation"]
+SUBMISSION_STAGE_ORDER = {"diagnosis": 0, "mitigation": 1}
+SUBMISSION_STAGES = frozenset(SUBMISSION_STAGE_ORDER)
+
+
+class EvaluationInProgress(RuntimeError):
+    """A submission for the current stage was already accepted."""
+
+    def __init__(self, stage: str | None):
+        self.stage = stage
+        super().__init__(f"A submission for stage {stage!r} is already being evaluated.")
+
+
+class SubmissionStageMismatch(RuntimeError):
+    """A submission was sent for a stage that is not currently active."""
+
+    def __init__(self, expected_stage: str, current_stage: str | None):
+        self.expected_stage = expected_stage
+        self.current_stage = current_stage
+        super().__init__(f"Submission targets stage {expected_stage!r}, but the current stage is {current_stage!r}.")
+
+
+class SubmissionAttemptClosed(RuntimeError):
+    """The attempt no longer accepts new submission requests."""
+
+
+class SubmissionAttemptMismatch(RuntimeError):
+    """A request registered for an older attempt reached a newer attempt."""
+
+    def __init__(self, expected_generation: int, current_generation: int):
+        self.expected_generation = expected_generation
+        self.current_generation = current_generation
+        super().__init__(
+            f"Submission belongs to attempt generation {expected_generation}, "
+            f"but the current generation is {current_generation}."
+        )

--- a/sregym/results/__init__.py
+++ b/sregym/results/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark result processing."""

--- a/sregym/results/report.py
+++ b/sregym/results/report.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Build a Markdown difficulty report from one SREGym results CSV."""
 
 import argparse
@@ -57,16 +56,23 @@ def build_report(
 
         diagnosis = _as_bool(row.get("Diagnosis.success"))
         mitigation = _as_bool(row.get("Mitigation.success"))
-        if diagnosis is not None:
+        attempt_incomplete = row.get("run_status") == "incomplete" or diagnosis is None or mitigation is None
+        if not attempt_incomplete and diagnosis is not None:
             diagnosis_evaluated += 1
             diagnosis_passes += int(diagnosis)
-        if mitigation is not None:
+        if not attempt_incomplete and mitigation is not None:
             mitigation_evaluated += 1
             mitigation_passes += int(mitigation)
 
         detail = ""
         if _as_bool(row.get("deploy_failed")):
             detail = "deployment failed"
+        elif row.get("run_status") == "incomplete":
+            reason = row.get("incomplete_reason") or "missing stage results"
+            stage = row.get("incomplete_stage")
+            detail = reason.replace("_", " ")
+            if stage:
+                detail = f"{detail} at {stage}"
         elif _as_bool(row.get("timed_out")):
             detail = "agent timed out"
         elif diagnosis is None or mitigation is None:
@@ -79,7 +85,7 @@ def build_report(
 
         diagnosis_text = "✅" if diagnosis is True else "❌" if diagnosis is False else "—"
         mitigation_text = "✅" if mitigation is True else "❌" if mitigation is False else "—"
-        if diagnosis is None or mitigation is None:
+        if attempt_incomplete:
             overall_text = "⚠️"
         else:
             complete_attempts += 1

--- a/sregym/results/resume.py
+++ b/sregym/results/resume.py
@@ -1,0 +1,32 @@
+def resume_row_is_complete(row: dict[str, str]) -> bool:
+    """Return whether a prior CSV row satisfies one requested attempt."""
+    run_status = str(row.get("run_status", "")).strip().lower()
+    if run_status:
+        return run_status == "complete"
+    if str(row.get("deploy_failed", "")).strip().lower() in {"true", "1", "yes"}:
+        return False
+    if str(row.get("timed_out", "")).strip().lower() in {"true", "1", "yes"}:
+        return False
+    # Legacy rows have no run_status. Require both standard stage results so
+    # diagnosis-only rows from the old lost-submission bug are rerun rather
+    # than counted as complete.
+    return bool(str(row.get("Diagnosis.success", "")).strip()) and bool(str(row.get("Mitigation.success", "")).strip())
+
+
+def complete_resume_rows(
+    rows: list[dict[str, str]],
+    requested_attempts: int,
+) -> dict[tuple[str, int], dict[str, str]]:
+    """Keep one complete row for each valid problem/attempt slot."""
+    complete_rows: dict[tuple[str, int], dict[str, str]] = {}
+    for row in rows:
+        try:
+            attempt_number = int(row.get("attempt", ""))
+        except (TypeError, ValueError):
+            continue
+        if not 1 <= attempt_number <= requested_attempts or not resume_row_is_complete(row):
+            continue
+        key = (row.get("problem_id", ""), attempt_number)
+        if key[0]:
+            complete_rows[key] = row
+    return complete_rows

--- a/tests/conductor/test_submission_lifecycle.py
+++ b/tests/conductor/test_submission_lifecycle.py
@@ -1,0 +1,738 @@
+import asyncio
+import concurrent.futures
+import logging
+import sys
+import threading
+import time
+from types import MethodType, SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from sregym.conductor import conductor as conductor_module
+from sregym.conductor import conductor_api
+from sregym.conductor.conductor import (
+    Conductor,
+    EvaluationInProgress,
+    SubmissionAttemptClosed,
+    SubmissionAttemptMismatch,
+)
+
+
+def _conductor(diagnosis_evaluation=None, mitigation_evaluation=None) -> Conductor:
+    conductor = Conductor.__new__(Conductor)
+    conductor.logger = logging.getLogger("test.submission_lifecycle")
+    conductor.config = SimpleNamespace(enable_noise=False)
+    conductor.problem = None
+    conductor._baseline_captured = False
+    conductor.execution_start_time = time.time()
+    conductor.results = {}
+    conductor.stage_sequence = [
+        {
+            "name": "diagnosis",
+            "evaluation": diagnosis_evaluation or (lambda _solution: None),
+        },
+        {
+            "name": "mitigation",
+            "evaluation": mitigation_evaluation or (lambda _solution: None),
+        },
+    ]
+    conductor.current_stage_index = 0
+    conductor.submission_stage = "diagnosis"
+    conductor.waiting_for_agent = True
+    conductor._evaluating = False
+    conductor._submit_future = None
+    conductor._submission_lock = threading.RLock()
+    conductor._pending_submission_stages = {}
+    conductor._submission_generation = 1
+    conductor._aborted_submission_generations = set()
+    conductor._accepting_submissions = True
+    conductor._attempt_closed = False
+
+    def advance(self, start_index=0):
+        self.waiting_for_agent = False
+        self.current_stage_index = start_index
+        if start_index < len(self.stage_sequence):
+            self.submission_stage = self.stage_sequence[start_index]["name"]
+            self.waiting_for_agent = True
+            self._accepting_submissions = not self._attempt_closed
+        else:
+            self.submission_stage = "done"
+            self._accepting_submissions = False
+            self._attempt_closed = True
+
+    conductor._advance_to_next_stage = MethodType(advance, conductor)
+    return conductor
+
+
+def _wait_for_current_evaluation(conductor: Conductor) -> None:
+    future = conductor._submit_future
+    if future is not None:
+        future.result(timeout=2)
+
+
+def test_conductor_rejects_duplicate_submission_during_evaluation():
+    gate = threading.Event()
+    conductor = _conductor(diagnosis_evaluation=lambda _solution: gate.wait(2))
+
+    async def run():
+        response = await conductor.submit("diagnosis", expected_stage="diagnosis")
+        assert response == {
+            "status": "accepted",
+            "message": "Submission received",
+            "stage": "diagnosis",
+        }
+        with pytest.raises(EvaluationInProgress):
+            await conductor.submit("duplicate", expected_stage="diagnosis")
+
+    try:
+        asyncio.run(run())
+    finally:
+        gate.set()
+        _wait_for_current_evaluation(conductor)
+
+
+def test_legacy_early_mitigation_waits_and_is_accepted_for_mitigation(monkeypatch):
+    diagnosis_gate = threading.Event()
+    mitigation_evaluated = threading.Event()
+
+    def evaluate_diagnosis(solution):
+        diagnosis_gate.wait(2)
+        conductor.results["Diagnosis"] = {"success": True, "submission": solution}
+
+    def evaluate_mitigation(_solution):
+        conductor.results["Mitigation"] = {"success": True}
+        mitigation_evaluated.set()
+
+    conductor = _conductor(evaluate_diagnosis, evaluate_mitigation)
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        first = await conductor_api.submit_solution(
+            conductor_api.SubmitRequest(stage="diagnosis", solution="diagnosis")
+        )
+        assert first["stage"] == "diagnosis"
+
+        # No explicit stage emulates existing clients. The empty solution still
+        # identifies this request as mitigation, so it cannot become a duplicate diagnosis.
+        mitigation_request = asyncio.create_task(
+            conductor_api.submit_solution(conductor_api.SubmitRequest(solution=""))
+        )
+        await asyncio.sleep(0.02)
+        assert not mitigation_request.done()
+
+        diagnosis_gate.set()
+        second = await asyncio.wait_for(mitigation_request, timeout=2)
+        assert second == {
+            "status": "200",
+            "message": "Submission received",
+            "stage": "mitigation",
+        }
+
+    asyncio.run(run())
+    _wait_for_current_evaluation(conductor)
+    assert mitigation_evaluated.is_set()
+    assert conductor.results["Diagnosis"]["submission"] == "diagnosis"
+    assert conductor.results["Mitigation"]["success"] is True
+
+
+def test_registered_early_mitigation_survives_atomic_agent_exit_close(monkeypatch):
+    diagnosis_gate = threading.Event()
+
+    def evaluate_diagnosis(solution):
+        diagnosis_gate.wait(2)
+        conductor.results["Diagnosis"] = {"success": True, "submission": solution}
+
+    def evaluate_mitigation(_solution):
+        conductor.results["Mitigation"] = {"success": True}
+
+    conductor = _conductor(evaluate_diagnosis, evaluate_mitigation)
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        await conductor_api.submit_solution(conductor_api.SubmitRequest(stage="diagnosis", solution="diagnosis"))
+        mitigation_request = asyncio.create_task(
+            conductor_api.submit_solution(conductor_api.SubmitRequest(stage="mitigation", solution=""))
+        )
+        await asyncio.sleep(0.02)
+        assert conductor.close_submissions() is True
+
+        diagnosis_gate.set()
+        mitigation = await asyncio.wait_for(mitigation_request, timeout=2)
+        assert mitigation["stage"] == "mitigation"
+        await conductor.wait_for_submission_work(timeout=2)
+
+    asyncio.run(run())
+    assert conductor.results["Diagnosis"]["success"] is True
+    assert conductor.results["Mitigation"]["success"] is True
+    assert conductor.submission_stage == "done"
+
+
+def test_close_rejects_requests_that_arrive_after_agent_exit(monkeypatch):
+    conductor = _conductor()
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+    assert conductor.close_submissions() is False
+    with pytest.raises(SubmissionAttemptClosed):
+        conductor.register_pending_submission("diagnosis")
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/submit",
+                json={"stage": "diagnosis", "solution": "late diagnosis"},
+            )
+            assert response.status_code == 409
+
+    asyncio.run(run())
+    assert conductor._submit_future is None
+
+
+def test_closed_incomplete_attempt_does_not_claim_all_stages_were_graded(monkeypatch):
+    conductor = _conductor()
+    conductor.record_incomplete_attempt("agent_exited_before_all_stages_completed")
+    conductor.submission_stage = "done"
+    conductor.close_submissions()
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            status = await client.get("/status")
+            late = await client.post("/submit", json={"stage": "mitigation", "solution": ""})
+            assert status.json() == {"stage": "done"}
+            assert late.status_code == 409
+            assert "no longer accepts" in late.json()["detail"]
+
+    asyncio.run(run())
+
+
+def test_old_attempt_generation_cannot_submit_to_new_attempt():
+    conductor = _conductor()
+    old_generation = conductor.register_pending_submission("diagnosis")
+    conductor.close_submissions()
+    with conductor._submission_lock:
+        conductor._submission_generation += 1
+        conductor._attempt_closed = False
+        conductor._accepting_submissions = True
+
+    async def run():
+        with pytest.raises(SubmissionAttemptMismatch):
+            await conductor.submit(
+                "old attempt",
+                expected_stage="diagnosis",
+                expected_generation=old_generation,
+            )
+
+    try:
+        asyncio.run(run())
+    finally:
+        conductor.unregister_pending_submission("diagnosis", old_generation)
+
+
+def test_duplicate_diagnosis_never_becomes_mitigation(monkeypatch):
+    diagnosis_gate = threading.Event()
+    conductor = _conductor(diagnosis_evaluation=lambda _solution: diagnosis_gate.wait(2))
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        await conductor_api.submit_solution(conductor_api.SubmitRequest(stage="diagnosis", solution="diagnosis"))
+        with pytest.raises(HTTPException) as exc_info:
+            await conductor_api.submit_solution(conductor_api.SubmitRequest(solution="duplicate diagnosis"))
+        assert exc_info.value.status_code == 409
+
+    try:
+        asyncio.run(run())
+    finally:
+        diagnosis_gate.set()
+        _wait_for_current_evaluation(conductor)
+
+    assert conductor.submission_stage == "mitigation"
+    assert "Mitigation" not in conductor.results
+
+
+def test_mcp_reports_the_stage_that_accepted_the_submission(monkeypatch):
+    conductor = _conductor()
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    response = asyncio.run(conductor_api.submit_via_conductor.fn("diagnosis", stage="diagnosis"))
+
+    assert response == {
+        "status": "200",
+        "text": "Submission received",
+        "stage": "diagnosis",
+    }
+    _wait_for_current_evaluation(conductor)
+
+
+def test_legacy_nonempty_mitigation_uses_current_stage(monkeypatch):
+    conductor = _conductor()
+    conductor.current_stage_index = 1
+    conductor.submission_stage = "mitigation"
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    response = asyncio.run(conductor_api.submit_solution(conductor_api.SubmitRequest(solution="fixed and verified")))
+
+    assert response["stage"] == "mitigation"
+    _wait_for_current_evaluation(conductor)
+
+
+def test_legacy_empty_diagnosis_uses_idle_current_stage(monkeypatch):
+    conductor = _conductor()
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    response = asyncio.run(conductor_api.submit_solution(conductor_api.SubmitRequest(solution="")))
+
+    assert response["stage"] == "diagnosis"
+    _wait_for_current_evaluation(conductor)
+
+
+def test_http_api_waits_for_early_mitigation_and_rejects_duplicate_diagnosis(monkeypatch):
+    diagnosis_gate = threading.Event()
+
+    def evaluate_diagnosis(solution):
+        diagnosis_gate.wait(2)
+        conductor.results["Diagnosis"] = {"success": True, "submission": solution}
+
+    def evaluate_mitigation(_solution):
+        conductor.results["Mitigation"] = {"success": True}
+
+    conductor = _conductor(evaluate_diagnosis, evaluate_mitigation)
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            diagnosis = await client.post(
+                "/submit",
+                json={"stage": "diagnosis", "solution": "diagnosis"},
+            )
+            assert diagnosis.status_code == 200
+            assert diagnosis.json()["stage"] == "diagnosis"
+
+            mitigation_request = asyncio.create_task(
+                client.post(
+                    "/submit",
+                    json={"stage": "mitigation", "solution": ""},
+                )
+            )
+            await asyncio.sleep(0.02)
+            assert not mitigation_request.done()
+            assert conductor._pending_submission_stages == {(1, "mitigation"): 1}
+
+            duplicate = await client.post(
+                "/submit",
+                json={"stage": "diagnosis", "solution": "duplicate"},
+            )
+            assert duplicate.status_code == 409
+
+            diagnosis_gate.set()
+            await conductor.wait_for_submission_work(timeout=2)
+            mitigation = await asyncio.wait_for(mitigation_request, timeout=2)
+            assert mitigation.status_code == 200
+            assert mitigation.json()["stage"] == "mitigation"
+
+    try:
+        asyncio.run(run())
+    finally:
+        diagnosis_gate.set()
+        _wait_for_current_evaluation(conductor)
+
+    assert conductor.results["Diagnosis"]["submission"] == "diagnosis"
+    assert conductor.results["Mitigation"]["success"] is True
+
+
+def test_early_mitigation_is_rejected_when_diagnosis_was_not_submitted(monkeypatch):
+    conductor = _conductor()
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/submit",
+                json={"stage": "mitigation", "solution": ""},
+            )
+            assert response.status_code == 409
+
+    asyncio.run(run())
+    assert conductor._pending_submission_stages == {}
+    assert conductor.submission_stage == "diagnosis"
+
+
+@pytest.mark.parametrize("stage", [None, "setup"])
+def test_submission_before_an_agent_stage_is_rejected_without_leaking(monkeypatch, stage):
+    conductor = _conductor()
+    conductor.submission_stage = stage
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/submit",
+                json={"stage": "diagnosis", "solution": "diagnosis"},
+            )
+            assert response.status_code == 409
+
+    asyncio.run(run())
+    assert conductor._pending_submission_stages == {}
+
+
+def test_api_cannot_observe_a_partial_stage_transition(monkeypatch):
+    conductor = _conductor()
+    conductor.waiting_for_agent = False
+    conductor._evaluating = True
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+    transition_started = threading.Event()
+
+    def finish_diagnosis():
+        with conductor._submission_lock:
+            conductor._evaluating = False
+            transition_started.set()
+            time.sleep(0.05)
+            conductor.current_stage_index = 1
+            conductor.submission_stage = "mitigation"
+            conductor.waiting_for_agent = True
+
+    transition = threading.Thread(target=finish_diagnosis)
+    transition.start()
+    assert transition_started.wait(1)
+
+    async def run():
+        response = await conductor_api.submit_solution(conductor_api.SubmitRequest(stage="mitigation", solution=""))
+        assert response["stage"] == "mitigation"
+
+    asyncio.run(run())
+    transition.join(timeout=1)
+    _wait_for_current_evaluation(conductor)
+
+
+def test_submission_wait_propagates_a_completed_evaluation_failure():
+    conductor = _conductor()
+    future = concurrent.futures.Future()
+    future.set_exception(RuntimeError("cleanup failed"))
+    conductor._submit_future = future
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        asyncio.run(conductor.wait_for_submission_work(timeout=1))
+    assert conductor._submit_future is None
+
+
+def test_submission_wait_times_out_while_a_request_remains_pending():
+    conductor = _conductor()
+    generation = conductor.register_pending_submission("mitigation")
+
+    try:
+        with pytest.raises(TimeoutError):
+            asyncio.run(conductor.wait_for_submission_work(timeout=0.01))
+    finally:
+        conductor.unregister_pending_submission("mitigation", generation)
+
+
+def test_abandoned_evaluator_cannot_publish_or_advance_late_result():
+    gate = threading.Event()
+
+    def evaluate(_solution):
+        gate.wait(2)
+        return {"success": True}
+
+    conductor = _conductor(diagnosis_evaluation=evaluate)
+
+    async def run():
+        await conductor.submit("diagnosis", expected_stage="diagnosis")
+        old_future = conductor._submit_future
+        assert old_future is not None
+        with pytest.raises(TimeoutError):
+            await conductor.wait_for_submission_work(timeout=0.01)
+        conductor.abandon_submission_work()
+        gate.set()
+        old_future.result(timeout=2)
+
+    asyncio.run(run())
+    assert conductor.submission_stage == "aborted"
+    assert "Diagnosis" not in conductor.results
+    assert conductor._submit_future is None
+
+
+def test_abandoned_conductor_cannot_start_an_overlapping_attempt():
+    conductor = _conductor()
+    conductor.problem_id = "next-problem"
+    conductor.abandon_submission_work()
+
+    with pytest.raises(RuntimeError, match="cannot be reused"):
+        asyncio.run(conductor.start_problem())
+
+
+def test_worker_base_exception_becomes_controlled_evaluation_failure():
+    conductor = _conductor(diagnosis_evaluation=lambda _solution: sys.exit("oracle exited"))
+
+    async def run():
+        await conductor.submit("diagnosis", expected_stage="diagnosis")
+        with pytest.raises(RuntimeError, match="Evaluator terminated with SystemExit"):
+            await conductor.wait_for_submission_work(timeout=1)
+
+    asyncio.run(run())
+    assert conductor._submit_future is None
+
+
+def test_late_noise_restart_is_stopped_after_attempt_is_abandoned(monkeypatch):
+    start_entered = threading.Event()
+    release_start = threading.Event()
+
+    class FakeNoiseManager:
+        def __init__(self):
+            self.running = False
+            self.stages: list[str] = []
+
+        def start(self):
+            start_entered.set()
+            release_start.wait(2)
+            self.running = True
+
+        def stop(self):
+            self.running = False
+
+        def set_stage(self, stage):
+            self.stages.append(stage)
+
+    noise = FakeNoiseManager()
+    conductor = _conductor(diagnosis_evaluation=lambda _solution: {"success": True})
+    conductor.config.enable_noise = True
+    monkeypatch.setattr(conductor_module, "get_noise_manager", lambda: noise)
+
+    worker = threading.Thread(
+        target=conductor._submit_evaluate_and_advance,
+        args=("diagnosis", conductor.stage_sequence[0], 1),
+    )
+    worker.start()
+    assert start_entered.wait(1)
+    conductor.abandon_submission_work()
+    noise.stop()  # Emulate the driver's global shutdown after abandonment.
+    release_start.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert noise.running is False
+    assert noise.stages == []
+    assert conductor.submission_stage == "aborted"
+
+
+def test_incomplete_attempt_records_missing_stages_and_agent_exit():
+    conductor = _conductor()
+    conductor.results["Diagnosis"] = {"success": True}
+    conductor.submission_stage = "mitigation"
+
+    conductor.record_incomplete_attempt(
+        "agent_exited_before_all_stages_completed",
+        agent_return_code=0,
+    )
+
+    assert conductor.finalize_attempt_status() == "incomplete"
+    assert conductor.results["incomplete_stage"] == "mitigation"
+    assert conductor.results["missing_stages"] == "mitigation"
+    assert conductor.results["agent_return_code"] == 0
+
+
+def test_agent_exit_during_diagnosis_records_both_missing_stages():
+    conductor = _conductor()
+
+    conductor.record_incomplete_attempt(
+        "agent_exited_before_all_stages_completed",
+        agent_return_code=1,
+    )
+
+    assert conductor.finalize_attempt_status() == "incomplete"
+    assert conductor.results["incomplete_stage"] == "diagnosis"
+    assert conductor.results["missing_stages"] == "diagnosis,mitigation"
+    assert conductor.results["agent_return_code"] == 1
+
+
+def test_final_status_fails_safe_when_a_stage_result_is_missing():
+    conductor = _conductor()
+    conductor.results["Diagnosis"] = {"success": True}
+    conductor.submission_stage = "done"
+
+    assert conductor.finalize_attempt_status() == "incomplete"
+    assert conductor.results["incomplete_reason"] == "missing_stage_results"
+    assert conductor.results["incomplete_stage"] == "mitigation"
+
+
+def test_final_status_is_complete_only_when_every_stage_has_a_result():
+    conductor = _conductor()
+    conductor.results["Diagnosis"] = {"success": True}
+    conductor.results["Mitigation"] = {"success": False}
+
+    assert conductor.finalize_attempt_status() == "complete"
+    assert conductor.results["run_status"] == "complete"
+
+
+def test_cleanup_failure_makes_a_fully_graded_attempt_incomplete():
+    conductor = _conductor()
+    conductor.results["Diagnosis"] = {"success": True}
+    conductor.results["Mitigation"] = {"success": True}
+    conductor.results["cleanup_failed"] = True
+
+    assert conductor.finalize_attempt_status() == "incomplete"
+    assert conductor.results["incomplete_reason"] == "cleanup_failed"
+
+
+def test_cleanup_continues_after_recovery_error_and_reaches_terminal_state():
+    conductor = _conductor()
+    app_cleaned = threading.Event()
+
+    def recover_fault():
+        raise RuntimeError("recovery failed")
+
+    conductor.problem = SimpleNamespace(
+        recover_fault=recover_fault,
+        app=SimpleNamespace(cleanup=app_cleaned.set),
+    )
+    conductor._baseline_captured = False
+    conductor.submission_stage = "tearing_down"
+
+    conductor._cleanup_sync()
+
+    assert app_cleaned.is_set()
+    assert conductor.submission_stage == "done"
+    assert conductor.results["cleanup_failed"] is True
+    assert "recover_fault: RuntimeError: recovery failed" in conductor.results["cleanup_error"]
+
+
+def test_abandoned_cleanup_does_not_run_later_cleanup_phases():
+    conductor = _conductor()
+    recovery_started = threading.Event()
+    release_recovery = threading.Event()
+    app_cleanup_ran = threading.Event()
+    reconcile_ran = threading.Event()
+
+    def recover_fault():
+        recovery_started.set()
+        release_recovery.wait(2)
+
+    conductor.problem = SimpleNamespace(
+        recover_fault=recover_fault,
+        app=SimpleNamespace(cleanup=app_cleanup_ran.set),
+    )
+    conductor._baseline_captured = True
+    conductor.cluster_state = SimpleNamespace(reconcile_to_baseline=lambda: reconcile_ran.set() or {})
+    conductor.submission_stage = "tearing_down"
+
+    cleanup = threading.Thread(target=conductor._cleanup_sync, args=(1,))
+    cleanup.start()
+    assert recovery_started.wait(1)
+    conductor.abandon_submission_work()
+    release_recovery.set()
+    cleanup.join(timeout=2)
+
+    assert not cleanup.is_alive()
+    assert not app_cleanup_ran.is_set()
+    assert not reconcile_ran.is_set()
+    assert conductor.submission_stage == "aborted"
+
+
+def test_background_safety_cleanup_can_be_bounded_and_abandoned():
+    conductor = _conductor()
+    recovery_started = threading.Event()
+    release_recovery = threading.Event()
+    app_cleanup_ran = threading.Event()
+
+    def recover_fault():
+        recovery_started.set()
+        release_recovery.wait(2)
+
+    conductor.problem = SimpleNamespace(
+        recover_fault=recover_fault,
+        app=SimpleNamespace(cleanup=app_cleanup_ran.set),
+    )
+
+    async def run():
+        future = conductor.finish_problem_in_background()
+        assert recovery_started.wait(1)
+        with pytest.raises(TimeoutError):
+            await conductor.wait_for_submission_work(timeout=0.01)
+        conductor.abandon_submission_work()
+        release_recovery.set()
+        future.result(timeout=2)
+
+    asyncio.run(run())
+    assert not app_cleanup_ran.is_set()
+    assert conductor.submission_stage == "aborted"
+    assert conductor._submit_future is None
+
+
+def test_orphaned_teardown_cannot_be_reported_as_successful_cleanup():
+    conductor = _conductor()
+    conductor.submission_stage = "tearing_down"
+    conductor._submit_future = None
+
+    with pytest.raises(RuntimeError, match="stopped unexpectedly"):
+        conductor.finish_problem_in_background()
+
+
+def test_no_stage_path_starts_bounded_background_cleanup():
+    conductor = _conductor()
+    recovery_started = threading.Event()
+    release_recovery = threading.Event()
+
+    def recover_fault():
+        recovery_started.set()
+        release_recovery.wait(2)
+
+    conductor.problem = SimpleNamespace(
+        recover_fault=recover_fault,
+        app=SimpleNamespace(cleanup=lambda: None),
+    )
+    conductor.stage_sequence = []
+
+    started_at = time.monotonic()
+    Conductor._advance_to_next_stage(conductor)
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 0.2
+    assert recovery_started.wait(1)
+    future = conductor._submit_future
+    assert future is not None
+    conductor.abandon_submission_work()
+    release_recovery.set()
+    future.result(timeout=2)
+
+
+def test_new_generation_uses_setup_state_before_early_setup_failure(monkeypatch):
+    recovered = threading.Event()
+    app_cleaned = threading.Event()
+    new_problem = SimpleNamespace(
+        recover_fault=recovered.set,
+        app=SimpleNamespace(cleanup=app_cleaned.set),
+    )
+    conductor = _conductor()
+    conductor.problem_id = "problem"
+    conductor.submission_stage = "done"
+    conductor.problems = SimpleNamespace(get_problem_instance=lambda _problem_id: new_problem)
+    conductor.dependency_check = lambda _binaries: (_ for _ in ()).throw(RuntimeError("missing dependency"))
+    monkeypatch.setattr(conductor_module, "DetectionOracle", lambda _problem: object())
+
+    with pytest.raises(RuntimeError, match="missing dependency"):
+        asyncio.run(conductor.start_problem())
+
+    assert conductor.submission_stage == "setup"
+    future = conductor.finish_problem_in_background()
+    future.result(timeout=2)
+
+    assert recovered.is_set()
+    assert app_cleaned.is_set()
+    assert conductor.submission_stage == "done"
+
+
+def test_teardown_failure_stays_incomplete_even_when_stage_results_exist():
+    conductor = _conductor()
+    conductor.results["Diagnosis"] = {"success": True}
+    conductor.results["Mitigation"] = {"success": True}
+    conductor.submission_stage = "tearing_down"
+
+    conductor.record_incomplete_attempt("evaluation_timeout_after_agent_exit", agent_return_code=0)
+
+    assert conductor.finalize_attempt_status() == "incomplete"
+    assert conductor.results["incomplete_stage"] == "tearing_down"
+    assert conductor.results["missing_stages"] == ""

--- a/tests/e2e-testing-scripts/auto_submit.py
+++ b/tests/e2e-testing-scripts/auto_submit.py
@@ -1,19 +1,27 @@
-import subprocess
 import threading
 from time import sleep
+
+import requests
+
+SERVER_URL = "http://localhost:8000"
 
 
 def automatic_submit():
     ctr = 0
     while ctr < 10000:
-        subprocess.run(
-            [
-                "bash",
-                "-c",
-                'curl -v http://localhost:8000/submit -H "Content-Type: application/json" -d \'{"solution":"yes"}\'',
-            ],
-            stdin=subprocess.DEVNULL,
-        )
+        try:
+            status = requests.get(f"{SERVER_URL}/status", timeout=10).json().get("stage")
+            if status == "done":
+                return
+            if status in {"diagnosis", "mitigation"}:
+                response = requests.post(
+                    f"{SERVER_URL}/submit",
+                    json={"stage": status, "solution": "yes" if status == "diagnosis" else ""},
+                    timeout=310,
+                )
+                response.raise_for_status()
+        except requests.RequestException:
+            pass
         sleep(30)
         ctr += 1
 

--- a/tests/integration/smoke_test.py
+++ b/tests/integration/smoke_test.py
@@ -23,6 +23,8 @@ async def _run_smoke_test():
 
     # 2. Select the problem
     conductor.problem_id = PROBLEM_ID
+    # Keep this smoke test independent from a developer's local tasklist.yml.
+    conductor.get_problem_stages = lambda: setattr(conductor, "tasklist", ["mitigation"])
 
     # 3. Deploy app and inject fault
     result = await conductor.start_problem()
@@ -33,7 +35,7 @@ async def _run_smoke_test():
 
     # 4. Submit a placeholder solution (we expect mitigation to fail)
     response = await conductor.submit("placeholder")
-    assert response.get("status") == "ok", f"submit response: {response}"
+    assert response.get("status") == "accepted", f"submit response: {response}"
 
     # 5. Poll until evaluation completes
     elapsed = 0

--- a/tests/mcp/test_submission_contract.py
+++ b/tests/mcp/test_submission_contract.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from clients.stratus.tools.submit_tool import _require_accepted_submission
+from mcp_server import submit_server
+
+
+@pytest.mark.parametrize(
+    ("answer", "stage", "expected_payload"),
+    [
+        ("root cause", "diagnosis", {"solution": "root cause", "stage": "diagnosis"}),
+        ("", "mitigation", {"solution": "", "stage": "mitigation"}),
+        ("", None, {"solution": ""}),
+    ],
+)
+def test_submission_mcp_forwards_the_stage(monkeypatch, answer, stage, expected_payload):
+    request = {}
+
+    def post(url, *, json, headers, timeout):
+        request.update(url=url, json=json, headers=headers, timeout=timeout)
+        return SimpleNamespace(status_code=200, text='{"status":"200"}')
+
+    monkeypatch.setattr(submit_server.requests, "post", post)
+
+    response = submit_server.submit.fn(answer, stage=stage)
+
+    assert response["status"] == "200"
+    assert request["json"] == expected_payload
+    assert request["timeout"] == 310
+
+
+def test_stratus_manual_submission_rejects_an_mcp_error():
+    with pytest.raises(RuntimeError, match="rejected the mitigation submission"):
+        _require_accepted_submission(
+            {"status": "error", "text": "evaluation in progress"},
+            "mitigation",
+        )
+
+
+@pytest.mark.parametrize("status", ["200", "done"])
+def test_stratus_manual_submission_accepts_success_statuses(status):
+    _require_accepted_submission({"status": status}, "mitigation")

--- a/tests/stratus/test_usage_reporting.py
+++ b/tests/stratus/test_usage_reporting.py
@@ -36,8 +36,8 @@ def test_completed_run_adds_summary_usage_to_csv(monkeypatch, tmp_path):
         }
         return stats, object(), []
 
-    async def fake_stage_switch(**_kwargs):
-        return "done"
+    async def fake_stage_switch(**kwargs):
+        return "diagnosis" if kwargs["current_stage"] == "setup" else "done"
 
     monkeypatch.setattr(driver, "diagnosis_with_localization_task_main", fake_diagnosis_run)
     monkeypatch.setattr(driver, "generate_run_summary", lambda *_args: "summary")

--- a/tests/test_demo_submission_compatibility.py
+++ b/tests/test_demo_submission_compatibility.py
@@ -1,0 +1,25 @@
+from clients.demo.driver import parse_submit_command, resolve_demo_submission_stage
+
+
+def test_demo_parser_accepts_staged_submission():
+    assert parse_submit_command('submit("diagnosis", "root cause")') == ("diagnosis", "root cause")
+    assert parse_submit_command('submit("mitigation", "")') == ("mitigation", "")
+
+
+def test_demo_parser_keeps_legacy_current_stage_submission():
+    assert parse_submit_command('submit("root cause")') == (None, "root cause")
+    assert parse_submit_command(r'submit("root cause: \"memory\"")') == (None, 'root cause: "memory"')
+
+
+def test_demo_parser_does_not_treat_kubectl_as_submission():
+    assert parse_submit_command("kubectl get pods") is None
+    assert parse_submit_command('submit("unknown", "answer")') is None
+    assert parse_submit_command("submit(answer)") is None
+    assert parse_submit_command('submit([], "answer")') is None
+    assert parse_submit_command('other("diagnosis", "answer")') is None
+
+
+def test_second_legacy_demo_submission_targets_mitigation():
+    assert resolve_demo_submission_stage(None, None) is None
+    assert resolve_demo_submission_stage(None, "diagnosis") == "mitigation"
+    assert resolve_demo_submission_stage("diagnosis", "diagnosis") == "diagnosis"

--- a/tests/test_main_campaign_abort.py
+++ b/tests/test_main_campaign_abort.py
@@ -1,0 +1,43 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_main_module():
+    main_path = Path(__file__).resolve().parents[1] / "main.py"
+    spec = importlib.util.spec_from_file_location("sregym_benchmark_main_for_test", main_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_driver_wrapper_preserves_partial_results_and_failure(monkeypatch):
+    benchmark_main = _load_main_module()
+    partial_results = [
+        {
+            "codex": [
+                {
+                    "problem_id": "problem",
+                    "attempt": 1,
+                    "run_status": "incomplete",
+                    "incomplete_reason": "cleanup_timeout_after_agent_exit",
+                }
+            ]
+        }
+    ]
+
+    def abort_driver(*_args, **_kwargs):
+        raise benchmark_main.BenchmarkCampaignAborted("cleanup timed out", partial_results)
+
+    shutdown_called = []
+    monkeypatch.setattr(benchmark_main, "driver_loop", abort_driver)
+    monkeypatch.setattr(benchmark_main.LAUNCHER, "cleanup_all", lambda: None)
+    monkeypatch.setattr(benchmark_main, "request_shutdown", lambda: shutdown_called.append(True))
+
+    benchmark_main._run_driver_and_shutdown(object())
+
+    assert benchmark_main._driver_results == partial_results
+    assert isinstance(benchmark_main._driver_error, benchmark_main.BenchmarkCampaignAborted)
+    assert shutdown_called == [True]

--- a/tests/test_main_resume.py
+++ b/tests/test_main_resume.py
@@ -1,0 +1,33 @@
+from sregym.results.resume import complete_resume_rows, resume_row_is_complete
+
+
+def _row(attempt: int, **extra: str) -> dict[str, str]:
+    return {"problem_id": "problem", "attempt": str(attempt), **extra}
+
+
+def test_explicit_incomplete_and_failed_rows_do_not_satisfy_resume():
+    rows = [
+        _row(1, run_status="incomplete", **{"Diagnosis.success": "True"}),
+        _row(2, deploy_failed="True"),
+        _row(3, timed_out="True", **{"Diagnosis.success": "True", "Mitigation.success": "True"}),
+    ]
+
+    assert complete_resume_rows(rows, requested_attempts=3) == {}
+
+
+def test_resume_keeps_only_complete_attempt_slots_and_deduplicates_them():
+    first = _row(1, run_status="complete")
+    replacement = _row(1, run_status="complete", marker="latest")
+    outside_requested_range = _row(4, run_status="complete")
+
+    rows = complete_resume_rows([first, replacement, outside_requested_range], requested_attempts=3)
+
+    assert rows == {("problem", 1): replacement}
+
+
+def test_legacy_diagnosis_only_row_is_rerun():
+    diagnosis_only = _row(1, **{"Diagnosis.success": "True"})
+    both_stages = _row(2, **{"Diagnosis.success": "False", "Mitigation.success": "False"})
+
+    assert resume_row_is_complete(diagnosis_only) is False
+    assert resume_row_is_complete(both_stages) is True

--- a/tests/test_problem_evaluation_report.py
+++ b/tests/test_problem_evaluation_report.py
@@ -1,4 +1,4 @@
-from sregym.problem_evaluation_report import build_report
+from sregym.results.report import build_report
 
 
 def _row(attempt: int, diagnosis: object = True, mitigation: object = True, **extra):
@@ -50,4 +50,73 @@ def test_report_does_not_count_infrastructure_failure_as_model_failure():
     assert "**Overall pass rate:** 1/1 (100%)" in report
     assert "| 2 | — | — | ⚠️ | deployment failed |" in report
     assert "| 3 | — | — | ⚠️ | not run |" in report
+    assert "⚠️ **Inconclusive**" in report
+
+
+def test_report_explains_an_explicit_incomplete_attempt():
+    rows = [
+        {
+            "problem_id": "example_problem",
+            "attempt": "1",
+            "Diagnosis.success": "True",
+            "run_status": "incomplete",
+            "incomplete_reason": "agent_exited_before_all_stages_completed",
+            "incomplete_stage": "mitigation",
+            "missing_stages": "mitigation",
+        }
+    ]
+
+    report = build_report(
+        rows,
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=1,
+    )
+
+    assert "agent exited before all stages completed at mitigation" in report
+    assert "⚠️ **Inconclusive**" in report
+
+
+def test_report_includes_stage_for_an_explicit_timeout():
+    rows = [
+        {
+            "problem_id": "example_problem",
+            "attempt": "1",
+            "run_status": "incomplete",
+            "incomplete_reason": "agent_timeout",
+            "incomplete_stage": "diagnosis",
+            "missing_stages": "diagnosis,mitigation",
+            "timed_out": "True",
+        }
+    ]
+
+    report = build_report(
+        rows,
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=1,
+    )
+
+    assert "agent timeout at diagnosis" in report
+
+
+def test_report_does_not_count_explicitly_incomplete_run_with_stage_results():
+    row = _row(
+        1,
+        run_status="incomplete",
+        incomplete_reason="agent_timeout",
+        incomplete_stage="run",
+    )
+
+    report = build_report(
+        [row],
+        problem_id="example_problem",
+        model="glm-4.7",
+        requested_attempts=1,
+    )
+
+    assert "**Complete attempts:** 0" in report
+    assert "**Diagnosis pass rate:** n/a" in report
+    assert "**Mitigation pass rate:** n/a" in report
+    assert "| 1 | ✅ | ✅ | ⚠️ | agent timeout at run |" in report
     assert "⚠️ **Inconclusive**" in report

--- a/tests/test_tierzero_stages.py
+++ b/tests/test_tierzero_stages.py
@@ -1,0 +1,35 @@
+from clients.tierzero import driver
+
+
+def test_tierzero_skips_diagnosis_when_attempt_starts_at_mitigation(monkeypatch, tmp_path):
+    submissions: list[tuple[str, str]] = []
+    prompts: list[str] = []
+
+    monkeypatch.setattr(driver, "TIERZERO_ORG_API_KEY", "test-key")
+    monkeypatch.setattr(driver, "AGENT_LOGS_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        driver, "wait_for_stage", lambda stages, timeout: "mitigation" if "mitigation" in stages else "done"
+    )
+    monkeypatch.setattr(
+        driver,
+        "get_app_info",
+        lambda: {"app_name": "app", "namespace": "namespace", "descriptions": "description"},
+    )
+    monkeypatch.setattr(driver, "resolve_problem_id", lambda: "problem")
+
+    def create_interaction(prompt, context=None):
+        prompts.append(prompt)
+        assert context is None
+        return "mitigation-interaction"
+
+    monkeypatch.setattr(driver, "create_interaction", create_interaction)
+    monkeypatch.setattr(driver, "poll_interaction", lambda _interaction_id: {"status": "COMPLETED"})
+    monkeypatch.setattr(driver, "extract_content", lambda _result: "fixed")
+    monkeypatch.setattr(driver, "submit_to_conductor", lambda answer, stage: submissions.append((answer, stage)))
+
+    driver.main()
+
+    assert len(prompts) == 1
+    assert submissions == [("", "mitigation")]
+    assert not (tmp_path / "diagnosis_result.json").exists()
+    assert (tmp_path / "mitigation_result.json").exists()


### PR DESCRIPTION
During Opus 5 and Sonnet 5 runs on SREGym-Lite, some attempts had no mitigation result. This affected 6 of 63 Sonnet 5 attempts. An agent can submit its mitigation before diagnosis grading finishes. Previously, the API returned success, but the Conductor discarded the early mitigation. The attempt then ended without a mitigation result.

This PR tracks the stage of each submission. If mitigation arrives during diagnosis grading, the API waits until the mitigation stage starts. It returns success only after the Conductor accepts the submission. Older clients that do not send a stage still work.

The runner now marks attempts with missing results as incomplete. It also waits for grading and cleanup before it starts the next attempt. If cleanup cannot finish safely, the runner stops the campaign. Resume runs also retry incomplete attempts. Evaluation reports do not count incomplete attempts as model successes or failures.

---

- The submission API now accepts an optional `stage` value: `diagnosis` or `mitigation`.
- Each pending submission is linked to its benchmark attempt. Submissions from an old or closed attempt are rejected.
- An early mitigation request waits for up to 300 seconds. The API checks every 100 milliseconds for the mitigation stage.
- The Conductor accepts only one submission for the active stage. The API reports success only after this acceptance.
- The runner waits for pending submissions, grading tasks, and cleanup tasks before it saves the final result.