### PR TITLE
Separate evaluation and cleanup deadlines

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,8 @@ logger = logging.getLogger(__name__)
 _driver_results: list[dict] = []
 _driver_base_dir: Path | None = None
 _driver_error: BaseException | None = None
-SUBMISSION_DRAIN_TIMEOUT_SECONDS = float(os.getenv("SUBMISSION_DRAIN_TIMEOUT_SECONDS", "300"))
+EVALUATION_DRAIN_TIMEOUT_SECONDS = 300
+CLEANUP_DRAIN_TIMEOUT_SECONDS = 300
 
 
 class BenchmarkCampaignAborted(RuntimeError):
@@ -251,13 +252,13 @@ def driver_loop(
             """Run safety cleanup without letting a stuck Kubernetes call hang the campaign."""
             try:
                 conductor.finish_problem_in_background()
-                await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                await conductor.wait_for_submission_work(timeout=CLEANUP_DRAIN_TIMEOUT_SECONDS)
             except TimeoutError:
                 conductor.abandon_submission_work()
                 conductor.results["cleanup_timed_out"] = True
                 conductor.record_incomplete_attempt(timeout_reason)
                 console.log(
-                    "⛔ Conductor cleanup did not finish before the drain deadline; "
+                    "⛔ Conductor cleanup did not finish before the cleanup deadline; "
                     "aborting without starting another attempt"
                 )
                 return False
@@ -479,7 +480,7 @@ def driver_loop(
                     console.log("⏩ No agent stages are configured; waiting only for bounded cleanup")
                     if conductor.close_submissions():
                         try:
-                            await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                            await conductor.wait_for_submission_work(timeout=CLEANUP_DRAIN_TIMEOUT_SECONDS)
                         except TimeoutError:
                             abort_campaign_after_attempt = True
                             conductor.abandon_submission_work()
@@ -505,13 +506,15 @@ def driver_loop(
                         if submission_work:
                             console.log("⏳ Waiting for the accepted submission evaluation to complete...")
                             try:
-                                await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                                await conductor.wait_for_submission_evaluations(
+                                    timeout=EVALUATION_DRAIN_TIMEOUT_SECONDS
+                                )
                             except TimeoutError:
                                 evaluation_failed = True
                                 abort_campaign_after_attempt = True
                                 conductor.abandon_submission_work()
                                 console.log(
-                                    "⛔ Submission evaluation did not finish before the drain deadline; "
+                                    "⛔ Submission evaluation did not finish before the evaluation deadline; "
                                     "aborting the campaign without concurrent cluster cleanup"
                                 )
                             except Exception as e:
@@ -542,19 +545,22 @@ def driver_loop(
                             if submission_work:
                                 console.log("⏳ Waiting for conductor evaluation to complete...")
                                 try:
-                                    await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                                    await conductor.wait_for_submission_evaluations(
+                                        timeout=EVALUATION_DRAIN_TIMEOUT_SECONDS
+                                    )
                                 except TimeoutError:
                                     evaluation_failed = True
                                     abort_campaign_after_attempt = True
                                     conductor.abandon_submission_work()
                                     console.log(
-                                        "⛔ Submission evaluation did not finish before the drain deadline; "
+                                        "⛔ Submission evaluation did not finish before the evaluation deadline; "
                                         "aborting the campaign without concurrent cluster cleanup"
                                     )
                                 except Exception as e:
                                     evaluation_failed = True
                                     console.log(f"⚠️  Conductor evaluation raised: {e}")
-                            if conductor.submission_stage != "done":
+                            missing_stages = conductor.missing_submission_stages()
+                            if abort_campaign_after_attempt or evaluation_failed or missing_stages:
                                 if abort_campaign_after_attempt:
                                     reason = "evaluation_timeout_after_agent_exit"
                                 elif evaluation_failed:
@@ -579,18 +585,21 @@ def driver_loop(
                 # freezing the attempt snapshot or starting another attempt.
                 if not abort_campaign_after_attempt and conductor.close_submissions():
                     try:
-                        await conductor.wait_for_submission_work(timeout=SUBMISSION_DRAIN_TIMEOUT_SECONDS)
+                        await conductor.wait_for_submission_work(timeout=CLEANUP_DRAIN_TIMEOUT_SECONDS)
                     except TimeoutError:
                         abort_campaign_after_attempt = True
                         conductor.abandon_submission_work()
-                        conductor.record_incomplete_attempt("evaluation_timeout_after_stage_completion")
+                        conductor.results["cleanup_timed_out"] = True
+                        conductor.record_incomplete_attempt("cleanup_timeout_after_stage_completion")
                         console.log(
-                            "⛔ Submission evaluation did not finish before the drain deadline; "
-                            "aborting the campaign without concurrent cluster cleanup"
+                            "⛔ Conductor cleanup did not finish before the cleanup deadline; "
+                            "aborting without starting another attempt"
                         )
                     except Exception as e:
-                        console.log(f"⚠️  Conductor evaluation raised after stage completion: {e}")
-                        conductor.record_incomplete_attempt("evaluation_failed_after_stage_completion")
+                        console.log(f"⚠️  Conductor cleanup raised after stage completion: {e}")
+                        conductor.results["cleanup_failed"] = True
+                        conductor.results["cleanup_error"] = f"{type(e).__name__}: {e}"
+                        conductor.record_incomplete_attempt("cleanup_failed")
 
                 run_status = conductor.finalize_attempt_status()
                 if conductor.results.get("cleanup_failed"):

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -879,18 +879,27 @@ class Conductor:
     async def wait_for_submission_evaluations(self, timeout: float | None) -> None:
         """Wait for accepted stage requests and grading, but not teardown.
 
+        Give each accepted stage evaluation a fresh deadline. An early
+        mitigation request can wait behind diagnosis grading. Each will get
+        their own deadlines.
+
         The final stage worker performs teardown in the same future. Return as
         soon as that worker enters ``tearing_down`` so the driver can apply a
         separate cleanup deadline without allowing attempts to overlap.
         """
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout if timeout is not None else None
+        observed_future: concurrent.futures.Future | None = None
 
         while True:
             with self._submission_lock:
                 stage = self.submission_stage
                 future = self._submit_future
                 pending = bool(self._pending_submission_stages)
+
+            if future is not None and future is not observed_future:
+                observed_future = future
+                deadline = loop.time() + timeout if timeout is not None else None
 
             if future is not None and future.done():
                 try:

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -471,9 +471,11 @@ class Conductor:
         self.logger.info("[STAGE] Teardown complete")
 
     def finish_problem_in_background(self) -> concurrent.futures.Future:
-        """Start safety cleanup on a daemon thread so the driver can enforce a deadline."""
+        """Return running teardown or start it so the driver can enforce a deadline."""
         with self._submission_lock:
             if self._submit_future is not None:
+                if self.submission_stage in ("tearing_down", "done"):
+                    return self._submit_future
                 raise RuntimeError("Cannot start cleanup while submission work is still active.")
             if self.submission_stage == "tearing_down":
                 raise RuntimeError(
@@ -873,6 +875,45 @@ class Conductor:
             self._evaluating = False
             self.submission_stage = "aborted"
             self._submit_future = None
+
+    async def wait_for_submission_evaluations(self, timeout: float | None) -> None:
+        """Wait for accepted stage requests and grading, but not teardown.
+
+        The final stage worker performs teardown in the same future. Return as
+        soon as that worker enters ``tearing_down`` so the driver can apply a
+        separate cleanup deadline without allowing attempts to overlap.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout if timeout is not None else None
+
+        while True:
+            with self._submission_lock:
+                stage = self.submission_stage
+                future = self._submit_future
+                pending = bool(self._pending_submission_stages)
+
+            if future is not None and future.done():
+                try:
+                    future.result()
+                finally:
+                    with self._submission_lock:
+                        if self._submit_future is future:
+                            self._submit_future = None
+                continue
+
+            if stage in {"tearing_down", "done"}:
+                return
+
+            if future is None and not pending:
+                return
+
+            if deadline is not None:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise TimeoutError
+                await asyncio.sleep(min(0.05, remaining))
+            else:
+                await asyncio.sleep(0.05)
 
     async def wait_for_submission_work(self, timeout: float | None) -> None:
         """Wait for all accepted evaluations and registered stage requests.

--- a/tests/conductor/test_submission_lifecycle.py
+++ b/tests/conductor/test_submission_lifecycle.py
@@ -445,7 +445,7 @@ def test_abandoned_evaluator_cannot_publish_or_advance_late_result():
         old_future = conductor._submit_future
         assert old_future is not None
         with pytest.raises(TimeoutError):
-            await conductor.wait_for_submission_work(timeout=0.01)
+            await conductor.wait_for_submission_evaluations(timeout=0.01)
         conductor.abandon_submission_work()
         gate.set()
         old_future.result(timeout=2)
@@ -453,6 +453,62 @@ def test_abandoned_evaluator_cannot_publish_or_advance_late_result():
     asyncio.run(run())
     assert conductor.submission_stage == "aborted"
     assert "Diagnosis" not in conductor.results
+    assert conductor._submit_future is None
+
+
+def test_evaluation_and_cleanup_have_separate_deadlines():
+    evaluation_started = threading.Event()
+    release_evaluation = threading.Event()
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+
+    def evaluate_mitigation(_solution):
+        evaluation_started.set()
+        release_evaluation.wait(2)
+        return {"success": True}
+
+    def recover_fault():
+        cleanup_started.set()
+        release_cleanup.wait(2)
+
+    conductor = _conductor()
+    conductor.stage_sequence = [{"name": "mitigation", "evaluation": evaluate_mitigation}]
+    conductor.current_stage_index = 0
+    conductor.submission_stage = "mitigation"
+    conductor.problem = SimpleNamespace(
+        recover_fault=recover_fault,
+        app=SimpleNamespace(cleanup=lambda: None),
+    )
+
+    async def release_after(delay, event):
+        await asyncio.sleep(delay)
+        event.set()
+
+    async def run():
+        started_at = time.monotonic()
+        await conductor.submit("", expected_stage="mitigation")
+        assert evaluation_started.wait(1)
+
+        evaluation_release = asyncio.create_task(release_after(0.12, release_evaluation))
+        await conductor.wait_for_submission_evaluations(timeout=0.2)
+        await evaluation_release
+
+        assert conductor.submission_stage == "tearing_down"
+        assert cleanup_started.wait(1)
+        cleanup_future = conductor.finish_problem_in_background()
+        assert cleanup_future is conductor._submit_future
+
+        cleanup_release = asyncio.create_task(release_after(0.12, release_cleanup))
+        await conductor.wait_for_submission_work(timeout=0.2)
+        await cleanup_release
+        return time.monotonic() - started_at
+
+    elapsed = asyncio.run(run())
+
+    assert elapsed > 0.2
+    assert conductor.results["Mitigation"]["success"] is True
+    assert conductor.missing_submission_stages() == []
+    assert conductor.submission_stage == "done"
     assert conductor._submit_future is None
 
 

--- a/tests/conductor/test_submission_lifecycle.py
+++ b/tests/conductor/test_submission_lifecycle.py
@@ -456,6 +456,86 @@ def test_abandoned_evaluator_cannot_publish_or_advance_late_result():
     assert conductor._submit_future is None
 
 
+def test_evaluation_wait_times_out_while_a_request_remains_pending():
+    conductor = _conductor()
+    generation = conductor.register_pending_submission("mitigation")
+
+    try:
+        with pytest.raises(TimeoutError):
+            asyncio.run(conductor.wait_for_submission_evaluations(timeout=0.01))
+    finally:
+        conductor.unregister_pending_submission("mitigation", generation)
+
+
+def test_each_queued_stage_evaluation_gets_its_own_deadline(monkeypatch):
+    diagnosis_started = threading.Event()
+    release_diagnosis = threading.Event()
+    mitigation_started = threading.Event()
+    release_mitigation = threading.Event()
+
+    def evaluate_diagnosis(_solution):
+        diagnosis_started.set()
+        release_diagnosis.wait(2)
+        return {"success": True}
+
+    def evaluate_mitigation(_solution):
+        mitigation_started.set()
+        release_mitigation.wait(2)
+        return {"success": True}
+
+    conductor = _conductor(evaluate_diagnosis, evaluate_mitigation)
+    monkeypatch.setattr(conductor_api, "_conductor", conductor)
+
+    async def release_after_start(started, release):
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        await asyncio.sleep(0.12)
+        release.set()
+
+    async def wait_for_pending_request():
+        while not conductor._pending_submission_stages:
+            await asyncio.sleep(0.005)
+
+    async def run():
+        transport = httpx.ASGITransport(app=conductor_api.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            diagnosis_response = await client.post(
+                "/submit",
+                json={"stage": "diagnosis", "solution": "diagnosis"},
+            )
+            assert diagnosis_response.status_code == 200
+
+            mitigation_request = asyncio.create_task(
+                client.post(
+                    "/submit",
+                    json={"stage": "mitigation", "solution": ""},
+                )
+            )
+            await asyncio.wait_for(wait_for_pending_request(), timeout=1)
+            conductor.close_submissions()
+
+            diagnosis_release = asyncio.create_task(release_after_start(diagnosis_started, release_diagnosis))
+            mitigation_release = asyncio.create_task(release_after_start(mitigation_started, release_mitigation))
+            started_at = time.monotonic()
+            await conductor.wait_for_submission_evaluations(timeout=0.2)
+            elapsed = time.monotonic() - started_at
+
+            mitigation_response = await mitigation_request
+            await diagnosis_release
+            await mitigation_release
+            await conductor.wait_for_submission_work(timeout=1)
+            return elapsed, mitigation_response
+
+    elapsed, mitigation_response = asyncio.run(run())
+
+    assert elapsed > 0.2
+    assert mitigation_response.status_code == 200
+    assert mitigation_response.json()["stage"] == "mitigation"
+    assert conductor.results["Diagnosis"]["success"] is True
+    assert conductor.results["Mitigation"]["success"] is True
+    assert conductor.submission_stage == "done"
+
+
 def test_evaluation_and_cleanup_have_separate_deadlines():
     evaluation_started = threading.Event()
     release_evaluation = threading.Event()


### PR DESCRIPTION
## Problem

Two 63-attempt (21 faults x 3 attempts each) SREGym-Lite campaigns stopped at `kafka_poison_pill_hol_block`.

In each campaign, 18 attempts completed, one was marked incomplete, and 44 never started. The agent submitted both stages, and the mitigation evaluation succeeded.

However, the runner recorded `evaluation_timeout_after_agent_exit` and stopped the campaign.

The runner used one 300-second deadline for evaluation and cleanup. Cleanup includes fault recovery, application removal, and cluster reconciliation.

The Terra run spent 130 seconds in evaluation and 183 seconds in cleanup. The Luna run spent 131 seconds in evaluation and 184 seconds in cleanup.

Each phase finished within 300 seconds. However, their combined times were 313 and 315 seconds. The old shared deadline therefore stopped both campaigns incorrectly.

## Change

This PR gives evaluation and cleanup separate 300-second deadlines.

The Conductor returns control when evaluation finishes and cleanup begins. The runner then waits for the same cleanup task with a new deadline.

The runner does not start another attempt until cleanup finishes. It also records evaluation and cleanup timeouts separately.