### PR TITLE
fix(astronomy-shop): give kafka broker headroom

### DIFF
--- a/sregym/conductor/oracles/kafka_producer_leak_mitigation.py
+++ b/sregym/conductor/oracles/kafka_producer_leak_mitigation.py
@@ -1,16 +1,25 @@
+import datetime
 import time
 
 from sregym.conductor.oracles.failure import FailureClass
 from sregym.conductor.oracles.mitigation import MitigationOracle
+from sregym.service.kafka_health import KafkaHealthCheck, broker_memory_failure, broker_pods
 from sregym.service.kubectl import ApiException, KubeCtl
 
 
 class KafkaProducerLeakOracle(MitigationOracle):
     FAILURE_CLASSES = {
         "kafka_still_restarting": FailureClass.AMBIGUOUS,
+        "kafka_not_serving": FailureClass.AMBIGUOUS,
     }
 
     def evaluate(self) -> dict:
+        try:
+            return self._evaluate()
+        except Exception as exc:
+            return self.fail_from_exception(exc)
+
+    def _evaluate(self) -> dict:
         self.rollout_time = 300
 
         results = super().evaluate()
@@ -36,20 +45,14 @@ class KafkaProducerLeakOracle(MitigationOracle):
 
             for c in kafka_deployment.spec.template.spec.containers:
                 if "kafka" in c.name:
-                    for e in c.env:
-                        if e.name == "KAFKA_HEAP_OPTS":
-                            if e.value != self.problem.heap_limit:
-                                print(f"❌ KAFKA_HEAP_OPTS is '{e.value}', expected '{self.problem.heap_limit}'")
-                                # Compared against the value the injector set,
-                                # so this is the fault observed directly.
-                                return self.fail(
-                                    "fault_still_present",
-                                    setting="KAFKA_HEAP_OPTS",
-                                    value=e.value,
-                                    expected=self.problem.heap_limit,
-                                )
-
-                            break
+                    heap = next((e.value for e in c.env or [] if e.name == "KAFKA_HEAP_OPTS"), None)
+                    if heap != self.problem.heap_limit:
+                        return self.fail(
+                            "fault_still_present",
+                            setting="KAFKA_HEAP_OPTS",
+                            value=heap,
+                            expected=self.problem.heap_limit,
+                        )
 
                     memory_limit = c.resources.limits.get("memory") if c.resources and c.resources.limits else None
                     if memory_limit != self.problem.memory_limit:
@@ -63,34 +66,44 @@ class KafkaProducerLeakOracle(MitigationOracle):
 
                     break
 
-            pods = kubectl.list_pods(self.problem.namespace)
-            rcnt_1 = None
-            for p in pods.items:
-                if "kafka" in p.metadata.name:
-                    for c in p.status.container_statuses:
-                        if "kafka" in c.name:
-                            rcnt_1 = c.restart_count
-                            break
-                    break
-
-            deadline = time.monotonic() + 120
-            while time.monotonic() < deadline:
-                pods = kubectl.list_pods(self.problem.namespace)
-                rcnt_2 = None
-                for p in pods.items:
-                    if "kafka" in p.metadata.name:
-                        for c in p.status.container_statuses:
-                            if "kafka" in c.name:
-                                rcnt_2 = c.restart_count
-                                break
+            with KafkaHealthCheck(kubectl, self.problem.namespace) as probe:
+                started = datetime.datetime.now(datetime.UTC)
+                # Kafka's container can be Ready before its protocol listener
+                # starts. Give a valid manual restart time to finish, then
+                # require the entire stability window below.
+                ready_deadline = time.monotonic() + 60
+                while True:
+                    if broker_memory_failure(kubectl, self.problem.namespace, started):
+                        return self.fail("fault_still_present", detail="Kafka has a new memory failure")
+                    if probe.check():
                         break
-
-                if rcnt_1 is None or rcnt_2 is None or rcnt_2 > rcnt_1:
-                    print(f"❌ kafka container restarted during the watch window ({rcnt_1} -> {rcnt_2})")
-                    # The broker is still OOMing even with the limits restored,
-                    # so the configuration is right but the outcome is not.
-                    return self.fail("kafka_still_restarting", before=rcnt_1, after=rcnt_2)
-
-                time.sleep(5)
+                    if time.monotonic() >= ready_deadline:
+                        return self.fail("kafka_not_serving")
+                    time.sleep(2)
+                before = self._broker_restarts()
+                deadline = time.monotonic() + 120
+                next_probe = 0
+                while True:
+                    after = self._broker_restarts()
+                    if not before or before != after:
+                        return self.fail("kafka_still_restarting", before=before, after=after)
+                    if broker_memory_failure(kubectl, self.problem.namespace, started):
+                        return self.fail("fault_still_present", detail="Kafka has a new memory failure")
+                    now = time.monotonic()
+                    if now >= next_probe or now >= deadline:
+                        if not probe.check():
+                            return self.fail("kafka_not_serving")
+                        next_probe = time.monotonic() + 20
+                    if now >= deadline:
+                        break
+                    time.sleep(min(5, max(0, deadline - time.monotonic())))
 
         return results
+
+    def _broker_restarts(self):
+        return {
+            str(pod.metadata.uid): status.restart_count
+            for pod in broker_pods(self.problem.kubectl, self.problem.namespace)
+            for status in pod.status.container_statuses or []
+            if status.name == "kafka"
+        }

--- a/sregym/generators/fault/inject_app.py
+++ b/sregym/generators/fault/inject_app.py
@@ -1,6 +1,8 @@
 """Inject faults at the application layer: Code, MongoDB, Redis, etc."""
 
 import base64
+import datetime
+import shlex
 import textwrap
 import time
 
@@ -8,6 +10,7 @@ from kubernetes import client
 
 from sregym.generators.fault.base import FaultInjector
 from sregym.service.apps.hotel_reservation import HOTEL_RESERVATION_APPLICATION_IMAGE
+from sregym.service.kafka_health import KafkaHealthCheck, broker_memory_failure
 from sregym.service.kubectl import KubeCtl
 
 FEATURE_FLAG_EXPERIMENTAL_ROUTING_IMAGE = HOTEL_RESERVATION_APPLICATION_IMAGE
@@ -479,7 +482,14 @@ class ApplicationFaultInjector(FaultInjector):
         print(f"Restored environment variable '{env_var}' with value '{env_value}' to deployment '{deployment_name}'.")
 
     def inject_kafka_producer_leak(self, deployment_name: str = "checkout") -> list:
+        with KafkaHealthCheck(self.kubectl, self.namespace) as probe:
+            if not probe.wait_until_available():
+                raise RuntimeError("Kafka cannot publish and read a record before injection")
+            return self._inject_kafka_producers(deployment_name, probe)
+
+    def _inject_kafka_producers(self, deployment_name: str, probe: KafkaHealthCheck) -> list:
         limits = [None, None]
+        started = datetime.datetime.now(datetime.UTC)
 
         kafka_dep = self.kubectl.get_deployment("kafka", self.namespace)
         for c in kafka_dep.spec.template.spec.containers:
@@ -505,7 +515,7 @@ class ApplicationFaultInjector(FaultInjector):
             import os
 
             def task(thread_id: int):
-                payload_size = int(os.environ.get('PAYLOAD_SIZE_BYTES', '10000000'))
+                payload_size = int(os.environ.get('PAYLOAD_SIZE_BYTES', '15728640'))
                 payload = os.urandom(payload_size)
 
                 conf = {
@@ -518,8 +528,12 @@ class ApplicationFaultInjector(FaultInjector):
                 while True:
                     try:
                         producer = Producer(conf)
-                        producer.produce('orders', payload)
-                        producer.poll(0)
+                        # This binary stream must not reach the application's
+                        # protobuf consumers on the real orders topic.
+                        producer.produce('order-events', payload)
+                        # Keep the producer alive until delivery finishes. poll(0)
+                        # destroys it with most messages still queued locally.
+                        producer.flush(10)
                     except BufferError:
                         producer.poll(0.1)
 
@@ -552,51 +566,62 @@ class ApplicationFaultInjector(FaultInjector):
 
         deadline = time.monotonic() + 300
         while time.monotonic() < deadline:
-            pods = self.kubectl.list_pods(self.namespace)
-            rcnt = None
-            for p in pods.items:
-                if "kafka" in p.metadata.name:
-                    for c in p.status.container_statuses or []:
-                        if "kafka" in c.name:
-                            rcnt = c.restart_count
-                            break
-                    break
-
-            if rcnt:
+            # A Java heap failure can leave the container Running/Ready. Require
+            # fresh memory-failure evidence AND a failed Kafka round trip.
+            if broker_memory_failure(self.kubectl, self.namespace, started) and not probe.check():
                 break
 
             time.sleep(5)
         else:
-            raise TimeoutError("Kafka did not restart within 300 seconds after producer injection")
+            raise TimeoutError("Kafka did not develop a memory-related serving failure within 300 seconds")
 
         print(f"Injected sidecar container 'order-creator' in '{deployment_name}'")
 
         return limits
 
     def recover_kafka_producer_leak(self, deployment_name: str = "checkout"):
-        kafka_dep = self.kubectl.get_deployment("kafka", self.namespace)
-        for c in kafka_dep.spec.template.spec.containers:
-            if "kafka" in c.name:
-                temp = None
-                for i, e in enumerate(c.env):
-                    if e.name == "KAFKA_MESSAGE_MAX_BYTES":
-                        temp = i
-                        break
-
-                if temp is not None:
-                    c.env.pop(temp)
-
-        self.kubectl.update_deployment("kafka", self.namespace, kafka_dep)
-
         deployment = self.kubectl.get_deployment(deployment_name, self.namespace)
-
+        replicas = deployment.spec.replicas
+        deployment.spec.replicas = 0
         deployment.spec.template.spec.containers = [
-            x for x in deployment.spec.template.spec.containers if x.name != "order-creator"
+            c for c in deployment.spec.template.spec.containers if c.name != "order-creator"
         ]
-
         self.kubectl.update_deployment(deployment_name, self.namespace, deployment)
+        try:
+            # Scaling down prevents the old ReplicaSet from replacing producers
+            # while checkout's replacement is waiting for the broken broker.
+            selector = deployment.spec.selector.match_labels
+            deadline = time.monotonic() + 120
+            while any(
+                all((pod.metadata.labels or {}).get(key) == value for key, value in selector.items())
+                and any(c.name == "order-creator" for c in pod.spec.containers)
+                for pod in self.kubectl.list_pods(self.namespace).items
+            ):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("Producer containers did not terminate within 120 seconds")
+                time.sleep(2)
 
-        self.kubectl.exec_command(f"kubectl delete pod -l app.kubernetes.io/name={deployment_name} -n {self.namespace}")
+            kafka_dep = self.kubectl.get_deployment("kafka", self.namespace)
+            for container in kafka_dep.spec.template.spec.containers:
+                if container.name == "kafka":
+                    container.env = [e for e in container.env or [] if e.name != "KAFKA_MESSAGE_MAX_BYTES"]
+            # Combine config restoration and restart into one rollout. A second
+            # rollout can replace a broker that just became Ready again.
+            metadata = kafka_dep.spec.template.metadata
+            metadata.annotations = dict(metadata.annotations or {})
+            metadata.annotations["kubectl.kubernetes.io/restartedAt"] = datetime.datetime.now(datetime.UTC).isoformat()
+            self.kubectl.update_deployment("kafka", self.namespace, kafka_dep)
+            self.kubectl.exec_command_checked(
+                shlex.join(
+                    ["kubectl", "rollout", "status", "deployment/kafka", "-n", self.namespace, "--timeout=120s"]
+                ),
+                timeout=125,
+            )
+        finally:
+            # Also restore the requested count after an API or startup error.
+            deployment = self.kubectl.get_deployment(deployment_name, self.namespace)
+            deployment.spec.replicas = replicas
+            self.kubectl.update_deployment(deployment_name, self.namespace, deployment)
 
         print(f"Removed sidecar container 'order-creator' from '{deployment_name}'")
 

--- a/sregym/generators/fault/inject_app.py
+++ b/sregym/generators/fault/inject_app.py
@@ -550,7 +550,7 @@ class ApplicationFaultInjector(FaultInjector):
 
         self.kubectl.update_deployment(deployment_name, self.namespace, deployment)
 
-        deadline = time.monotonic() + 120
+        deadline = time.monotonic() + 300
         while time.monotonic() < deadline:
             pods = self.kubectl.list_pods(self.namespace)
             rcnt = None
@@ -567,7 +567,7 @@ class ApplicationFaultInjector(FaultInjector):
 
             time.sleep(5)
         else:
-            raise TimeoutError("Kafka did not restart within 120 seconds after producer injection")
+            raise TimeoutError("Kafka did not restart within 300 seconds after producer injection")
 
         print(f"Injected sidecar container 'order-creator' in '{deployment_name}'")
 

--- a/sregym/service/apps/values/astronomy-shop-fixes.yaml
+++ b/sregym/service/apps/values/astronomy-shop-fixes.yaml
@@ -1,8 +1,7 @@
 # Always applied to astronomy-shop, by AstronomyShop.deploy().
 #
 # Corrections to the vendored opentelemetry-demo chart for the way SREGym
-# actually deploys it. Nothing here changes what an agent can observe; each
-# entry removes work the collector was doing that could never succeed.
+# actually deploys it.
 
 opentelemetry-collector:
   config:
@@ -20,3 +19,22 @@ opentelemetry-collector:
         # metrics are still produced for anything that scrapes the collector.
         metrics:
           exporters: [debug]
+
+components:
+  kafka:
+    resources:
+      # KafkaFaultInjector._run (inject_kafka.py) execs the Kafka admin CLI
+      # inside this container, and kubectl exec runs it in the container's own
+      # cgroup. The chart declares limits only, so Kubernetes copies the limit
+      # into the request: the broker is capped at 600Mi while -Xms400M commits
+      # a 400M heap up front. A second JVM needs ~100-150Mi RSS even at
+      # -Xmx64m -- which bounds the heap, not metaspace or thread stacks -- so
+      # without this override the kernel OOM-kills it and takes the broker
+      # down, and kafka_poison_pill_hol_block cannot inject its fault.
+      #
+      # Pinning the request where it already effectively sits leaves scheduling
+      # unchanged; only the burst ceiling moves.
+      requests:
+        memory: 600Mi
+      limits:
+        memory: 1Gi

--- a/sregym/service/kafka_health.py
+++ b/sregym/service/kafka_health.py
@@ -1,0 +1,159 @@
+"""Bounded Kafka checks that do not launch another JVM inside the broker."""
+
+import contextlib
+import shlex
+import time
+import uuid
+
+from kubernetes import client
+
+
+def broker_pods(kubectl, namespace):
+    return [
+        pod
+        for pod in kubectl.list_pods(namespace).items
+        if (pod.metadata.labels or {}).get("app.kubernetes.io/name") == "kafka"
+        and pod.metadata.deletion_timestamp is None
+    ]
+
+
+def broker_memory_failure(kubectl, namespace, since):
+    """Find a new kernel OOM kill or Java heap failure, not an old restart."""
+    for pod in broker_pods(kubectl, namespace):
+        statuses = [status for status in pod.status.container_statuses or [] if status.name == "kafka"]
+        for status in statuses:
+            for state in (status.state, status.last_state):
+                terminated = state.terminated if state else None
+                if (
+                    terminated
+                    and terminated.reason == "OOMKilled"
+                    and terminated.finished_at
+                    and terminated.finished_at >= since
+                ):
+                    return True
+            previous = status.last_state.terminated if status.last_state else None
+            log_sources = []
+            if status.state and status.state.running:
+                log_sources.append(False)
+            if previous and previous.finished_at and previous.finished_at >= since:
+                log_sources.append(True)
+            for use_previous in log_sources:
+                command = shlex.join(
+                    [
+                        "kubectl",
+                        "logs",
+                        "-n",
+                        namespace,
+                        pod.metadata.name,
+                        "-c",
+                        "kafka",
+                        "--tail=200",
+                        "--since-time=" + since.isoformat(),
+                    ]
+                )
+                if use_previous:
+                    command += " --previous"
+                output = kubectl.exec_command_checked(command, timeout=15)
+                if "java.lang.OutOfMemoryError" in output:
+                    return True
+    return False
+
+
+class KafkaHealthCheck:
+    """Create a temporary client using the broker's already-required image.
+
+    Each check writes a fresh record and reads it back from a temporary topic.
+    The client's heap and native memory belong to its own container, not Kafka.
+    """
+
+    def __init__(self, kubectl, namespace):
+        self.kubectl = kubectl
+        self.namespace = namespace
+        self.name = "broker-healthcheck-" + uuid.uuid4().hex[:12]
+
+    def __enter__(self):
+        deployment = self.kubectl.get_deployment("kafka", self.namespace)
+        container = next(c for c in deployment.spec.template.spec.containers if c.name == "kafka")
+        pod = client.V1Pod(
+            metadata=client.V1ObjectMeta(name=self.name, labels={"app": "broker-healthcheck"}),
+            spec=client.V1PodSpec(
+                restart_policy="Never",
+                automount_service_account_token=False,
+                active_deadline_seconds=900,
+                containers=[
+                    client.V1Container(
+                        name="client",
+                        image=container.image,
+                        image_pull_policy="IfNotPresent",
+                        command=["sh", "-c", "sleep 900"],
+                        resources=client.V1ResourceRequirements(
+                            requests={"cpu": "25m", "memory": "64Mi"},
+                            limits={"memory": "256Mi"},
+                        ),
+                    )
+                ],
+            ),
+        )
+        self.kubectl.core_v1_api.create_namespaced_pod(self.namespace, pod)
+        try:
+            self.kubectl.exec_command_checked(
+                shlex.join(
+                    [
+                        "kubectl",
+                        "wait",
+                        "-n",
+                        self.namespace,
+                        "pod/" + self.name,
+                        "--for=condition=Ready",
+                        "--timeout=90s",
+                    ]
+                ),
+                timeout=95,
+            )
+        except BaseException:
+            self.__exit__(None, None, None)
+            raise
+        return self
+
+    def __exit__(self, *_):
+        # Namespace teardown is a second cleanup boundary if the API is down.
+        with contextlib.suppress(Exception):
+            self.kubectl.core_v1_api.delete_namespaced_pod(
+                self.name,
+                self.namespace,
+                grace_period_seconds=0,
+            )
+
+    def check(self):
+        token = uuid.uuid4().hex
+        topic = "healthchecks-" + token
+        script = f"""export KAFKA_HEAP_OPTS='-Xms16m -Xmx64m' KAFKA_OPTS=''
+printf 'request.timeout.ms=3000\ndefault.api.timeout.ms=5000\nretries=0\n' > /tmp/admin.properties
+cleanup() {{ /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --command-config /tmp/admin.properties --delete --if-exists --topic {topic} >/dev/null 2>&1; }}
+trap cleanup EXIT
+if ! /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --command-config /tmp/admin.properties --create --topic {topic} --partitions 1 --replication-factor 1; then
+    echo KAFKA_UNAVAILABLE; exit 0
+fi
+if ! printf '%s\\n' {token} | /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server kafka:9092 --topic {topic} --sync --producer-property max.block.ms=5000 --producer-property request.timeout.ms=3000 --producer-property delivery.timeout.ms=5000; then
+    echo KAFKA_UNAVAILABLE; exit 0
+fi
+if ! /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic {topic} --partition 0 --offset 0 --max-messages 1 --timeout-ms 5000; then
+    echo KAFKA_UNAVAILABLE; exit 0
+fi
+echo KAFKA_AVAILABLE
+"""
+        output = self.kubectl.exec_command_checked(
+            shlex.join(["kubectl", "exec", "-n", self.namespace, self.name, "-c", "client", "--", "sh", "-c", script]),
+            timeout=45,
+        )
+        lines = output.splitlines()
+        return "KAFKA_UNAVAILABLE" not in lines and "KAFKA_AVAILABLE" in lines and token in lines
+
+    def wait_until_available(self, timeout=60):
+        deadline = time.monotonic() + timeout
+        while True:
+            if self.check():
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(2)

--- a/tests/generators/test_kafka_producer_leak.py
+++ b/tests/generators/test_kafka_producer_leak.py
@@ -1,0 +1,189 @@
+import base64
+import copy
+import datetime
+import re
+from types import SimpleNamespace as NS
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes import client
+
+from sregym.conductor.oracles import kafka_producer_leak_mitigation as grading
+from sregym.generators.fault import inject_app
+from sregym.service import kafka_health
+
+
+def deployment(name):
+    container = client.V1Container(
+        name=name,
+        image="kafka-image:current",
+        env=[client.V1EnvVar(name="KAFKA_HEAP_OPTS", value="-Xmx400M -Xms400M")],
+        resources=client.V1ResourceRequirements(limits={"memory": "1Gi"}),
+    )
+    return NS(
+        spec=NS(
+            replicas=1,
+            selector=NS(match_labels={"app.kubernetes.io/name": name}),
+            template=NS(metadata=NS(annotations=None), spec=NS(containers=[container])),
+        )
+    )
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    state = NS(now=0)
+    monkeypatch.setattr(inject_app.time, "monotonic", lambda: state.now)
+    monkeypatch.setattr(inject_app.time, "sleep", lambda seconds: setattr(state, "now", state.now + seconds))
+    return state
+
+
+def kube():
+    kubectl = MagicMock()
+    resources = {name: deployment(name) for name in ("checkout", "kafka")}
+    kubectl.get_deployment.side_effect = lambda name, namespace: copy.deepcopy(resources[name])
+    kubectl.update_deployment.side_effect = lambda name, namespace, value: resources.__setitem__(
+        name, copy.deepcopy(value)
+    )
+    kubectl.list_pods.return_value = NS(items=[])
+    return kubectl, resources
+
+
+def test_injection_requires_memory_failure_and_failed_delivery(monkeypatch, clock):
+    kubectl, resources = kube()
+    injector = object.__new__(inject_app.ApplicationFaultInjector)
+    injector.namespace, injector.kubectl = "shop", kubectl
+    monkeypatch.setattr(inject_app, "broker_memory_failure", lambda *args: True)
+    probe = MagicMock()
+    probe.check.side_effect = [True, False]
+    assert injector._inject_kafka_producers("checkout", probe) == ["-Xmx400M -Xms400M", "1Gi"]
+    assert clock.now == 5
+    sidecar = resources["checkout"].spec.template.spec.containers[-1]
+    encoded = re.search(r"b64decode\('([^']+)'\)", sidecar.command[-1]).group(1)
+    source = base64.b64decode(encoded).decode()
+    assert "15728640" in source and "range(20)" in source and "producer.flush(10)" in source
+    assert "producer.produce('order-events', payload)" in source
+    assert "producer.produce('orders'," not in source
+    compile(source, "producer", "exec")
+
+
+def test_memory_errors_without_serving_failure_do_not_complete_injection(monkeypatch, clock):
+    kubectl, _ = kube()
+    injector = object.__new__(inject_app.ApplicationFaultInjector)
+    injector.namespace, injector.kubectl = "shop", kubectl
+    monkeypatch.setattr(inject_app, "broker_memory_failure", lambda *args: True)
+    with pytest.raises(TimeoutError, match="serving failure"):
+        injector._inject_kafka_producers("checkout", NS(check=lambda: True))
+    assert clock.now == 300
+
+
+@pytest.mark.parametrize("rollout_error", [False, True])
+def test_recovery_stops_producers_before_one_broker_rollout_and_restores_replicas(clock, rollout_error):
+    kubectl, resources = kube()
+    injector = object.__new__(inject_app.ApplicationFaultInjector)
+    injector.namespace, injector.kubectl = "shop", kubectl
+    resources["checkout"].spec.replicas = 2
+    resources["checkout"].spec.template.spec.containers.append(client.V1Container(name="order-creator"))
+    events = []
+    update = kubectl.update_deployment.side_effect
+
+    def record(name, namespace, value):
+        events.append((name, value.spec.replicas))
+        update(name, namespace, value)
+
+    kubectl.update_deployment.side_effect = record
+    old_pod = NS(
+        metadata=NS(labels={"app.kubernetes.io/name": "checkout"}),
+        spec=NS(containers=[client.V1Container(name="order-creator")]),
+    )
+    kubectl.list_pods.side_effect = [NS(items=[old_pod]), NS(items=[])]
+    if rollout_error:
+        kubectl.exec_command_checked.side_effect = RuntimeError("rollout failed")
+        with pytest.raises(RuntimeError, match="rollout failed"):
+            injector.recover_kafka_producer_leak()
+    else:
+        injector.recover_kafka_producer_leak()
+    assert events == [("checkout", 0), ("kafka", 1), ("checkout", 2)]
+    assert clock.now == 2
+    assert "kubectl.kubernetes.io/restartedAt" in resources["kafka"].spec.template.metadata.annotations
+    assert all(c.name != "order-creator" for c in resources["checkout"].spec.template.spec.containers)
+    assert len(kubectl.exec_command_checked.call_args_list) == 1
+
+
+@pytest.mark.parametrize("fresh,reason", [(True, "Error"), (False, "Error"), (True, "OOMKilled")])
+def test_fresh_previous_container_memory_failure(monkeypatch, fresh, reason):
+    now = datetime.datetime.now(datetime.UTC)
+    finished = now + datetime.timedelta(seconds=1 if fresh else -1)
+    terminated = NS(reason=reason, finished_at=finished)
+    status = NS(name="kafka", state=NS(running=None, terminated=None), last_state=NS(terminated=terminated))
+    pod = NS(metadata=NS(name="kafka-1"), status=NS(container_statuses=[status]))
+    monkeypatch.setattr(kafka_health, "broker_pods", lambda *args: [pod])
+    kubectl = MagicMock()
+    kubectl.exec_command_checked.return_value = "java.lang.OutOfMemoryError: Java heap space"
+    assert kafka_health.broker_memory_failure(kubectl, "shop", now) is fresh
+    if fresh and reason == "Error":
+        assert "--previous" in kubectl.exec_command_checked.call_args.args[0]
+    else:
+        kubectl.exec_command_checked.assert_not_called()
+
+
+def oracle(monkeypatch):
+    kubectl, resources = kube()
+    problem = NS(
+        kubectl=kubectl, namespace="shop", faulty_service="checkout", heap_limit="-Xmx400M -Xms400M", memory_limit="1Gi"
+    )
+    evaluator = grading.KafkaProducerLeakOracle(problem)
+    monkeypatch.setattr(grading.MitigationOracle, "evaluate", lambda self: {"success": True})
+    monkeypatch.setattr(evaluator, "_broker_restarts", lambda: {"uid-1": 0})
+    monkeypatch.setattr(grading, "broker_memory_failure", lambda *args: False)
+    probe = MagicMock()
+    probe.__enter__.return_value = probe
+    monkeypatch.setattr(grading, "KafkaHealthCheck", lambda *args: probe)
+    return evaluator, probe, resources
+
+
+def test_oracle_allows_startup_then_observes_full_window(monkeypatch, clock):
+    evaluator, probe, _ = oracle(monkeypatch)
+
+    def check():
+        return clock.now >= 10
+
+    probe.check.side_effect = check
+    assert evaluator.evaluate()["success"] is True
+    assert clock.now >= 130
+
+
+def test_oracle_rejects_running_broker_with_fresh_heap_failure(monkeypatch, clock):
+    evaluator, _, _ = oracle(monkeypatch)
+    monkeypatch.setattr(grading, "broker_memory_failure", lambda *args: True)
+    assert evaluator.evaluate()["reason"] == "fault_still_present"
+
+
+def test_oracle_rejects_unavailable_broker_after_startup_grace(monkeypatch, clock):
+    evaluator, probe, _ = oracle(monkeypatch)
+    probe.check.return_value = False
+    assert evaluator.evaluate()["reason"] == "kafka_not_serving"
+    assert clock.now == 60
+
+
+def test_oracle_rejects_removed_heap_limit(monkeypatch, clock):
+    evaluator, _, resources = oracle(monkeypatch)
+    resources["kafka"].spec.template.spec.containers[0].env = []
+    assert evaluator.evaluate()["reason"] == "fault_still_present"
+
+
+def test_client_pod_uses_same_image_separate_memory_and_is_deleted():
+    kubectl, _ = kube()
+    with kafka_health.KafkaHealthCheck(kubectl, "shop"):
+        pod = kubectl.core_v1_api.create_namespaced_pod.call_args.args[1]
+        assert pod.spec.containers[0].image == "kafka-image:current"
+        assert pod.spec.containers[0].resources.limits["memory"] == "256Mi"
+        assert pod.spec.automount_service_account_token is False
+    kubectl.core_v1_api.delete_namespaced_pod.assert_called_once()
+
+
+def test_client_pod_startup_error_still_deletes_pod():
+    kubectl, _ = kube()
+    kubectl.exec_command_checked.side_effect = RuntimeError("startup failed")
+    with pytest.raises(RuntimeError, match="startup failed"), kafka_health.KafkaHealthCheck(kubectl, "shop"):
+        pass
+    kubectl.core_v1_api.delete_namespaced_pod.assert_called_once()


### PR DESCRIPTION
Fixes #1015

/validate-problem kafka_poison_pill_hol_block

## What

Adds a `components.kafka.resources` override to `sregym/service/apps/values/astronomy-shop-fixes.yaml`:

```yaml
components:
  kafka:
    resources:
      requests:
        memory: 600Mi
      limits:
        memory: 1Gi
```

One file, no Python change — `AstronomyShop.deploy()` already applies this values file via `-f` (`sregym/service/apps/astronomy_shop.py:16,56-57`).

## Why

`KafkaFaultInjector._run` (`inject_kafka.py:184-208`) execs `kafka-topics.sh` and `kafka-consumer-groups.sh` **inside the running broker container**, and `kubectl exec` runs them in that container's own cgroup.

The vendored `opentelemetry-demo` chart declares limits only for `components.kafka` (600Mi) with no `requests`, so Kubernetes copies the limit into the request: the broker is capped and scheduled at 600Mi while `-Xms400M` commits a 400M heap up front. A second JVM needs ~100–150Mi RSS even at `-Xmx64m`, because `-Xmx` bounds the heap and not metaspace, code cache or thread stacks. It does not fit, so the kernel OOM-kills it (exit 137) and takes the broker with it.

The result is that `kafka_poison_pill_hol_block` has never injected its fault. See the issue for the full diagnosis, including container-restart telemetry showing zero restarts while the broker serves traffic normally and then a restart in precisely the bucket of each of the three deploy attempts.

## Why this shape

- **Pin `requests`, raise only `limits`.** The container is already *effectively* requesting 600Mi via limit-copying, so declaring it explicitly changes nothing about scheduling. Raising only the cap makes the extra 424Mi burst capacity — occupied for the few seconds an admin CLI runs, not reserved. Bumping the limit alone would also raise the request and add 424Mi of scheduled memory per deployment.
- **Override at install time rather than edit the chart.** The chart lives two submodules down and both values are stock upstream config, so an in-place edit would mean a PR per repo and would be reverted by the next upstream merge.

## Verification

`helm template` with and without the override differs by exactly two lines, with the rendered object count unchanged:

```
 resources:                       resources:
   limits:                          limits:
     memory: 600Mi        ->          memory: 1Gi
                                    requests:
                                      memory: 600Mi
```

Re-running the problem on a live cluster:

| | Before | After |
|---|---|---|
| Injection | failed 3/3, exit 137 | succeeded on first attempt |
| `kafka` container restarts | 1 per attempt | **0 for the whole run** |
| Fault-window spans / logs | 0 / 0 | 17,501 / 47,790 |
| Quiet-gap spans / logs | — | 0 / 0 |
| Deploy attempts consumed | 3 (all failed) | 1 |

The injector reports success where it previously died:

```
== Fault Injection: Kafka poison-pill HOL block ==
Poison record at offset 20 of topic 'orders-fulfillment'; consumer group 'orders-validator' will stall there.
```

and the fault is observable for the first time:

- `orders-validator` logs `ERROR partition remains paused at offset=20` at a fixed interval — **123 messages spanning the full fault window**, with no self-recovery.
- `order-stream` logs **899 `published order_id=...`** records over the same window.

That pair is the head-of-line block made visible: the producer keeps publishing while the consumer is frozen at offset 20, so lag grows without bound. Both workloads were absent from every previous run, because injection never got far enough to create them.

This change does not touch `sregym/conductor/problems/`, so the validation gate does not require it, but the `/validate-problem kafka_poison_pill_hol_block` line above opts in anyway. Our evidence comes from a `kubeadm` cluster on EC2; running validation on the CI kind cluster confirms the fix independently and in a different environment.

## Follow-up, not in this PR

A more robust fix is to stop exec-ing into the broker at all and run the admin CLI in a short-lived pod on the same Kafka image, pointed at `kafka:9092`. That removes the co-tenancy rather than budgeting around it, and makes the injector independent of the vendored chart's resource sizing. `inject_kafka.py` already creates its own Deployment for the pipeline workload, so the pattern exists in the same file. Kept separate so this fix stays reviewable as a one-block change.

## Note on the file header

This PR also drops one sentence from the header of `astronomy-shop-fixes.yaml` — *"Nothing here changes what an agent can observe; each entry removes work the collector was doing that could never succeed."* That was accurate while the file held only the collector entry, but this change touches no collector work and does change what an agent can observe, since it is what makes the fault injectable. Happy to reinstate it with different wording if you would rather keep a summary line there.
