### PR TITLE
Disable Codex web search in filtered mode

### DIFF
--- a/clients/codex/codex_agent.py
+++ b/clients/codex/codex_agent.py
@@ -336,6 +336,8 @@ class CodexAgent:
             "unified_exec",
         ]
         command.extend(custom_provider_args())
+        if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
+            command.extend(["-c", 'web_search="disabled"'])
         reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
         if reasoning_effort:
             command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from clients.claudecode.claudecode_agent import ClaudeCodeAgent
+from clients.codex.codex_agent import CodexAgent
 from clients.copilot.copilot_agent import CopilotCliAgent
 from clients.geminicli.geminicli_agent import GeminiCliAgent
 from sregym.agent_launcher import AgentLauncher
@@ -336,6 +337,20 @@ def test_open_mode_keeps_claude_web_search(monkeypatch):
     monkeypatch.setenv("AGENT_INTERNET_ACCESS", "open")
     assert "WebFetch" in ClaudeCodeAgent.allowed_tools()
     assert "WebSearch" in ClaudeCodeAgent.allowed_tools()
+
+
+def test_filtered_mode_disables_codex_web_search(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
+    agent = CodexAgent(logs_dir=tmp_path, model_name="gpt-5.6-sol")
+
+    assert 'web_search="disabled"' in agent._build_command("inspect the cluster")
+
+
+def test_open_mode_keeps_codex_web_search(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_INTERNET_ACCESS", "open")
+    agent = CodexAgent(logs_dir=tmp_path, model_name="gpt-5.6-sol")
+
+    assert 'web_search="disabled"' not in agent._build_command("inspect the cluster")
 
 
 def test_filtered_mode_disables_gemini_provider_web_tools(monkeypatch, tmp_path):


### PR DESCRIPTION
A Codex agent could use hosted web search to access the SREGym repository. This request runs outside the agent container, so the network proxy could not block it. This exposed the real fault name and caused some runs to be rejected (we auto reject runs if the agent traces contain unmasked fault id).

This change removes the hosted web-search tool from Codex when filtered internet access is active. Shell commands still use the existing network proxy. Open-mode runs remain unchanged.