### PR TITLE
Fix Kubernetes API proxy upgraded connections

### DIFF
--- a/sregym/service/k8s_proxy.py
+++ b/sregym/service/k8s_proxy.py
@@ -20,9 +20,11 @@ import json
 import logging
 import os
 import secrets
+import socket
 import ssl
 import tempfile
 import threading
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from ipaddress import ip_address
@@ -293,6 +295,38 @@ def is_valid_bearer_token(authorization: str | None, expected_token: str) -> boo
     """Validate the bearer token presented by an agent request."""
     scheme, separator, token = (authorization or "").partition(" ")
     return bool(separator and scheme.casefold() == "bearer" and secrets.compare_digest(token, expected_token))
+
+
+def _relay_upgraded_connection(
+    client_socket: socket.socket,
+    upstream_socket: socket.socket,
+    read_from_client: Callable[[int], bytes],
+    read_from_upstream: Callable[[int], bytes],
+) -> None:
+    """Relay an upgraded HTTP connection until either endpoint closes."""
+
+    def relay(read: Callable[[int], bytes], destination: socket.socket) -> None:
+        try:
+            while data := read(64 * 1024):
+                destination.sendall(data)
+        except OSError:
+            pass
+        finally:
+            # An upgraded Kubernetes stream is one logical connection. Once
+            # either endpoint closes, unblock the copy in the other direction.
+            for connection in (client_socket, upstream_socket):
+                with contextlib.suppress(OSError):
+                    connection.shutdown(socket.SHUT_RDWR)
+
+    client_to_upstream = threading.Thread(
+        target=relay,
+        args=(read_from_client, upstream_socket),
+        name="k8s-proxy-client-to-upstream",
+        daemon=True,
+    )
+    client_to_upstream.start()
+    relay(read_from_upstream, client_socket)
+    client_to_upstream.join()
 
 
 class KubernetesAPIProxy:
@@ -575,7 +609,20 @@ class KubernetesAPIProxy:
                     excluded_headers = {"host", "accept-encoding", "authorization"}
                     if requires_json:
                         excluded_headers.add("accept")
-                    headers = {k: v for k, v in self.headers.items() if k.lower() not in excluded_headers}
+                    headers: dict[str, str] = {}
+                    stream_protocol_header = "X-Stream-Protocol-Version"
+                    for header, value in self.headers.items():
+                        header_lower = header.lower()
+                        if header_lower in excluded_headers:
+                            continue
+                        if header_lower == "x-stream-protocol-version":
+                            # Kubernetes accepts this negotiation header as a
+                            # comma-separated preference list. Preserve every
+                            # value instead of letting the dict drop all but one.
+                            previous = headers.get(stream_protocol_header)
+                            headers[stream_protocol_header] = f"{previous}, {value}" if previous else value
+                        else:
+                            headers[header] = value
                     if requires_json:
                         # The proxy cannot safely filter Kubernetes' protobuf form.
                         headers["Accept"] = "application/json"
@@ -584,6 +631,40 @@ class KubernetesAPIProxy:
                         headers["Authorization"] = f"Bearer {bearer_token}"
                     conn.request(method, path, body=body, headers=headers)
                     response = conn.getresponse()
+
+                    if response.status == 101:
+                        if conn.sock is None or response.fp is None:
+                            raise ConnectionError("Kubernetes upgrade did not provide a usable connection")
+
+                        # A 101 ends HTTP response handling and turns both sides
+                        # into one opaque, bidirectional stream. Do not call
+                        # response.read(): it treats 1xx responses as empty and
+                        # closes the buffered reader that may hold the first frame.
+                        self.protocol_version = "HTTP/1.1"
+                        self.close_connection = True
+                        try:
+                            self.send_response(response.status)
+                            for header, value in response.getheaders():
+                                if header.lower() not in ("transfer-encoding", "content-length", "content-encoding"):
+                                    self.send_header(header, value)
+                            self.end_headers()
+                            self.wfile.flush()
+                            _relay_upgraded_connection(
+                                self.connection,
+                                conn.sock,
+                                self.rfile.read1,
+                                response.fp.read1,
+                            )
+                        except OSError as exc:
+                            logger.debug("Upgraded Kubernetes connection closed: %s", exc)
+                        except Exception:
+                            # The HTTP response has already switched protocols,
+                            # so another HTTP error response cannot be sent.
+                            logger.exception("Kubernetes upgraded-connection relay failed")
+                        finally:
+                            response.close()
+                            conn.close()
+                        return
 
                     # Read response
                     response_body = response.read()

--- a/tests/service/test_k8s_proxy.py
+++ b/tests/service/test_k8s_proxy.py
@@ -45,10 +45,18 @@ ORDINARY_SECRET = {
 
 
 class FakeResponse:
-    def __init__(self, body: bytes, content_type: str = "application/json", status: int = 200):
+    def __init__(
+        self,
+        body: bytes,
+        content_type: str = "application/json",
+        status: int = 200,
+        headers: list[tuple[str, str]] | None = None,
+        fp=None,
+    ):
         self.status = status
         self._body = body
-        self._headers = [("Content-Type", content_type), ("Content-Length", str(len(body)))]
+        self._headers = headers or [("Content-Type", content_type), ("Content-Length", str(len(body)))]
+        self.fp = fp
 
     def read(self) -> bytes:
         return self._body
@@ -59,13 +67,18 @@ class FakeResponse:
     def getheaders(self) -> list[tuple[str, str]]:
         return self._headers
 
+    def close(self):
+        if self.fp is not None:
+            self.fp.close()
+
 
 class FakeHTTPSConnection:
     requests: list[tuple[str, str, dict[str, str]]] = []
     response = FakeResponse(b"{}")
+    sock: socket.socket | None = None
 
     def __init__(self, *args, **kwargs):
-        pass
+        self.sock = type(self).sock
 
     def request(self, method: str, path: str, body=None, headers=None):
         self.requests.append((method, path, headers or {}))
@@ -74,13 +87,16 @@ class FakeHTTPSConnection:
         return self.response
 
     def close(self):
-        pass
+        if self.sock is not None:
+            self.sock.close()
+            self.sock = None
 
 
 @pytest.fixture
 def proxy(monkeypatch):
     FakeHTTPSConnection.requests = []
     FakeHTTPSConnection.response = FakeResponse(b"{}")
+    FakeHTTPSConnection.sock = None
     monkeypatch.setattr(http.client, "HTTPSConnection", FakeHTTPSConnection)
 
     instance = object.__new__(KubernetesAPIProxy)
@@ -364,3 +380,91 @@ def test_ordinary_secret_remains_accessible(proxy):
 
     assert status == 200
     assert json.loads(body) == ORDINARY_SECRET
+
+
+@pytest.mark.parametrize("upgrade_protocol", ["websocket", "SPDY/3.1"])
+def test_protocol_upgrade_relays_buffered_and_subsequent_bytes_in_both_directions(proxy, upgrade_protocol):
+    proxy_side, upstream_side = socket.socketpair()
+    proxy_side.settimeout(2)
+    upstream_side.settimeout(2)
+    upstream_reader = proxy_side.makefile("rb")
+    FakeHTTPSConnection.sock = proxy_side
+    FakeHTTPSConnection.response = FakeResponse(
+        b"",
+        status=101,
+        headers=[
+            ("Connection", "Upgrade"),
+            ("Upgrade", upgrade_protocol),
+            ("Sec-WebSocket-Accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="),
+            ("Sec-WebSocket-Protocol", "v5.channel.k8s.io"),
+        ],
+        fp=upstream_reader,
+    )
+    upstream_side.sendall(b"early server frame")
+    assert upstream_reader.peek(18) == b"early server frame"
+
+    port = proxy.server.server_address[1]
+    context = ssl._create_unverified_context()
+    try:
+        with (
+            socket.create_connection(("127.0.0.1", port), timeout=2) as raw_socket,
+            context.wrap_socket(raw_socket, server_hostname="localhost") as connection,
+        ):
+            connection.settimeout(2)
+            connection.sendall(
+                b"GET /api/v1/namespaces/default/pods/example/exec?command=true&stdout=true HTTP/1.1\r\n"
+                + f"Authorization: Bearer {proxy._agent_token}\r\n".encode()
+                + b"Connection: Upgrade\r\n"
+                + f"Upgrade: {upgrade_protocol}\r\n".encode()
+                + b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + b"Sec-WebSocket-Version: 13\r\n"
+                + b"Sec-WebSocket-Protocol: v5.channel.k8s.io\r\n"
+                + b"X-Stream-Protocol-Version: v5.channel.k8s.io\r\n"
+                + b"X-Stream-Protocol-Version: v4.channel.k8s.io\r\n"
+                + b"\r\n"
+                + b"early client frame"
+            )
+            response = http.client.HTTPResponse(connection)
+            response.begin()
+
+            assert response.status == 101
+            assert response.version == 11
+            assert response.getheader("Upgrade") == upgrade_protocol
+            assert response.getheader("Sec-WebSocket-Accept") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+            assert response.getheader("Sec-WebSocket-Protocol") == "v5.channel.k8s.io"
+            assert response.getheader("Content-Length") is None
+            assert upstream_side.recv(18) == b"early client frame"
+            assert response.fp.read1(18) == b"early server frame"
+
+            connection.sendall(b"client frame")
+            assert upstream_side.recv(12) == b"client frame"
+
+            upstream_side.sendall(b"server frame")
+            assert response.fp.read1(12) == b"server frame"
+
+            _, _, forwarded_headers = FakeHTTPSConnection.requests[0]
+            assert forwarded_headers["Connection"] == "Upgrade"
+            assert forwarded_headers["Upgrade"] == upgrade_protocol
+            assert forwarded_headers["Sec-WebSocket-Key"] == "dGhlIHNhbXBsZSBub25jZQ=="
+            assert forwarded_headers["Sec-WebSocket-Version"] == "13"
+            assert forwarded_headers["Sec-WebSocket-Protocol"] == "v5.channel.k8s.io"
+            assert forwarded_headers["X-Stream-Protocol-Version"] == "v5.channel.k8s.io, v4.channel.k8s.io"
+    finally:
+        upstream_side.close()
+        upstream_reader.close()
+
+
+def test_rejected_protocol_upgrade_uses_the_normal_response_path(proxy):
+    response_body = b'{"kind":"Status","message":"pod not found"}'
+    FakeHTTPSConnection.response = FakeResponse(response_body, status=404)
+
+    status, headers, body = request(
+        proxy,
+        "/api/v1/namespaces/default/pods/missing/exec?command=true&stdout=true",
+        method="POST",
+        headers={"Connection": "Upgrade", "Upgrade": "websocket"},
+    )
+
+    assert status == 404
+    assert headers["Content-Length"] == str(len(response_body))
+    assert body == response_body


### PR DESCRIPTION
## Summary

Fixes #982.

The Kubernetes API proxy treated upgraded connections like normal HTTP responses. Commands such as `kubectl exec`, `kubectl cp`, and `kubectl port-forward` switch to a bidirectional stream, so the proxy closed them early and returned WebSocket EOF errors.

This change relays upgraded connections in both directions, preserves upgrade headers and buffered bytes, and closes both sockets when the stream ends. Ordinary API requests continue using the existing response path.

## Testing

- Added regression tests for WebSocket and SPDY upgrades, buffered data, rejected upgrades, and ordinary responses
- Verified live `exec`, `cp`, `port-forward`, large transfers, concurrent streams, and interrupted streams
- Ran two Luna Max attempts on `node_conntrack_exhaustion_hotel_reservation`. Across 77 expanded agent-side `kubectl exec` invocations, there were no WebSocket EOF or 1006 proxy failures
