### PR TITLE
Add profile mechanism to drop unused components

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,44 @@ uv run main.py --agent codex --model gpt-5 --force-build
 Containerized agents can use the public internet by default, but direct access to the benchmark's GitHub source is
 blocked. Use `--internet-access open` only when you intentionally need the previous unrestricted network behavior.
 
+### Deployment Profiles
+
+`--profile` controls how much infrastructure SREGym stands up. It is independent of
+`--suite` — the profile selects *what gets deployed*, the suite selects *which problems run*.
+
+| Profile | Behaviour |
+|---------|-----------|
+| `full` (default) | The standard stack. Use this for results you intend to compare against the leaderboard. |
+| `svelte` | Additionally drops components that nothing in SREGym reads, and shortens metric retention. |
+
+```bash
+uv run main.py --suite sregym-lite --agent stratus --model gpt-5 --profile svelte
+```
+
+`svelte` removes:
+
+- astronomy-shop's bundled **OpenSearch**, **Grafana** and **Jaeger**. Nothing in `sregym/`,
+  `mcp_server/` or `clients/` queries OpenSearch or Grafana; the bundled Jaeger is deleted
+  moments after deployment anyway, by `Jaeger.create_external_name_service()`.
+- Prometheus **Alertmanager** and **Pushgateway** (no alert rules are configured and nothing
+  pushes), and TSDB retention cut from 15d to 2h.
+- The OpenEBS **node-disk-manager** stack, which backs the `openebs-device` StorageClass.
+  SREGym only provisions through `openebs-hostpath`.
+
+Measured on one astronomy-shop problem (peak RSS / peak CPU, sampled over the run):
+
+| | `full` | `svelte` |
+|---|---|---|
+| OpenSearch | 1096 MiB / 1709m | — |
+| Grafana | 475 MiB / 303m | — |
+| OpenEBS NDM (7 pods) | ~190 MiB / 582m | — |
+
+> [!WARNING]
+> `svelte` changes what an agent can observe in the cluster, so its scores are **not**
+> comparable with `full`. It is intended for local iteration on memory-constrained hosts,
+> not for leaderboard submissions. Note that `--profile svelte` and `--suite sregym-lite`
+> are unrelated: you can run either without the other.
+
 ### Model Selection
 
 SREGym uses [LiteLLM](https://docs.litellm.ai/docs/providers) model strings directly (no config file needed). Just pass any supported model string via `--model`:

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from sregym.conductor.conductor import Conductor, ConductorConfig
 from sregym.conductor.conductor_api import request_shutdown, run_api
 from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.problem_sets import PROBLEM_SETS
+from sregym.profile import PROFILES, set_profile
 from sregym.results.resume import complete_resume_rows
 from sregym.run_artifacts import ArtifactFinalizationError, RunArtifacts
 from sregym.service.container_runner import ContainerRunner, ExecInput, get_container_host_bind_address
@@ -777,6 +778,8 @@ def main(args):
     agent_model, judge_model = _configure_model_environment(args)
     internet_policy = InternetPolicy.from_mode(args.internet_access)
 
+    set_profile(args.profile)
+
     if args.noise:
         logger.info("Noise injection enabled.")
     os.environ["API_HOSTNAME"] = "0.0.0.0"
@@ -966,6 +969,18 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--use-external-harness", action="store_true", help="For use in external harnesses, deploy the fault and exit."
+    )
+    parser.add_argument(
+        "--profile",
+        choices=PROFILES,
+        default=os.environ.get("SREGYM_PROFILE", "full"),
+        help=(
+            "Deployment profile (independent of --suite). 'full' (default) deploys the standard "
+            "stack. 'svelte' additionally drops components no part of SREGym reads — astronomy-shop's "
+            "bundled OpenSearch/Grafana/Jaeger, Prometheus Alertmanager/Pushgateway, the OpenEBS NDM "
+            "stack — and shortens metric retention. 'svelte' changes what an agent can observe, so "
+            "its results are not comparable with 'full'."
+        ),
     )
     parser.add_argument(
         "--noise",

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -30,6 +30,7 @@ from sregym.generators.noise.manager import get_noise_manager
 from sregym.observer.jaeger import Jaeger
 from sregym.observer.otel_collector import OtelCollector
 from sregym.paths import CLUSTER_BASELINE_STATE_FILE
+from sregym.profile import is_svelte
 from sregym.service.apps.app_registry import AppRegistry
 from sregym.service.cluster_state import ClusterStateManager
 from sregym.service.dm_flakey_manager import DmFlakeyManager
@@ -1210,19 +1211,28 @@ class Conductor:
             self.khaos.ensure_deployed()
 
         self.logger.info("[DEPLOY] Setting up OpenEBS…")
+        svelte = is_svelte()
         # `openebs` is protected from reconciliation, so it persists across
         # problems and the operator manifest only needs fetching once.
-        if self._openebs_ready():
+        if self._openebs_ready(svelte):
             self.logger.info("[DEPLOY] OpenEBS already deployed; skipping operator re-apply")
         else:
-            self._preflight_openebs_udev_mount()
+            if not svelte:
+                # The udev preflight exists solely for the node-disk-manager,
+                # which svelte does not deploy.
+                self._preflight_openebs_udev_mount()
             self.kubectl.exec_command("kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml")
             self.kubectl.exec_command(
                 "kubectl patch storageclass openebs-hostpath "
                 '-p \'{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}\''
             )
+        # Idempotent and cheap; also covers an `openebs` left over from an
+        # earlier full-profile run on the same cluster.
+        if svelte:
+            self._trim_openebs_ndm()
         self.kubectl.wait_for_ready("openebs")
-        self._ensure_openebs_device_storageclass()
+        if not svelte:
+            self._ensure_openebs_device_storageclass()
 
         self.logger.info("[DEPLOY] Deploying Prometheus…")
         self.prometheus.deploy()
@@ -1342,12 +1352,15 @@ class Conductor:
             return False
         return True
 
-    def _openebs_ready(self) -> bool:
-        """True if the OpenEBS tier is already fully deployed.
+    def _openebs_ready(self, svelte: bool) -> bool:
+        """True if the OpenEBS tier already matches what this profile wants.
 
-        Checks the node-disk-manager as well as the LocalPV provisioner so that a
+        Under `full` that includes the node-disk-manager, so that a
         partially-present `openebs` namespace is repaired by re-applying the
-        operator manifest rather than silently accepted.
+        operator manifest rather than silently accepted. Checking it also matters
+        because `openebs` persists between problems: a cluster whose last run was
+        `svelte` has had NDM removed, and accepting the provisioner alone would
+        leave `openebs-device` permanently unbacked after switching back.
         """
         out = self.kubectl.exec_command(
             "kubectl -n openebs get deployment openebs-localpv-provisioner "
@@ -1359,11 +1372,38 @@ class Conductor:
         except (ValueError, AttributeError):
             return False
 
+        if svelte:
+            return True
+
         ndm = self.kubectl.exec_command("kubectl -n openebs get daemonset openebs-ndm -o name --ignore-not-found")
         if not ndm or not ndm.strip():
             self.logger.info("[DEPLOY] OpenEBS node-disk-manager missing; re-applying operator manifest")
             return False
         return True
+
+    # openebs-operator.yaml bundles the node-disk-manager alongside the LocalPV
+    # provisioner. NDM exists to discover block devices and back the
+    # `openebs-device` StorageClass; SREGym only ever provisions through
+    # `openebs-hostpath`, which needs the provisioner alone. Measured on one
+    # problem, these seven pods cost 603m CPU (13% of the cluster) scanning
+    # disks nothing claims.
+    _OPENEBS_NDM_WORKLOADS = (
+        ("daemonset", "openebs-ndm"),
+        ("daemonset", "openebs-ndm-node-exporter"),
+        ("deployment", "openebs-ndm-operator"),
+        ("deployment", "openebs-ndm-cluster-exporter"),
+    )
+
+    def _trim_openebs_ndm(self) -> None:
+        """Remove the node-disk-manager workloads left by openebs-operator.yaml.
+
+        Deleting rather than scaling: the operator manifest is a plain apply with
+        no controller to recreate them, and re-applying it recreates them for this
+        method to remove again.
+        """
+        self.logger.info("[svelte] Removing OpenEBS node-disk-manager (openebs-hostpath does not use it)")
+        for kind, name in self._OPENEBS_NDM_WORKLOADS:
+            self.kubectl.exec_command(f"kubectl delete {kind} {name} -n openebs --ignore-not-found")
 
     def _ensure_openebs_device_storageclass(self) -> None:
         self.logger.info("[DEPLOY] Ensuring OpenEBS LocalPV-Device StorageClass…")

--- a/sregym/observer/prometheus/values-svelte.yaml
+++ b/sregym/observer/prometheus/values-svelte.yaml
@@ -1,0 +1,30 @@
+# Applied to the central Prometheus only under `--profile svelte`.
+#
+# The vendored chart (prometheus-25.6.0) runs at stock defaults, which are sized
+# for a long-lived production install rather than a benchmark problem measured in
+# minutes.
+
+# Neither component is referenced anywhere in sregym/, mcp_server/ or clients/.
+# Nothing configures alert rules and nothing pushes to a gateway.
+alertmanager:
+  enabled: false
+prometheus-pushgateway:
+  enabled: false
+
+# Kept deliberately:
+#   kube-state-metrics        — cluster object metrics the oracles rely on
+#   prometheus-node-exporter  — node metrics
+#   blackbox-exporter         — target of the extraScrapeConfigs TCP probes
+#                               declared in values.yaml
+
+server:
+  # 15d of TSDB for a run that lasts minutes. Each problem tears the namespace
+  # down anyway, so retention beyond the problem's own duration is never read;
+  # 2h leaves plenty of headroom for the longest agent timeout (1800s default).
+  retention: 2h
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi

--- a/sregym/profile.py
+++ b/sregym/profile.py
@@ -1,0 +1,57 @@
+"""Deployment profile selection.
+
+SREGym deploys a fixed set of infrastructure and application components. Some of
+them are never read by the harness, the oracles, the MCP tools or the agent, but
+still cost real memory and CPU on the cluster. On a workstation-sized cluster
+that overhead is the difference between a suite that runs and one that OOMKills.
+
+The ``svelte`` profile removes those components. It is opt-in because it changes
+what an agent can observe in the cluster, so results produced under ``svelte`` are
+not directly comparable with results produced under ``full``.
+
+Read the profile with :func:`is_svelte`. It is a module-level singleton rather than
+a field on ``ConductorConfig`` because ``Application`` instances are constructed
+deep inside ``ProblemRegistry`` with no access to the conductor's config.
+"""
+
+import logging
+import os
+
+FULL = "full"
+SVELTE = "svelte"
+PROFILES = (FULL, SVELTE)
+
+_ENV_VAR = "SREGYM_PROFILE"
+
+logger = logging.getLogger("all.sregym.profile")
+
+_profile: str | None = None
+
+
+def set_profile(profile: str) -> None:
+    """Set the active profile. Called once from main.py before any deployment."""
+    global _profile
+    if profile not in PROFILES:
+        raise ValueError(f"Unknown profile {profile!r}; expected one of {PROFILES}")
+    _profile = profile
+    logger.info(f"Deployment profile: {profile}")
+
+
+def get_profile() -> str:
+    """Return the active profile, falling back to $SREGYM_PROFILE then 'full'.
+
+    The env fallback exists so that code paths which bypass main.py (tests, the
+    measurement harness, external harnesses) can still select a profile.
+    """
+    if _profile is not None:
+        return _profile
+    env = os.environ.get(_ENV_VAR)
+    if env:
+        if env not in PROFILES:
+            raise ValueError(f"{_ENV_VAR}={env!r} is not one of {PROFILES}")
+        return env
+    return FULL
+
+
+def is_svelte() -> bool:
+    return get_profile() == SVELTE

--- a/sregym/service/apps/astronomy_shop.py
+++ b/sregym/service/apps/astronomy_shop.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from sregym.generators.workload.locust import LocustWorkloadManager
 from sregym.paths import ASTRONOMY_SHOP_METADATA
+from sregym.profile import is_svelte
 from sregym.service.apps.base import Application
 from sregym.service.helm import Helm
 from sregym.service.kubectl import KubeCtl
@@ -41,7 +42,7 @@ class AstronomyShop(Application):
         """Deploy the Helm configurations."""
         self.kubectl.create_namespace_if_not_exist(self.namespace)
 
-        self.helm_configs["extra_args"] = [
+        extra_args = [
             # Disable bundled Prometheus to avoid ClusterRole conflict with central
             # Prometheus in the observe namespace (ClusterRoles are cluster-wide)
             "--set",
@@ -55,6 +56,11 @@ class AstronomyShop(Application):
             "-f",
             str(self._VALUES_DIR / "astronomy-shop-fixes.yaml"),
         ]
+        if is_svelte():
+            extra_args += ["-f", str(self._VALUES_DIR / "astronomy-shop-svelte.yaml")]
+            self.logger.info("[svelte] Dropping bundled OpenSearch, Grafana and Jaeger from astronomy-shop")
+
+        self.helm_configs["extra_args"] = extra_args
 
         Helm.install(**self.helm_configs)
         Helm.assert_if_deployed(self.helm_configs["namespace"])

--- a/sregym/service/apps/values/astronomy-shop-svelte.yaml
+++ b/sregym/service/apps/values/astronomy-shop-svelte.yaml
@@ -1,0 +1,47 @@
+# Applied to astronomy-shop only under `--profile svelte`.
+#
+# Removes the demo's bundled observability stack. SREGym deploys its own
+# Prometheus, Jaeger, OTel collector and Loki into `observe`, and no oracle,
+# MCP tool or agent tool in this repo reads OpenSearch or Grafana.
+#
+# Measured on one astronomy-shop problem (peak RSS / peak CPU over the run):
+#   opensearch  1096 MiB / 1709m   <- 14% of cluster memory, 39% of cluster CPU
+#   grafana      475 MiB /  303m
+#   jaeger         (never observed; see below)
+
+# Jaeger: the chart deploys it, Helm.assert_if_deployed() waits for it to become
+# Ready, and then Jaeger.create_external_name_service() (observer/jaeger/jaeger.py:64)
+# deletes the Deployment and replaces the Service with an ExternalName pointing at
+# the central collector. Disabling it reaches the identical end state without the
+# image pull, the scheduling, or the readiness wait.
+jaeger:
+  enabled: false
+
+# OpenSearch: the only writer is the collector's logs pipeline (rerouted below).
+# Container logs still reach Loki via the promtail DaemonSet in `observe`, which
+# is what SREGym's log tooling queries, so log observability is unaffected.
+opensearch:
+  enabled: false
+
+# Grafana: a UI with no headless consumer. frontend-proxy's envoy config keeps a
+# GRAFANA_HOST cluster; envoy's DNS clusters tolerate an unresolvable name (the
+# cluster is marked unhealthy, the listener still serves), so the shop's own
+# routes are unaffected.
+grafana:
+  enabled: false
+
+opentelemetry-collector:
+  config:
+    service:
+      pipelines:
+        # Drop the now-absent OpenSearch exporter. The exporter stays *declared*
+        # in the chart's `exporters:` map — the collector only instantiates
+        # components a pipeline references, so an unreferenced one is inert.
+        logs:
+          exporters: [debug]
+      telemetry:
+        metrics:
+          # The chart asks the collector to emit its own telemetry at `detailed`,
+          # which is high-cardinality and, on this deployment, loops back into the
+          # same collector. `basic` keeps the health signals without the volume.
+          level: basic

--- a/sregym/service/telemetry/prometheus.py
+++ b/sregym/service/telemetry/prometheus.py
@@ -6,6 +6,7 @@ import subprocess
 import yaml
 
 from sregym.paths import BASE_DIR, PROMETHEUS_METADATA
+from sregym.profile import is_svelte
 from sregym.service.helm import Helm
 from sregym.service.kubectl import KubeCtl
 
@@ -82,7 +83,13 @@ class Prometheus:
             if not self._pvc_exists(pvc_name):
                 self._apply_pvc()
 
-        Helm.install(**self.helm_configs)
+        helm_configs = dict(self.helm_configs)
+        if is_svelte():
+            svelte_values = BASE_DIR / "observer" / "prometheus" / "values-svelte.yaml"
+            helm_configs["extra_args"] = [*helm_configs.get("extra_args", []), "-f", str(svelte_values)]
+            self.logger.info("[svelte] Dropping Alertmanager and Pushgateway; retention 15d -> 2h")
+
+        Helm.install(**helm_configs)
         Helm.assert_if_deployed(self.namespace)
 
     def teardown(self):


### PR DESCRIPTION
SREGym deploys several components that never get used, and that
overhead is occasionally meaningful. This PR adds a flag, `--profile
{full,svelte}` which can remove the overhead, and this makes the
overall suite considerably more likely to successfully conclude in
constrained environments (particularly memory-constrained ones).

It defaults to `full` and is opt-in for now (though that creates some
maintenance problems) since dropping components strictly changes what an
agent can observe: scores under `svelte` are not comparable with `full`.
(We chose "svelte" to avoid name collision with the "lite" problem set.
Of course, the choice of the problem set is orthogonal to whether or not the
infra is fully working/specified/etc.)

## What `svelte` drops

**astronomy-shop's bundled OpenSearch and Grafana.** Nothing appears to query either.

**astronomy-shop's bundled Jaeger.** It is set up but then overridden to point at the
central one.

**Prometheus Alertmanager and Pushgateway**, plus a retention trim.
No alert rules are configured and nothing pushes to a gateway.
(Conversely, `kube-state-metrics`, `node-exporter`
and `blackbox-exporter` are all used and kept.)

**The OpenEBS node-disk-manager**, which exists to back the
`openebs-device` StorageClass.  SREGym only provisions through
`openebs-hostpath`.

## Measurements

`env_variable_shadowing_astronomy_shop` on a 4-node kind cluster (macOS/OrbStack, 18 vCPU,
18 GiB). Peak of six `kubectl top` samples at 20s intervals.

| | peak RSS | peak CPU | pods | deploy |
|---|---|---|---|---|
| `full` | 6,711–8,104 MiB | 2,094–5,191m | 75–79 | ~174s |
| `svelte` | 5,182 MiB | 1,798m | 63 | 155s |

Roughly a third less memory and around 60% less CPU, but there is some sampling
variance.

| component | peak RSS | peak CPU |
|---|---|---|
| `opensearch-0` | 1,096 MiB | 1,709m — **39% of all cluster CPU** |
| `grafana` | 475 MiB | 303m |
| OpenEBS NDM (7 pods) | 246 MiB | 603m — 13% of cluster CPU |

N=1 per configuration on one problem and one machine, so treat the totals as indicative.

## Questions

1. Is an opt-in resource profile something you want in-tree at all, or is this better as a
   downstream patch?
2. If yes, is `--profile` the right name?

## Notes

Commits carry `Co-Authored-By` trailers: implementation written with a coding agent, then
reviewed, deployed and measured on a real cluster per `CONTRIBUTING.md:42`.

