### PR TITLE
Fix egress proxy response buffering so filtered mode works for Cursor

### DIFF
--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -536,6 +536,7 @@ jobs:
             zai)
               agent_name="codex"
               judge_model="openai/${ZAI_MODEL}-judge"
+              internet_access="filtered"
               export AGENT_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
               export AGENT_API_KEY="$LITELLM_MASTER_KEY"
               export JUDGE_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
@@ -544,6 +545,14 @@ jobs:
             cursor)
               agent_name="cursor"
               judge_model="openai/$CURSOR_MODEL"
+              # The Cursor CLI does not go through the filtered egress proxy's
+              # TLS interception (it hangs until agent-side timeouts instead
+              # of erroring), so this fallback runs with open internet access.
+              # It's already restricted to write-access commenters; this
+              # trades away the filtered mode's GitHub-owner blocklist (which
+              # stops an agent from just reading this repo's answer key) only
+              # for the fallback path.
+              internet_access="open"
               export JUDGE_API_BASE="http://127.0.0.1:$CURSOR_JUDGE_BRIDGE_PORT/v1"
               export JUDGE_API_KEY="dummy"
               ;;
@@ -557,7 +566,7 @@ jobs:
             --judge-model "$judge_model" \
             --n-attempts "$ATTEMPTS" \
             --agent-timeout 1800 \
-            --internet-access filtered \
+            --internet-access "$internet_access" \
             2>&1 | tee benchmark.log
 
       - name: Dump cluster diagnostics

--- a/.github/workflows/problem-difficulty-evaluation.yml
+++ b/.github/workflows/problem-difficulty-evaluation.yml
@@ -536,7 +536,6 @@ jobs:
             zai)
               agent_name="codex"
               judge_model="openai/${ZAI_MODEL}-judge"
-              internet_access="filtered"
               export AGENT_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
               export AGENT_API_KEY="$LITELLM_MASTER_KEY"
               export JUDGE_API_BASE="http://127.0.0.1:$LITELLM_PORT/v1"
@@ -545,14 +544,6 @@ jobs:
             cursor)
               agent_name="cursor"
               judge_model="openai/$CURSOR_MODEL"
-              # The Cursor CLI does not go through the filtered egress proxy's
-              # TLS interception (it hangs until agent-side timeouts instead
-              # of erroring), so this fallback runs with open internet access.
-              # It's already restricted to write-access commenters; this
-              # trades away the filtered mode's GitHub-owner blocklist (which
-              # stops an agent from just reading this repo's answer key) only
-              # for the fallback path.
-              internet_access="open"
               export JUDGE_API_BASE="http://127.0.0.1:$CURSOR_JUDGE_BRIDGE_PORT/v1"
               export JUDGE_API_KEY="dummy"
               ;;
@@ -566,7 +557,7 @@ jobs:
             --judge-model "$judge_model" \
             --n-attempts "$ATTEMPTS" \
             --agent-timeout 1800 \
-            --internet-access "$internet_access" \
+            --internet-access filtered \
             2>&1 | tee benchmark.log
 
       - name: Dump cluster diagnostics

--- a/docker/egress_proxy.py
+++ b/docker/egress_proxy.py
@@ -12,7 +12,6 @@ from internet_policy import (
     DEFAULT_BLOCKED_GITHUB_REPOSITORIES,
     DEFAULT_BLOCKED_GITHUB_REPOSITORY_IDS,
     blocked_github_owner,
-    should_stream_response,
 )
 from mitmproxy import ctx, http
 
@@ -39,9 +38,16 @@ BLOCK_LOG = Path(os.environ.get("BLOCKED_REQUEST_LOG", "/state/blocked-requests.
 
 
 def responseheaders(flow: http.HTTPFlow) -> None:
-    """Forward long-lived SSE responses instead of buffering them forever."""
-    if should_stream_response(flow.response.headers.get("content-type")):
-        flow.response.stream = True
+    """Forward responses as they arrive instead of buffering them in full.
+
+    This addon only ever inspects request bodies (for the GitHub blocklist
+    below), never response bodies, so there is nothing that needs a fully
+    buffered response. Streaming unconditionally -- rather than only for a
+    recognized content type like text/event-stream -- avoids stalling any
+    long-lived agent connection for its whole duration before the client
+    sees a single byte, whatever content type it happens to use.
+    """
+    flow.response.stream = True
 
 
 def request(flow: http.HTTPFlow) -> None:

--- a/sregym/service/internet_policy.py
+++ b/sregym/service/internet_policy.py
@@ -46,14 +46,6 @@ class InternetPolicy:
         return self.mode == InternetAccessMode.FILTERED
 
 
-def should_stream_response(content_type: str | None) -> bool:
-    """Return whether a response must bypass mitmproxy body buffering."""
-    if not content_type:
-        return False
-    media_type = content_type.partition(";")[0].strip().casefold()
-    return media_type == "text/event-stream"
-
-
 def blocked_github_owner(
     host: str,
     request_target: str,

--- a/tests/service/test_internet_policy.py
+++ b/tests/service/test_internet_policy.py
@@ -20,7 +20,7 @@ from sregym.service.container_runner import (
     ContainerRunner,
     _find_host_ca_bundle,
 )
-from sregym.service.internet_policy import InternetPolicy, blocked_github_owner, should_stream_response
+from sregym.service.internet_policy import InternetPolicy, blocked_github_owner
 from sregym.service.k8s_proxy import KubernetesAPIProxy, _is_workload_create_path, is_valid_bearer_token
 
 
@@ -70,19 +70,6 @@ def test_resolves_dot_segments_before_applying_github_policy(target):
 
 def test_allows_unconfigured_numeric_github_repository_id():
     assert blocked_github_owner("api.github.com", "/repositories/12345/contents/README.md", None) is None
-
-
-@pytest.mark.parametrize(
-    ("content_type", "expected"),
-    [
-        ("text/event-stream", True),
-        ("Text/Event-Stream; charset=utf-8", True),
-        ("application/json", False),
-        (None, False),
-    ],
-)
-def test_only_event_stream_responses_are_streamed(content_type, expected):
-    assert should_stream_response(content_type) is expected
 
 
 def test_ignores_unrelated_query_and_json_text():


### PR DESCRIPTION
## Summary

The first real run of the Cursor fallback (PR #1012), triggered on #1005 after merging, got past provider selection and the Cursor CLI preflight on the bare runner, but hung inside the sandboxed agent container until the 60-second preflight timeout: https://github.com/SREGym/SREGym/actions/runs/34087713172/job/101634854904

```
subprocess.TimeoutExpired: Command '['agent', '--print', 'say ok', '--model', 'auto', '--output-format', 'json', '--trust']' timed out after 60 seconds
```

My first pass at this (now superseded) just gave the Cursor fallback `--internet-access open`, bypassing the filtered egress proxy entirely. That traded away the filtered mode's GitHub-owner blocklist (which stops an agent from just reading this repo's answer key), so it's the wrong fix — this PR replaces it with the actual root cause and a real fix instead.

## Root cause

Reproduced the hang locally without needing a real Cursor account. The filtered egress proxy's mitmproxy addon (`docker/egress_proxy.py`) only sets `flow.response.stream = True` — telling mitmproxy to forward a response as it arrives — for exactly one content type: `text/event-stream`. Every other response gets fully buffered in memory until the upstream connection closes, then forwarded all at once.

I confirmed this by running the actual production addon against a synthetic slow upstream (six chunks, 2s apart, over 12s total) through a real mitmproxy container:

| Response content-type | Time to first byte |
|---|---|
| `text/event-stream` (already whitelisted) | 0.017s |
| `application/x-ndjson` (unrecognized) | 12.024s (the entire response) |

A long-lived agent session that streams under any content type other than exactly `text/event-stream` — or just keeps a connection open for the length of a multi-minute task — gets stuck behind that full buffering, past any reasonable client-side timeout. That's consistent with what happened to the Cursor CLI.

I also confirmed the CLI does honor `HTTPS_PROXY` (ruling out "it ignores the proxy" as the cause): pointing it at an unreachable proxy address fails in ~1s with an explicit `Failed to reach the Cursor API. Check that your proxy (...) is reachable.` error, not a hang.

## Fix

- `docker/egress_proxy.py`: set `flow.response.stream = True` unconditionally. This addon only ever inspects **request** bodies (for the GitHub-owner blocklist); nothing depends on **responses** being buffered, so there's no reason to buffer any of them.
- `sregym/service/internet_policy.py`: remove `should_stream_response()`, now unused.
- `tests/service/test_internet_policy.py`: remove the now-obsolete parametrized test for it.
- `.github/workflows/problem-difficulty-evaluation.yml`: revert the Cursor fallback back to `--internet-access filtered`, matching the Z.ai path — both providers now get the same GitHub-blocklist protection.

Re-ran the same synthetic repro against the patched addon: the `application/x-ndjson` case now gets the same ~0.02s time-to-first-byte as the SSE case.

## Testing

- `uv run pytest tests/service/test_internet_policy.py`: 50 passed, 1 failed. The failure (`test_open_runner_keeps_existing_host_network`) is pre-existing on `main` before this change (verified by stashing and re-running) and unrelated to this fix.
- `pre-commit` (whitespace, YAML, ruff check/format, merge-conflict markers): passed.
- Have not re-run `/evaluate-problem` against this branch yet (needs merge first, since comment-triggered runs use the workflow from `main`) — recommend re-triggering on #1005 after merge to confirm the Cursor path now completes end to end.