### PR TITLE
Block Codex hosted tools in filtered runs

### DIFF
--- a/clients/codex/codex_agent.py
+++ b/clients/codex/codex_agent.py
@@ -338,6 +338,7 @@ class CodexAgent:
         command.extend(custom_provider_args())
         if os.environ.get("AGENT_INTERNET_ACCESS") == "filtered":
             command.extend(["-c", 'web_search="disabled"'])
+            command.extend(["--disable", "apps", "--disable", "plugins"])
         reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT")
         if reasoning_effort:
             command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -339,18 +339,28 @@ def test_open_mode_keeps_claude_web_search(monkeypatch):
     assert "WebSearch" in ClaudeCodeAgent.allowed_tools()
 
 
-def test_filtered_mode_disables_codex_web_search(monkeypatch, tmp_path):
+def test_filtered_mode_disables_codex_hosted_tools(monkeypatch, tmp_path):
     monkeypatch.setenv("AGENT_INTERNET_ACCESS", "filtered")
     agent = CodexAgent(logs_dir=tmp_path, model_name="gpt-5.6-sol")
 
-    assert 'web_search="disabled"' in agent._build_command("inspect the cluster")
+    command = agent._build_command("inspect the cluster")
+    option_pairs = list(zip(command, command[1:], strict=False))
+
+    assert 'web_search="disabled"' in command
+    assert ("--disable", "apps") in option_pairs
+    assert ("--disable", "plugins") in option_pairs
 
 
-def test_open_mode_keeps_codex_web_search(monkeypatch, tmp_path):
+def test_open_mode_keeps_codex_hosted_tools(monkeypatch, tmp_path):
     monkeypatch.setenv("AGENT_INTERNET_ACCESS", "open")
     agent = CodexAgent(logs_dir=tmp_path, model_name="gpt-5.6-sol")
 
-    assert 'web_search="disabled"' not in agent._build_command("inspect the cluster")
+    command = agent._build_command("inspect the cluster")
+    option_pairs = list(zip(command, command[1:], strict=False))
+
+    assert 'web_search="disabled"' not in command
+    assert ("--disable", "apps") not in option_pairs
+    assert ("--disable", "plugins") not in option_pairs
 
 
 def test_filtered_mode_disables_gemini_provider_web_tools(monkeypatch, tmp_path):


### PR DESCRIPTION
During a filtered Codex benchmark run, the agent accessed the SREGym GitHub repository through a hosted GitHub tool. This exposed the fault information and invalidated the result.

The recent PR (#997) disabled native web search. However, Codex Apps and plugins remained enabled. These tools run through OpenAI services, so the local network proxy cannot block their requests.

This PR disables apps and plugins when `AGENT_INTERNET_ACCESS=filtered`. This prevents hosted tools from bypassing the network policy. Runs with open internet access remain unchanged.
