### PR TITLE
Add Cursor CLI fallback for problem difficulty evaluation

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -3,12 +3,18 @@ name: Problem Difficulty Evaluation
 # Opt-in only: a core team member starts this workflow from the Actions UI or
 # comments "/evaluate-problem <id> [3|5] [glm-5.3-flash]" on a pull request.
 # Codex requires the Responses API, so a local LiteLLM proxy translates its
-# requests to Z.ai's OpenAI-compatible GLM Coding Plan endpoint.
+# requests to Z.ai's OpenAI-compatible GLM Coding Plan endpoint. Z.ai is a
+# low-volume annual plan, so when its preflight fails (quota, outage, or the
+# secret simply isn't set) this workflow falls back to a personal Cursor CLI
+# subscription instead of failing outright. The fallback doesn't try to match
+# models between runs -- it exists purely to flag whether a problem still
+# gets solved by *some* capable agent, not to compare agents.
 #
 # Comment runs evaluate the PR merged into the default branch so that problems
 # introduced by the PR itself can be scored before merge. Because this job
-# holds ZCODE_API_KEY, only OWNER/MEMBER/COLLABORATOR comments are honoured;
-# review the PR diff before issuing the command, as it executes PR code.
+# holds ZCODE_API_KEY/CURSOR_API_KEY, only OWNER/MEMBER/COLLABORATOR comments
+# are honoured; review the PR diff before issuing the command, as it executes
+# PR code.
 
 on:
   issue_comment:
@@ -165,53 +171,88 @@ jobs:
       ATTEMPTS: ${{ needs.resolve.outputs.attempts }}
       ZAI_MODEL: ${{ needs.resolve.outputs.model }}
       LITELLM_PORT: "4000"
+      CURSOR_JUDGE_BRIDGE_PORT: "4100"
+      CURSOR_MODEL: "auto"
     steps:
-      - name: Require Z.ai Coding Plan secret
+      - name: Choose evaluation provider
+        id: provider
         env:
           ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
-        run: |
-          if [ -z "$ZCODE_API_KEY" ]; then
-            echo "::error::Repository secret ZCODE_API_KEY is not configured."
-            exit 1
-          fi
-
-      - name: Preflight Z.ai Coding Plan quota
-        env:
-          ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
           set -euo pipefail
-          response_file="$RUNNER_TEMP/zai-preflight.json"
-          request_body=$(jq -cn --arg model "$ZAI_MODEL" '{
-            model: $model,
-            messages: [{role: "user", content: "Reply with OK."}],
-            thinking: {type: "disabled"},
-            max_tokens: 1,
-            stream: false
-          }')
-          http_status=$(curl --silent --show-error \
-            --connect-timeout 10 \
-            --max-time 60 \
-            --output "$response_file" \
-            --write-out '%{http_code}' \
-            --request POST \
-            --url https://api.z.ai/api/coding/paas/v4/chat/completions \
-            --header "Authorization: Bearer $ZCODE_API_KEY" \
-            --header 'Content-Type: application/json' \
-            --data "$request_body")
+          provider=""
+          zai_reason=""
 
-          case "$http_status" in
-            2??)
-              echo "Z.ai Coding Plan preflight passed for $ZAI_MODEL."
-              echo "ZAI_PREFLIGHT_PASSED=true" >> "$GITHUB_ENV"
-              ;;
-            *)
-              error_code=$(jq -r '.error.code // .code // "unknown"' "$response_file" 2>/dev/null || true)
-              error_message=$(jq -r '.error.message // .message // "unknown error"' "$response_file" 2>/dev/null || true)
-              printf 'Z.ai Coding Plan preflight failed: HTTP %s, code %s: %s\n' \
-                "$http_status" "${error_code:-unknown}" "${error_message:-unknown error}"
+          if [ -n "$ZCODE_API_KEY" ]; then
+            response_file="$RUNNER_TEMP/zai-preflight.json"
+            request_body=$(jq -cn --arg model "$ZAI_MODEL" '{
+              model: $model,
+              messages: [{role: "user", content: "Reply with OK."}],
+              thinking: {type: "disabled"},
+              max_tokens: 1,
+              stream: false
+            }')
+            http_status=$(curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --url https://api.z.ai/api/coding/paas/v4/chat/completions \
+              --header "Authorization: Bearer $ZCODE_API_KEY" \
+              --header 'Content-Type: application/json' \
+              --data "$request_body")
+
+            case "$http_status" in
+              2??)
+                provider="zai"
+                echo "Z.ai Coding Plan preflight passed for $ZAI_MODEL."
+                ;;
+              *)
+                error_code=$(jq -r '.error.code // .code // "unknown"' "$response_file" 2>/dev/null || true)
+                error_message=$(jq -r '.error.message // .message // "unknown error"' "$response_file" 2>/dev/null || true)
+                zai_reason="HTTP $http_status, code ${error_code:-unknown}: ${error_message:-unknown error}"
+                echo "Z.ai Coding Plan preflight failed: $zai_reason"
+                ;;
+            esac
+          else
+            zai_reason="repository secret ZCODE_API_KEY is not configured"
+            echo "$zai_reason"
+          fi
+
+          # Z.ai is a low-volume annual plan; when it's out of quota (or
+          # simply not configured), fall back to a personal Cursor CLI
+          # subscription instead of failing the whole run. This fallback
+          # doesn't try to hold the model constant across runs -- it exists
+          # to flag whether a problem is still solvable at all, not to
+          # compare agents/models.
+          if [ -z "$provider" ]; then
+            if [ -n "$CURSOR_API_KEY" ]; then
+              provider="cursor"
+              echo "Falling back to the Cursor CLI ($zai_reason)."
+            else
+              echo "::error::Neither Z.ai nor Cursor is usable for this run."
+              {
+                echo "# Problem Difficulty Evaluation"
+                echo
+                echo "❌ No usable evaluation backend."
+                echo
+                echo "- **Z.ai**: $zai_reason"
+                echo "- **Cursor**: repository secret \`CURSOR_API_KEY\` is not configured."
+              } | tee evaluation-report.md >> "$GITHUB_STEP_SUMMARY"
               exit 1
-              ;;
-          esac
+            fi
+          fi
+
+          run_model="$ZAI_MODEL"
+          [ "$provider" = "cursor" ] && run_model="$CURSOR_MODEL"
+
+          echo "provider=$provider" >> "$GITHUB_OUTPUT"
+          echo "PROVIDER=$provider" >> "$GITHUB_ENV"
+          echo "PROVIDER_READY=true" >> "$GITHUB_ENV"
+          echo "RUN_MODEL=$run_model" >> "$GITHUB_ENV"
+          echo "::notice::Using provider '$provider' (model '$run_model') for this evaluation."
 
       - name: React to triggering comment
         if: needs.resolve.outputs.comment_id != ''
@@ -238,7 +279,8 @@ jobs:
           COMMENT_ID: ${{ needs.resolve.outputs.comment_id }}
           PROBLEM_ID: ${{ needs.resolve.outputs.problem_id }}
           ATTEMPTS: ${{ needs.resolve.outputs.attempts }}
-          ZAI_MODEL: ${{ needs.resolve.outputs.model }}
+          PROVIDER: ${{ env.PROVIDER }}
+          RUN_MODEL: ${{ env.RUN_MODEL }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         with:
           script: |
@@ -247,11 +289,14 @@ jobs:
             const commandUrl =
               `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/` +
               `${process.env.PR_NUMBER}#issuecomment-${process.env.COMMENT_ID}`;
+            const providerLabel = process.env.PROVIDER === 'cursor'
+              ? 'Cursor CLI fallback'
+              : 'Z.ai Coding Plan';
             const body =
               `${marker}\n> In response to [this command](${commandUrl}).\n\n` +
               `## ⏳ Problem Difficulty Evaluation\n\n` +
               `Running for \`${process.env.PROBLEM_ID}\` ` +
-              `(${process.env.ATTEMPTS} attempts, \`${process.env.ZAI_MODEL}\`)\n\n` +
+              `(${process.env.ATTEMPTS} attempts, \`${process.env.RUN_MODEL}\` via ${providerLabel})\n\n` +
               `Evaluating this PR merged into \`${process.env.DEFAULT_BRANCH}\`.\n\n` +
               `_[Live workflow run](${runUrl})_`;
 
@@ -279,7 +324,7 @@ jobs:
           if ! grep -Fq "\"$PROBLEM_ID\":" sregym/conductor/problems/registry.py; then
             echo "::error::Problem '$PROBLEM_ID' is not registered at $CHECKOUT_REF."
             {
-              echo "# Z.ai Problem Difficulty Evaluation"
+              echo "# Problem Difficulty Evaluation"
               echo
               echo "❌ Problem \`$PROBLEM_ID\` is not registered in" \
                 "\`sregym/conductor/problems/registry.py\` at \`$CHECKOUT_REF\`."
@@ -296,6 +341,7 @@ jobs:
         run: uv sync --locked
 
       - name: Start Codex-to-Z.ai bridge
+        if: env.PROVIDER == 'zai'
         env:
           ZCODE_API_KEY: ${{ secrets.ZCODE_API_KEY }}
         run: |
@@ -352,6 +398,7 @@ jobs:
           exit 1
 
       - name: Preflight Codex and judge bridges
+        if: env.PROVIDER == 'zai'
         run: |
           set -euo pipefail
           codex_response_file="$RUNNER_TEMP/zai-codex-bridge-preflight.json"
@@ -413,6 +460,52 @@ jobs:
 
           echo "Judge-to-Z.ai Chat Completions bridge preflight passed for $judge_model."
 
+      - name: Install Cursor CLI
+        if: env.PROVIDER == 'cursor'
+        run: |
+          set -euo pipefail
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/agent" --version
+
+      - name: Preflight Cursor CLI
+        if: env.PROVIDER == 'cursor'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          response_file="$RUNNER_TEMP/cursor-preflight.json"
+          if ! agent --print "Reply with OK." --model "$CURSOR_MODEL" --output-format json --trust \
+              > "$response_file" 2> "$RUNNER_TEMP/cursor-preflight.err"; then
+            echo "Cursor CLI preflight failed:"
+            cat "$RUNNER_TEMP/cursor-preflight.err" "$response_file" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Cursor CLI preflight passed for $CURSOR_MODEL."
+
+      - name: Start Cursor judge bridge
+        if: env.PROVIDER == 'cursor'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          nohup uv run python -m clients.cursor.judge_bridge \
+            --port "$CURSOR_JUDGE_BRIDGE_PORT" \
+            --model "$CURSOR_MODEL" \
+            > "$RUNNER_TEMP/cursor-judge-bridge.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/cursor-judge-bridge.pid"
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent "http://127.0.0.1:$CURSOR_JUDGE_BRIDGE_PORT/health" > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "::error::Cursor judge bridge did not become ready."
+          tail -200 "$RUNNER_TEMP/cursor-judge-bridge.log" || true
+          exit 1
+
       - name: Install Kind
         run: |
           curl -Lo /tmp/kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
@@ -432,27 +525,43 @@ jobs:
       - name: Create kind cluster with Calico
         run: bash kind/setup_kind_cluster.sh x86
 
-      - name: Run repeated Codex evaluation
+      - name: Run repeated agent evaluation
         env:
-          AGENT_API_BASE: http://127.0.0.1:4000/v1
-          JUDGE_API_BASE: http://127.0.0.1:4000/v1
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
           set -euo pipefail
           echo "EVALUATION_STARTED=true" >> "$GITHUB_ENV"
-          export AGENT_API_KEY="$LITELLM_MASTER_KEY"
-          export JUDGE_API_KEY="$LITELLM_MASTER_KEY"
+
+          case "$PROVIDER" in
+            zai)
+              agent_name="codex"
+              judge_model="openai/${ZAI_MODEL}-judge"
+              export AGENT_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
+              export AGENT_API_KEY="$LITELLM_MASTER_KEY"
+              export JUDGE_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
+              export JUDGE_API_KEY="$LITELLM_MASTER_KEY"
+              ;;
+            cursor)
+              agent_name="cursor"
+              judge_model="openai/$CURSOR_MODEL"
+              export JUDGE_API_BASE="http://127.0.0.1:$CURSOR_JUDGE_BRIDGE_PORT/v1"
+              export JUDGE_API_KEY="dummy"
+              ;;
+          esac
+          echo "AGENT_NAME=$agent_name" >> "$GITHUB_ENV"
+
           uv run main.py \
             --problem "$PROBLEM_ID" \
-            --agent codex \
-            --model "$ZAI_MODEL" \
-            --judge-model "openai/${ZAI_MODEL}-judge" \
+            --agent "$agent_name" \
+            --model "$RUN_MODEL" \
+            --judge-model "$judge_model" \
             --n-attempts "$ATTEMPTS" \
             --agent-timeout 1800 \
             --internet-access filtered \
             2>&1 | tee benchmark.log
 
       - name: Dump cluster diagnostics
-        if: failure() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        if: failure() && env.PROVIDER_READY == 'true'
         run: |
           kubectl get nodes -o wide || true
           kubectl get pods -A -o wide || true
@@ -463,16 +572,16 @@ jobs:
         if: always() && env.EVALUATION_STARTED == 'true'
         run: |
           set -euo pipefail
-          result_csv=$(find results -type f -name '*_codex_results.csv' ! -name 'codex_ALL_results.csv' 2>/dev/null \
+          result_csv=$(find results -type f -name "*_${AGENT_NAME}_results.csv" ! -name "${AGENT_NAME}_ALL_results.csv" 2>/dev/null \
             | sort | tail -n1 || true)
           if [ -z "$result_csv" ]; then
-            result_csv=$(find . -maxdepth 1 -type f -name '_running_*_codex_results.csv' \
+            result_csv=$(find . -maxdepth 1 -type f -name "_running_*_${AGENT_NAME}_results.csv" \
               | sort | tail -n1 || true)
           fi
 
           if [ -z "$result_csv" ]; then
             {
-              echo "# Z.ai Problem Difficulty Evaluation"
+              echo "# Problem Difficulty Evaluation"
               echo
               echo "No result CSV was produced. Inspect the benchmark and cluster logs."
             } | tee evaluation-report.md >> "$GITHUB_STEP_SUMMARY"
@@ -482,13 +591,13 @@ jobs:
           uv run python -m sregym.results.report \
             --csv "$result_csv" \
             --problem "$PROBLEM_ID" \
-            --model "$ZAI_MODEL" \
+            --model "$RUN_MODEL" \
             --attempts "$ATTEMPTS" \
             --output evaluation-report.md \
             --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload evaluation artifacts
-        if: always() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        if: always() && env.PROVIDER_READY == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: problem-difficulty-evaluation-${{ github.run_attempt }}
@@ -496,17 +605,25 @@ jobs:
             evaluation-report.md
             benchmark.log
             results/
-            _running_*_codex_results.csv
+            _running_*_${{ env.AGENT_NAME }}_results.csv
             ${{ runner.temp }}/litellm.log
+            ${{ runner.temp }}/cursor-judge-bridge.log
             /tmp/kind-logs/
           if-no-files-found: ignore
           retention-days: 30
 
       - name: Stop Codex-to-Z.ai bridge
-        if: always() && env.ZAI_PREFLIGHT_PASSED == 'true'
+        if: always() && env.PROVIDER == 'zai'
         run: |
           if [ -f "$RUNNER_TEMP/litellm.pid" ]; then
             kill "$(cat "$RUNNER_TEMP/litellm.pid")" 2>/dev/null || true
+          fi
+
+      - name: Stop Cursor judge bridge
+        if: always() && env.PROVIDER == 'cursor'
+        run: |
+          if [ -f "$RUNNER_TEMP/cursor-judge-bridge.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/cursor-judge-bridge.pid")" 2>/dev/null || true
           fi
 
       - name: Post evaluation result comment

--- a/agents.yaml
+++ b/agents.yaml
@@ -54,6 +54,12 @@ agents:
     kickoff_env: null
     install_script: install-copilot.sh
     agent_version: null
+  - name: cursor
+    kickoff_command: python -m clients.cursor.driver
+    kickoff_workdir: .
+    kickoff_env: null
+    install_script: install-cursor.sh
+    agent_version: null
   - name: demo
     kickoff_command: python -m clients.demo.driver
     kickoff_workdir: .

--- a/clients/cursor/__init__.py
+++ b/clients/cursor/__init__.py
@@ -1,0 +1,5 @@
+"""Cursor CLI agent for SREGym."""
+
+from clients.cursor.cursor_agent import CursorAgent
+
+__all__ = ["CursorAgent"]

--- a/clients/cursor/cursor_agent.py
+++ b/clients/cursor/cursor_agent.py
@@ -1,0 +1,218 @@
+"""
+Cursor CLI agent implementation for SREGym.
+
+Wraps Cursor's headless `agent` CLI (https://cursor.com/docs/cli), used as a
+low-usage fallback when the primary Z.ai-backed Codex path is out of quota.
+Authentication is via the CURSOR_API_KEY environment variable; model choice
+is intentionally loose (any model the CLI exposes, including "auto") since
+this path only needs to gauge whether a problem is saturated, not compare
+models consistently.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger("all.cursor.agent")
+
+_INSTALL_URL = "https://cursor.com/install"
+
+
+class CursorAgent:
+    """
+    The Cursor agent uses Cursor's `agent` CLI in non-interactive mode.
+    """
+
+    _OUTPUT_FILENAME = "cursor.json"
+
+    @staticmethod
+    def check_installation() -> bool:
+        """Check if the Cursor CLI (`agent`) is installed."""
+        return shutil.which("agent") is not None
+
+    @staticmethod
+    def ensure_installed(auto_install: bool = True) -> None:
+        """
+        Ensure the Cursor CLI is installed, optionally attempting installation.
+
+        Args:
+            auto_install: If True, attempt to install the CLI if not found
+
+        Raises:
+            RuntimeError: If the CLI is not installed and auto_install fails
+        """
+        if CursorAgent.check_installation():
+            logger.info("Cursor CLI is already installed")
+            return
+
+        logger.warning("Cursor CLI not found in PATH")
+
+        if not auto_install:
+            raise RuntimeError(
+                "Cursor CLI is not installed. Please install it using:\n"
+                f"  curl {_INSTALL_URL} -fsS | bash\n"
+                "Or visit: https://cursor.com/docs/cli/overview"
+            )
+
+        logger.info("Attempting to install Cursor CLI...")
+        try:
+            subprocess.run(
+                f"curl {_INSTALL_URL} -fsS | bash",
+                shell=True,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            home_bin = Path(os.environ.get("HOME", "/root")) / ".local" / "bin" / "agent"
+            if not CursorAgent.check_installation() and home_bin.exists():
+                # The installer writes to ~/.cursor/bin, which is only on PATH
+                # in login shells. Link it into a directory already on PATH so
+                # later, unrelated subprocess invocations can find it too.
+                target = Path("/usr/local/bin/agent")
+                if not target.exists():
+                    target.symlink_to(home_bin)
+
+            if not CursorAgent.check_installation():
+                raise RuntimeError("Cursor CLI installation appeared to succeed but 'agent' is still not available")
+
+            logger.info("Successfully installed Cursor CLI")
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            raise RuntimeError(
+                f"Failed to auto-install Cursor CLI: {e}\n"
+                f"Please install it manually using:\n"
+                f"  curl {_INSTALL_URL} -fsS | bash\n"
+                "Or visit: https://cursor.com/docs/cli/overview"
+            ) from None
+
+    def __init__(self, logs_dir: Path, model_name: str):
+        """
+        Initialize the Cursor agent.
+
+        Args:
+            logs_dir: Directory to store logs and output
+            model_name: Model id to pass to `agent --model` (e.g. "auto",
+                "gpt-5", "sonnet-4.5", "grok-code")
+        """
+        self.logs_dir = Path(logs_dir)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.model_name = model_name
+
+        if not os.environ.get("CURSOR_API_KEY"):
+            logger.warning("CURSOR_API_KEY is not set; the Cursor CLI will not be authenticated")
+
+        logger.info(f"Initialized Cursor agent with model={model_name}")
+        logger.info(f"Logs dir: {self.logs_dir}")
+
+    @property
+    def output_path(self) -> Path:
+        """Path to the raw `agent` CLI JSON output."""
+        return self.logs_dir / self._OUTPUT_FILENAME
+
+    def get_usage_metrics(self) -> dict[str, int]:
+        """
+        Cursor's `--output-format json` result does not report token usage,
+        so this always returns zeros. Kept for interface parity with the
+        other agent clients, whose usage metrics feed the same report.
+        """
+        return {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+
+    def generate_trajectory(self, problem_id: str) -> Path | None:
+        """Cursor CLI trajectories are not wired into the visualizer yet."""
+        del problem_id
+        return None
+
+    def _build_command(self, instruction: str) -> list[str]:
+        command = [
+            "agent",
+            "--print",
+            instruction,
+            "--model",
+            self.model_name,
+            "--output-format",
+            "json",
+            "--trust",
+        ]
+        return command
+
+    def run(self, instruction: str) -> int:
+        """
+        Run the Cursor agent with the given instruction.
+
+        Args:
+            instruction: The task instruction to pass to the agent
+
+        Returns:
+            Return code from the `agent` CLI (0 for success)
+        """
+        logger.info(f"Running Cursor agent with model: {self.model_name}")
+
+        command = self._build_command(instruction)
+        logger.info(f"Executing command: {' '.join(command[:4])} ...")
+
+        try:
+            with open(self.output_path, "w") as out_file:
+                process = subprocess.run(
+                    command,
+                    stdout=out_file,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                )
+
+            logger.info(f"Cursor agent finished with return code: {process.returncode}")
+
+            if process.returncode != 0:
+                # On failure the CLI writes a plain error to stderr/stdout
+                # instead of the JSON result object; surface it for the log.
+                try:
+                    tail = self.output_path.read_text()[-4000:]
+                    logger.error(f"Cursor agent output:\n{tail}")
+                except OSError:
+                    pass
+
+            return process.returncode
+
+        except Exception as e:
+            logger.error(f"Error running Cursor agent: {e}")
+            raise
+
+    def result_text(self) -> str | None:
+        """Best-effort extraction of the final assistant text, if present."""
+        if not self.output_path.exists():
+            return None
+        try:
+            data = json.loads(self.output_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        if isinstance(data, dict):
+            return data.get("result")
+        return None
+
+
+def save_results(
+    logs_dir: Path,
+    problem_id: str,
+    return_code: int,
+    usage_metrics: dict,
+) -> None:
+    """Save run results to a JSON file, matching the other agent drivers."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    results_file = Path(logs_dir) / f"cursor_results_{problem_id}_{timestamp}.json"
+
+    results = {
+        "problem_id": problem_id,
+        "timestamp": timestamp,
+        "return_code": return_code,
+        "success": return_code == 0,
+        "usage_metrics": usage_metrics,
+    }
+
+    with open(results_file, "w") as f:
+        json.dump(results, f, indent=2)
+
+    logger.info(f"Saved results to {results_file}")

--- a/clients/cursor/driver.py
+++ b/clients/cursor/driver.py
@@ -1,0 +1,293 @@
+"""
+Cursor agent driver for SREGym.
+Entry point for running the Cursor CLI agent on SREGym tasks.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+# Add SREGym root to path
+sregym_root = Path(__file__).resolve().parents[2]
+if str(sregym_root) not in sys.path:
+    sys.path.insert(0, str(sregym_root))
+
+from logger import init_logger  # noqa: E402
+
+init_logger()
+
+from clients.cursor.cursor_agent import CursorAgent  # noqa: E402
+from clients.harness.problem_id import resolve_problem_id  # noqa: E402
+
+logger = logging.getLogger("all.cursor.driver")
+
+
+def run_preflight() -> None:
+    """Validate model + credentials by making a minimal Cursor CLI call."""
+    import subprocess
+
+    if not os.environ.get("CURSOR_API_KEY"):
+        print("missing CURSOR_API_KEY")
+        sys.exit(1)
+
+    m = os.environ["AGENT_MODEL_ID"]
+    command = ["agent", "--print", "say ok", "--model", m, "--output-format", "json", "--trust"]
+
+    r = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        stdin=subprocess.DEVNULL,
+    )
+    if r.returncode:
+        print(r.stdout or r.stderr)
+    sys.exit(r.returncode)
+
+
+def get_api_base_url() -> str:
+    """Get the conductor API base URL."""
+    host = os.getenv("API_HOSTNAME", "localhost")
+    port = os.getenv("API_PORT", "8000")
+    return f"http://{host}:{port}"
+
+
+def get_app_info() -> dict:
+    """Get application info from conductor API."""
+    api_url = f"{get_api_base_url()}/get_app"
+    logger.info(f"Fetching app info from {api_url}")
+
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
+        app_info = response.json()
+        logger.info(f"App info: {app_info}")
+        return app_info
+    except Exception as e:
+        logger.error(f"Failed to get app info: {e}")
+        raise
+
+
+def wait_for_ready_stage(timeout: int = 300) -> str:
+    """
+    Wait for conductor to reach a submission-ready stage (diagnosis or mitigation).
+
+    Args:
+        timeout: Maximum seconds to wait
+
+    Returns:
+        Current stage name
+
+    Raises:
+        TimeoutError: If timeout is reached before ready
+    """
+    import time
+
+    api_url = f"{get_api_base_url()}/status"
+    allowed_stages = {"diagnosis", "mitigation"}
+    start_time = time.time()
+
+    logger.info("Waiting for conductor to reach submission-ready stage...")
+
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(api_url)
+            response.raise_for_status()
+            status_data = response.json()
+            stage = status_data.get("stage")
+
+            if stage in allowed_stages:
+                logger.info(f"Conductor ready at stage: {stage}")
+                return stage
+            else:
+                logger.debug(f"Current stage: {stage}, waiting for {allowed_stages}...")
+                time.sleep(1)
+
+        except Exception as e:
+            logger.debug(f"Error checking status: {e}, retrying...")
+            time.sleep(1)
+
+    raise TimeoutError(f"Conductor did not reach ready stage within {timeout} seconds")
+
+
+def build_instruction(app_info: dict) -> str:
+    """
+    Build the instruction string for the Cursor agent.
+
+    Args:
+        app_info: Application information from conductor
+
+    Returns:
+        Instruction string to pass to the agent
+    """
+    app_name = app_info.get("app_name", "unknown")
+    namespace = app_info.get("namespace", "default")
+    descriptions = app_info.get("descriptions", "")
+
+    instruction = f"""You are an SRE agent tasked with diagnosing and fixing issues in a Kubernetes application.
+
+Application: {app_name}
+Namespace: {namespace}
+
+{descriptions}
+
+CRITICAL: You are running in an AUTOMATED environment. Work autonomously and make all decisions yourself. DO NOT ask for user confirmation or approval. Proceed with the best solution based on your analysis.
+
+WORKFLOW: You will perform TWO tasks in sequence:
+
+TASK 1: DIAGNOSIS
+- Investigate the application to detect any anomalies or issues
+- Analyze metrics, logs, and traces
+- When ready, submit a natural language description of the issue you found
+- Your diagnosis is evaluated on whether you correctly identify the faulty components and root cause
+
+TASK 2: MITIGATION
+- Identify the root cause of the issue
+- Implement a fix to resolve the problem autonomously (do not ask for confirmation)
+- After applying the fix, YOU MUST submit with an empty string to trigger validation
+- The submission is REQUIRED - do not exit without submitting
+- Your mitigation is evaluated on whether the application is healthy after your changes
+- Your fix is also evaluated on whether it addresses the root cause, not just the symptoms
+
+HOW TO SUBMIT:
+
+The submission endpoint is: {get_api_base_url()}/submit
+
+For DIAGNOSIS stage:
+- Submit with a natural language description of the issue
+- Example: POST {get_api_base_url()}/submit with JSON: {{"solution": "The frontend service is crashing due to missing environment variable"}}
+
+For MITIGATION stage:
+- After applying your fix, YOU MUST submit with an EMPTY STRING
+- POST {get_api_base_url()}/submit with JSON: {{"solution": ""}}
+- This submission is MANDATORY - the conductor needs it to validate your fix
+
+Important:
+- You have access to kubectl commands to inspect and modify resources in namespace '{namespace}'
+- You can query metrics and traces through the available observability tools
+- The conductor API is available at {get_api_base_url()}
+- Use shell commands directly (kubectl, curl, etc.) rather than asking to run them
+"""
+
+    logger.info(f"Built instruction:\n{instruction}")
+    return instruction
+
+
+def save_results(
+    logs_dir: Path,
+    problem_id: str,
+    return_code: int,
+    usage_metrics: dict,
+) -> None:
+    """
+    Save run results to JSON file.
+
+    Args:
+        logs_dir: Directory containing logs
+        problem_id: Problem identifier
+        return_code: Cursor agent return code
+        usage_metrics: Token usage metrics
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    results_file = logs_dir / f"cursor_results_{problem_id}_{timestamp}.json"
+
+    results = {
+        "problem_id": problem_id,
+        "timestamp": timestamp,
+        "return_code": return_code,
+        "success": return_code == 0,
+        "usage_metrics": usage_metrics,
+    }
+
+    with open(results_file, "w") as f:
+        json.dump(results, f, indent=2)
+
+    logger.info(f"Saved results to {results_file}")
+
+
+def main():
+    """Main entry point for Cursor agent driver."""
+    parser = argparse.ArgumentParser(description="Run Cursor agent on SREGym tasks")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=os.getenv("AGENT_MODEL_ID", "auto"),
+        help="Model to use for the Cursor CLI (default: from AGENT_MODEL_ID env var or 'auto')",
+    )
+    parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=os.environ.get("AGENT_LOGS_DIR", "./logs/cursor"),
+        help="Directory to store logs (default: ./logs/cursor)",
+    )
+    parser.add_argument(
+        "--problem-id",
+        type=str,
+        default=None,
+        help="Problem ID for artifact naming (default: SREGYM_ARTIFACT_ID in benchmark runs)",
+    )
+    parser.add_argument(
+        "--no-auto-install",
+        action="store_true",
+        help="Disable auto-installation of the Cursor CLI if not found",
+    )
+
+    args = parser.parse_args()
+
+    logger.info("=" * 80)
+    logger.info("Starting Cursor agent for SREGym")
+    logger.info(f"Model: {args.model}")
+    logger.info(f"Logs directory: {args.logs_dir}")
+    logger.info("=" * 80)
+
+    try:
+        CursorAgent.ensure_installed(auto_install=not args.no_auto_install)
+    except RuntimeError as e:
+        logger.error(f"Cursor CLI installation check failed: {e}")
+        sys.exit(1)
+
+    try:
+        stage = wait_for_ready_stage(timeout=300)
+        logger.info(f"Conductor is ready at stage: {stage}")
+    except TimeoutError as e:
+        logger.error(f"Timeout waiting for conductor: {e}")
+        sys.exit(1)
+
+    try:
+        app_info = get_app_info()
+    except Exception as e:
+        logger.error(f"Failed to get app info: {e}")
+        sys.exit(1)
+
+    problem_id = resolve_problem_id(cli_problem_id=args.problem_id)
+    logger.info(f"Problem ID (harness): {problem_id}")
+
+    instruction = build_instruction(app_info)
+
+    logs_dir = Path(args.logs_dir)
+    agent = CursorAgent(logs_dir=logs_dir, model_name=args.model)
+
+    logger.info("Starting Cursor agent execution...")
+    return_code = agent.run(instruction)
+
+    usage_metrics = agent.get_usage_metrics()
+
+    save_results(logs_dir, problem_id, return_code, usage_metrics)
+
+    logger.info("=" * 80)
+    logger.info("Cursor agent execution completed")
+    logger.info(f"Return code: {return_code}")
+    logger.info(f"Usage metrics: {usage_metrics}")
+    logger.info("=" * 80)
+
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/cursor/judge_bridge.py
+++ b/clients/cursor/judge_bridge.py
@@ -1,0 +1,166 @@
+"""
+Minimal OpenAI-Chat-Completions-compatible bridge in front of the Cursor CLI.
+
+The problem-difficulty-evaluation workflow's LLM-as-a-judge talks to whatever
+JUDGE_API_BASE/JUDGE_API_KEY point at via LiteLLM's OpenAI-compatible client
+(see llm_backend/get_llm_backend.py). Cursor has no such HTTP inference API of
+its own -- only the interactive/headless `agent` CLI -- so when the Cursor
+fallback is in use for the agent, this bridge stands in for the judge too by
+shelling out to `agent --print ... --output-format json` per request and
+wrapping the result in a standard chat-completion response.
+
+This is intentionally single-purpose: single-turn, non-streaming, no tool
+use. It exists only so the existing judge code path needs no changes.
+
+Usage:
+    python -m clients.cursor.judge_bridge --port 4100 --model auto
+"""
+
+import argparse
+import json
+import logging
+import subprocess
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+logger = logging.getLogger("all.cursor.judge_bridge")
+
+DEFAULT_MODEL = "auto"
+CLI_TIMEOUT_SECONDS = 300
+
+
+def _flatten_messages(messages: list[dict]) -> str:
+    """Turn a chat-completions messages array into a single CLI prompt."""
+    parts = []
+    for message in messages:
+        role = message.get("role", "user")
+        content = message.get("content", "")
+        if isinstance(content, list):
+            # Some clients send content as a list of {"type": "text", "text": ...} parts.
+            content = "\n".join(part.get("text", "") for part in content if isinstance(part, dict))
+        parts.append(f"[{role}]\n{content}")
+    return "\n\n".join(parts)
+
+
+def _run_agent(prompt: str, model: str) -> str:
+    """Run the Cursor CLI once, non-interactively, and return its text result."""
+    command = [
+        "agent",
+        "--print",
+        prompt,
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        "--trust",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=CLI_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Cursor CLI exited {result.returncode}: {(result.stderr or result.stdout).strip()[:2000]}")
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Cursor CLI did not return valid JSON: {result.stdout[:2000]}") from e
+
+    if data.get("is_error"):
+        raise RuntimeError(f"Cursor CLI reported an error: {data}")
+
+    text = data.get("result")
+    if not isinstance(text, str):
+        raise RuntimeError(f"Cursor CLI response had no 'result' text: {data}")
+    return text
+
+
+def make_handler(default_model: str):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):  # noqa: A002 - matches base signature
+            logger.info("%s - %s", self.address_string(), format % args)
+
+        def _send_json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+            if self.path in ("/health", "/health/liveliness"):
+                self._send_json(200, {"status": "ok"})
+                return
+            self._send_json(404, {"error": {"message": "not found"}})
+
+        def do_POST(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+            if not self.path.rstrip("/").endswith("/chat/completions"):
+                self._send_json(404, {"error": {"message": "not found"}})
+                return
+
+            length = int(self.headers.get("Content-Length", 0))
+            raw_body = self.rfile.read(length) if length else b"{}"
+            try:
+                request = json.loads(raw_body or b"{}")
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": {"message": "invalid JSON body"}})
+                return
+
+            messages = request.get("messages", [])
+            model = request.get("model") or default_model
+            # LiteLLM model strings are typically "openai/<name>"; the CLI
+            # only wants the bare model id.
+            if "/" in model:
+                model = model.rsplit("/", 1)[-1]
+
+            prompt = _flatten_messages(messages)
+
+            try:
+                text = _run_agent(prompt, model)
+            except (RuntimeError, subprocess.TimeoutExpired) as e:
+                logger.error(f"Cursor judge bridge request failed: {e}")
+                self._send_json(502, {"error": {"message": str(e), "code": "cursor_cli_error"}})
+                return
+
+            response = {
+                "id": f"chatcmpl-{uuid.uuid4().hex}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+                # Cursor's CLI does not report token counts; zeros keep the
+                # response schema-valid without fabricating usage data.
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            }
+            self._send_json(200, response)
+
+    return Handler
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    parser = argparse.ArgumentParser(description="OpenAI-compatible bridge in front of the Cursor CLI")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Fallback model if the request omits one")
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), make_handler(args.model))
+    logger.info(f"Cursor judge bridge listening on http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/agents/install-scripts/install-cursor.sh
+++ b/docker/agents/install-scripts/install-cursor.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+VERSION="${AGENT_VERSION:-latest}"
+if [ "$VERSION" != "latest" ]; then
+    echo "[$(date -Iseconds)] Cursor CLI installer does not support pinning a version; ignoring AGENT_VERSION=$VERSION" >&2
+fi
+echo "[$(date -Iseconds)] Installing Cursor CLI..."
+curl https://cursor.com/install -fsS | bash
+
+# The installer places the binary under ~/.local/bin, which is only added to
+# PATH by shell rc files. Later steps run as separate, non-login processes
+# chained with '&&', so link it into a directory already on PATH. This must
+# be a symlink, not a copy: the installed `agent` script locates its bundled
+# node runtime relative to its own resolved (symlink-followed) path.
+ln -sf "$HOME/.local/bin/agent" /usr/local/bin/agent
+
+echo "[$(date -Iseconds)] Cursor CLI installed: $(agent --version)"

--- a/main.py
+++ b/main.py
@@ -70,6 +70,7 @@ def run_preflight_check(
         "copilot": "clients.copilot.driver",
         "opencode": "clients.opencode.driver",
         "gemini": "clients.geminicli.driver",
+        "cursor": "clients.cursor.driver",
     }
 
     module_path = agent_driver_modules.get(agent_name)

--- a/sregym/service/container_runner.py
+++ b/sregym/service/container_runner.py
@@ -202,6 +202,8 @@ class ContainerRunner:
         "GLM_API_KEY",
         "ZAI_API_KEY",
         "ZHIPU_API_KEY",
+        # Cursor CLI
+        "CURSOR_API_KEY",
         # Claude Code
         "CLAUDE_CODE_OAUTH_TOKEN",
         # GitHub Copilot CLI


### PR DESCRIPTION
## Summary

The Z.ai Coding Plan backing `/evaluate-problem` is a low-volume annual subscription (we have a Cursor subscription with more spare capacity). When Z.ai's preflight fails — quota exhausted, an outage, or the secret simply isn't configured — the workflow now falls back to a personal Cursor CLI subscription instead of failing the run outright.

The fallback is deliberately loose about which model runs: it exists to answer "is this problem still solvable by *some* capable agent," not to compare models or agents consistently. `CURSOR_MODEL` defaults to `"auto"` and lets Cursor pick.

## Changes

- **`clients/cursor/`** — a new agent client following the existing `codex`/`opencode` pattern: `cursor_agent.py` (install/run/usage-metrics), `driver.py` (the conductor wait/submit loop used by `main.py --agent cursor`), and `judge_bridge.py`, a small stdlib-only HTTP server that wraps the Cursor CLI as an OpenAI-Chat-Completions-compatible endpoint. Cursor has no plain inference API of its own, so this bridge lets the judge (which talks to whatever `JUDGE_API_BASE` points at via LiteLLM) work unmodified when Cursor is standing in for both the agent and the judge.
- **`agents.yaml`** / **`main.py`** — register `cursor` as an agent, including in the preflight driver map.
- **`sregym/service/container_runner.py`** — forward `CURSOR_API_KEY` into agent containers (same allowlist as the other provider keys).
- **`docker/agents/install-scripts/install-cursor.sh`** — installs the Cursor CLI for the container-isolated agent path.
- **`.github/workflows/problem-difficulty-evaluation.yml`** — replaces the old "Require Z.ai secret" + "Preflight Z.ai quota" steps with a single "Choose evaluation provider" step that tries Z.ai first and falls back to Cursor; the rest of the job (bridge setup, result CSV globbing, cleanup, PR comment) is now agent-aware instead of Codex/Z.ai-specific.

## Testing

- `pre-commit` (whitespace, YAML, ruff check/format, merge-conflict markers): passed on all changed/added files.
- Verified the new provider-selection logic with `act` against the real Z.ai endpoint:
  - Invalid `ZCODE_API_KEY` + no `CURSOR_API_KEY` → correctly hard-fails with both reasons in the job summary.
  - Invalid `ZCODE_API_KEY` + a `CURSOR_API_KEY` → correctly selects `provider=cursor` and threads it through every conditional step (bridge start/stop, artifact upload, diagnostics), including a checkout-failure scenario, without any step erroring ungracefully.
- Ran the real `install-cursor.sh` installer inside a container matching `docker/agents/Dockerfile`, which caught that Cursor's installer actually places the binary under `~/.local/bin` (with its bundled `node` runtime resolved relative to that real, non-symlinked path) — not `~/.cursor/bin` as Cursor's own CLI docs describe — and that copying the binary out (rather than symlinking it) breaks that resolution. Fixed to symlink instead of copy, and confirmed `agent --version` and `agent --print ... --trust` (rejecting with "Authentication required" as expected without a real key) both work from a clean `PATH` via the symlink.
- Did not exercise a real Cursor evaluation end-to-end (needs a live `CURSOR_API_KEY` and the full kind cluster, which is unchanged from the existing Z.ai path) — recommend a real `/evaluate-problem` run once `CURSOR_API_KEY` is added as a repository secret.

## Follow-ups (not in this PR)

- `CURSOR_API_KEY` needs to be added as a repository secret for the fallback to actually engage.
- Cursor model choice is hardcoded to `"auto"`; could be exposed as a workflow input if finer control is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P32DTTRYGSCPkAcp6k57ka