### PR TITLE
Improve deployment rollout checkes

### DIFF
--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -42,6 +42,7 @@ from sregym.service.k8s_proxy import KubernetesAPIProxy
 from sregym.service.khaos import KhaosController
 from sregym.service.kubectl import KubeCtl
 from sregym.service.mcp_server import MCPServer
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.service.telemetry.loki import Loki
 from sregym.service.telemetry.prometheus import Prometheus
 
@@ -1526,13 +1527,12 @@ class Conductor:
         leave `openebs-device` permanently unbacked after switching back.
         """
         out = self.kubectl.exec_command(
-            "kubectl -n openebs get deployment openebs-localpv-provisioner "
-            "-o jsonpath='{.status.readyReplicas}' --ignore-not-found"
+            "kubectl -n openebs get deployment openebs-localpv-provisioner -o json --ignore-not-found"
         )
         try:
-            if int(out.strip()) < 1:
+            if not deployment_rollout_complete(json.loads(out)):
                 return False
-        except (ValueError, AttributeError):
+        except (ValueError, TypeError):
             return False
 
         if svelte:

--- a/sregym/conductor/oracles/admission_webhook_outage_mitigation.py
+++ b/sregym/conductor/oracles/admission_webhook_outage_mitigation.py
@@ -3,6 +3,7 @@ import time
 from kubernetes import client
 
 from sregym.conductor.oracles.base import Oracle
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class AdmissionWebhookOutageMitigationOracle(Oracle):
@@ -20,19 +21,7 @@ class AdmissionWebhookOutageMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/calico_route_reflector_mitigation.py
+++ b/sregym/conductor/oracles/calico_route_reflector_mitigation.py
@@ -11,6 +11,7 @@ from kubernetes.client.exceptions import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 _ROLLOUT_SETTLE_SECONDS = 180
 _ROLLOUT_POLL_INTERVAL = 5
@@ -80,13 +81,7 @@ class CalicoRouteReflectorMitigationOracle(Oracle):
             deployments = self.apps_v1.list_namespaced_deployment(namespace)
             all_settled = True
             for dep in deployments.items:
-                desired = dep.spec.replicas or 0
-                status = dep.status
-                if (
-                    (status.updated_replicas or 0) < desired
-                    or (status.ready_replicas or 0) < desired
-                    or (status.unavailable_replicas or 0) > 0
-                ):
+                if not deployment_rollout_complete(dep, allow_zero=True):
                     all_settled = False
                     break
             if all_settled:
@@ -114,8 +109,8 @@ class CalicoRouteReflectorMitigationOracle(Oracle):
             if desired < 1:
                 print(f"FAIL: Deployment '{namespace}/{name}' has {ready}/{desired} replicas ready")
                 return self.fail("required_deployment_scaled_to_zero", deployment=name, namespace=namespace)
-            if ready != desired:
-                print(f"FAIL: Deployment '{namespace}/{name}' has {ready}/{desired} replicas ready")
+            if not deployment_rollout_complete(deployment):
+                print(f"FAIL: Deployment '{namespace}/{name}' rollout is incomplete ({ready}/{desired} replicas ready)")
                 return self.fail(
                     "deployment_replicas_unready",
                     deployment=name,

--- a/sregym/conductor/oracles/cpu_throttling_mitigation.py
+++ b/sregym/conductor/oracles/cpu_throttling_mitigation.py
@@ -1,6 +1,7 @@
 import time
 
 from sregym.conductor.oracles.mitigation import MitigationOracle
+from sregym.service.rollout import deployment_rollout_complete
 
 _ROLLOUT_SETTLE_SECONDS = 60
 _ROLLOUT_POLL_INTERVAL = 5
@@ -27,16 +28,7 @@ class CpuThrottlingMitigationOracle(MitigationOracle):
 
     @staticmethod
     def _rollout_complete(deployment) -> bool:
-        desired = deployment.spec.replicas if deployment.spec.replicas is not None else 1
-        status = deployment.status
-        return (
-            desired > 0
-            and (status.observed_generation or 0) >= (deployment.metadata.generation or 0)
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_required_deployments(self) -> dict | None:
         if not self.replica_count:

--- a/sregym/conductor/oracles/cronjob_sidecar_mitigation.py
+++ b/sregym/conductor/oracles/cronjob_sidecar_mitigation.py
@@ -25,8 +25,8 @@ The oracle checks four independent properties:
 2. **Accumulated Jobs are gone.** Active Jobs created from the old regular-
    sidecar template are rejected. A small number of current-template Jobs may
    be active at a schedule boundary.
-3. **App still healthy.** Every Deployment in the namespace reports
-   ``ready_replicas == spec.replicas``. We check Deployment status directly
+3. **App still healthy.** Every Deployment in the namespace has completed
+   its current rollout. We check Deployment status directly
    rather than walking pods so ``Succeeded`` Job pods don't produce false
    negatives.
 4. **Current template works at runtime.** The oracle creates one fresh Job from
@@ -43,6 +43,7 @@ from kubernetes.client.exceptions import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 _ROLLOUT_SETTLE_SECONDS = 60
 _ROLLOUT_POLL_INTERVAL = 5
@@ -185,13 +186,7 @@ class CronJobSidecarBlocksCompletionMitigationOracle(Oracle):
             deployments = kubectl.list_deployments(namespace)
             all_settled = True
             for dep in deployments.items:
-                status = dep.status
-                desired = dep.spec.replicas or 1
-                if (
-                    (status.updated_replicas or 0) < desired
-                    or (status.ready_replicas or 0) < desired
-                    or (status.unavailable_replicas or 0) > 0
-                ):
+                if not deployment_rollout_complete(dep, allow_zero=True):
                     all_settled = False
                     break
             if all_settled:
@@ -324,12 +319,10 @@ class CronJobSidecarBlocksCompletionMitigationOracle(Oracle):
         return any(ref.kind == "CronJob" and ref.name == cronjob_name for ref in job.metadata.owner_references or [])
 
     def _unhealthy_deployment(self, namespace):
-        """Return the name of the first under-replicated Deployment, or None."""
+        """Return the first Deployment with an incomplete rollout, or None."""
         deployments = self.apps_v1.list_namespaced_deployment(namespace=namespace)
         for dep in deployments.items:
-            desired = dep.spec.replicas or 1
-            ready = dep.status.ready_replicas or 0
-            if ready < desired:
+            if not deployment_rollout_complete(dep):
                 return dep.metadata.name
         return None
 

--- a/sregym/conductor/oracles/cumulative_admission_webhook_timeout_mitigation.py
+++ b/sregym/conductor/oracles/cumulative_admission_webhook_timeout_mitigation.py
@@ -30,8 +30,8 @@ The oracle checks four properties in order:
    the fix must add the allow, not tear down the isolation. (Deleting
    only the baseline default-deny does not even work, because the other
    targeted allow policies still select and isolate the backends.)
-3. **Pod healthy.** The target deployment reports
-   ``ready_replicas == spec.replicas``; the Service has at least one
+3. **Pod healthy.** The target deployment has completed its current
+   rollout; the Service has at least one
    endpoint.
 4. **Fix verified at runtime.** A fresh probe pod is created in the
    application namespace and observed transitioning to Running within
@@ -50,6 +50,7 @@ from kubernetes.client.exceptions import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger(__name__)
 
@@ -287,11 +288,11 @@ class CumulativeAdmissionWebhookTimeoutMitigationOracle(Oracle):
         d = self.apps_v1.read_namespaced_deployment(name=target_deployment, namespace=app_namespace)
         desired = d.spec.replicas or 1
         ready = d.status.ready_replicas or 0
-        if ready < desired:
+        if not deployment_rollout_complete(d):
             return False, (
                 f"Deployment '{target_deployment}' in '{app_namespace}' shows "
                 f"ready_replicas={ready} (expected {desired}). The application is "
-                "still missing a replica; admission is likely still failing."
+                "rollout is incomplete."
             )
 
         # Service endpoints
@@ -369,11 +370,7 @@ class CumulativeAdmissionWebhookTimeoutMitigationOracle(Oracle):
             deployments = self.apps_v1.list_namespaced_deployment(namespace=namespace)
             settled = True
             for dep in deployments.items:
-                desired = dep.spec.replicas or 1
-                ready = dep.status.ready_replicas or 0
-                updated = dep.status.updated_replicas or 0
-                unavailable = dep.status.unavailable_replicas or 0
-                if ready < desired or updated < desired or unavailable > 0:
+                if not deployment_rollout_complete(dep):
                     # only block on the target; let the others settle in background
                     if dep.metadata.name == self.problem.TARGET_DEPLOYMENT:
                         settled = False

--- a/sregym/conductor/oracles/deployment_readiness.py
+++ b/sregym/conductor/oracles/deployment_readiness.py
@@ -7,7 +7,7 @@ absent from the namespace's pod list, so a per-pod health walk reports success
 because the remaining pods are healthy.
 
 This oracle reads the Deployment object directly and verifies its
-``ready_replicas`` matches ``spec.replicas`` — which works regardless of
+current rollout is complete — which works regardless of
 whether the missing pod is Pending, CrashLooping, or completely absent.
 It also walks the rest of the namespace's pods to catch crashloops or other
 downstream breakage the agent may have introduced.
@@ -17,6 +17,7 @@ import time
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 _ROLLOUT_SETTLE_SECONDS = 60
 _ROLLOUT_POLL_INTERVAL = 5
@@ -49,13 +50,7 @@ class DeploymentReadinessOracle(Oracle):
             deployments = kubectl.list_deployments(namespace)
             all_settled = True
             for dep in deployments.items:
-                status = dep.status
-                desired = dep.spec.replicas or 1
-                if (
-                    (status.updated_replicas or 0) < desired
-                    or (status.ready_replicas or 0) < desired
-                    or (status.unavailable_replicas or 0) > 0
-                ):
+                if not deployment_rollout_complete(dep, allow_zero=True):
                     all_settled = False
                     break
             if all_settled:
@@ -82,8 +77,8 @@ class DeploymentReadinessOracle(Oracle):
 
         desired = deployment.spec.replicas or 0
         ready = deployment.status.ready_replicas or 0
-        if ready != desired:
-            print(f"❌ Deployment '{deployment_name}' has {ready}/{desired} replicas ready")
+        if not deployment_rollout_complete(deployment):
+            print(f"❌ Deployment '{deployment_name}' rollout is incomplete ({ready}/{desired} replicas ready)")
             return self.fail(
                 "faulty_deployment_not_ready",
                 deployment=deployment_name,
@@ -94,6 +89,9 @@ class DeploymentReadinessOracle(Oracle):
 
         # Secondary check: the rest of the namespace is healthy (no agent-induced
         # collateral damage to other services).
+        for dep in kubectl.list_deployments(namespace).items:
+            if not deployment_rollout_complete(dep, allow_zero=True):
+                return self.fail("deployment_replicas_unready", deployment=dep.metadata.name, namespace=namespace)
         unready = self.pods_unready(kubectl.list_pods(namespace).items, namespace=namespace)
         if unready is not None:
             return unready

--- a/sregym/conductor/oracles/dns_resolution_mitigation.py
+++ b/sregym/conductor/oracles/dns_resolution_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class DNSResolutionMitigationOracle(Oracle):
@@ -16,21 +17,7 @@ class DNSResolutionMitigationOracle(Oracle):
 
     @staticmethod
     def _rollout_complete(deployment) -> bool:
-        desired = deployment.spec.replicas
-        if desired is None:
-            desired = 1
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/duplicate_pvc_mounts_mitigation.py
+++ b/sregym/conductor/oracles/duplicate_pvc_mounts_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class DuplicatePVCMountsMitigationOracle(Oracle):
@@ -24,20 +25,7 @@ class DuplicatePVCMountsMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/edge_request_filter_mitigation.py
+++ b/sregym/conductor/oracles/edge_request_filter_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class EdgeRequestFilterMitigationOracle(Oracle):
@@ -37,20 +38,7 @@ class EdgeRequestFilterMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/env_variable_shadowing_mitigation.py
+++ b/sregym/conductor/oracles/env_variable_shadowing_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class EnvVariableShadowingMitigationOracle(Oracle):
@@ -41,20 +42,7 @@ class EnvVariableShadowingMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/finalizer_deadlock_controller_mitigation.py
+++ b/sregym/conductor/oracles/finalizer_deadlock_controller_mitigation.py
@@ -8,6 +8,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class FinalizerDeadlockControllerMitigationOracle(Oracle):
@@ -106,17 +107,7 @@ class FinalizerDeadlockControllerMitigationOracle(Oracle):
             deployments = kubectl.list_deployments(namespace)
             all_settled = True
             for deployment in deployments.items:
-                desired = self._desired_replicas(deployment)
-                status = deployment.status
-                generation = deployment.metadata.generation or 0
-                if (
-                    desired < 1
-                    or (status.observed_generation or 0) < generation
-                    or (status.updated_replicas or 0) != desired
-                    or (status.ready_replicas or 0) != desired
-                    or (status.available_replicas or 0) != desired
-                    or (status.unavailable_replicas or 0) != 0
-                ):
+                if not deployment_rollout_complete(deployment):
                     all_settled = False
                     break
             if all_settled:
@@ -159,14 +150,7 @@ class FinalizerDeadlockControllerMitigationOracle(Oracle):
             return False, "[FAIL] Controller Deployment is scaled to zero."
 
         status = deployment.status
-        generation = deployment.metadata.generation or 0
-        healthy = (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        healthy = deployment_rollout_complete(deployment)
         if not healthy:
             return False, (
                 f"[FAIL] Controller Deployment is not fully rolled out ({status.ready_replicas or 0}/{desired} ready)."
@@ -241,6 +225,9 @@ class FinalizerDeadlockControllerMitigationOracle(Oracle):
 
     def _check_app_healthy(self, kubectl, namespace) -> tuple[bool, str]:
         try:
+            for deployment in kubectl.list_deployments(namespace).items:
+                if not deployment_rollout_complete(deployment):
+                    return False, f"[FAIL] Deployment `{deployment.metadata.name}` rollout is incomplete."
             pods = kubectl.list_pods(namespace).items
         except Exception as exc:
             return False, f"[FAIL] Could not list pods in `{namespace}`: {exc}"

--- a/sregym/conductor/oracles/hpa_control_plane_mitigation.py
+++ b/sregym/conductor/oracles/hpa_control_plane_mitigation.py
@@ -17,6 +17,7 @@ from json import JSONDecodeError
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 _DEFAULT_TIMEOUT_SECONDS = 60
 _DEFAULT_POLL_INTERVAL_SECONDS = 5
@@ -148,7 +149,7 @@ class HPAControlPlaneMitigationOracle(Oracle):
         if desired < 1:
             return False, f"Deployment/{self.deployment_name} has desired replicas={desired}; expected at least 1"
 
-        if ready < desired or updated < desired or unavailable:
+        if not deployment_rollout_complete(deployment):
             return False, (
                 f"Deployment/{self.deployment_name} rollout not ready: "
                 f"ready={ready}, updated={updated}, unavailable={unavailable}, desired={desired}"

--- a/sregym/conductor/oracles/incorrect_port.py
+++ b/sregym/conductor/oracles/incorrect_port.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class IncorrectPortAssignmentMitigationOracle(Oracle):
@@ -27,19 +28,7 @@ class IncorrectPortAssignmentMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/kubelet_eviction_threshold_misconfig_mitigation.py
+++ b/sregym/conductor/oracles/kubelet_eviction_threshold_misconfig_mitigation.py
@@ -1,6 +1,7 @@
 import re
 
 from sregym.conductor.oracles.mitigation import MitigationOracle
+from sregym.service.rollout import deployment_rollout_complete
 
 
 def _parse_config_threshold(value: str) -> float | None:
@@ -89,8 +90,8 @@ class KubeletEvictionThresholdMisconfigMitigationOracle(MitigationOracle):
         for dep in deployments.items:
             desired = dep.spec.replicas or 1
             ready = dep.status.ready_replicas or 0
-            if ready < desired:
-                print(f"❌ Deployment {dep.metadata.name}: {ready}/{desired} ready")
+            if not deployment_rollout_complete(dep):
+                print(f"❌ Deployment {dep.metadata.name}: incomplete rollout ({ready}/{desired} ready)")
                 all_ready = False
 
         if all_ready:

--- a/sregym/conductor/oracles/mitigation.py
+++ b/sregym/conductor/oracles/mitigation.py
@@ -2,6 +2,7 @@ import time
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 # Time to wait for deployments to settle after agent submission, so we
 # evaluate a stable state rather than a transient rolling-update window.
@@ -54,13 +55,7 @@ class MitigationOracle(Oracle):
             deployments = kubectl.list_deployments(namespace)
             all_settled = True
             for dep in deployments.items:
-                status = dep.status
-                desired = dep.spec.replicas if dep.spec.replicas is not None else 1
-                if (
-                    (status.updated_replicas or 0) < desired
-                    or (status.ready_replicas or 0) < desired
-                    or (status.unavailable_replicas or 0) > 0
-                ):
+                if not deployment_rollout_complete(dep, allow_zero=True):
                     all_settled = False
                     break
             if all_settled:
@@ -85,14 +80,16 @@ class MitigationOracle(Oracle):
             if name not in current_deps:
                 print(f"❌ Deployment '{name}' was deleted")
                 return self.fail("required_deployment_missing", deployment=name, namespace=namespace)
-            dep = current_deps[name]
+        # Recheck after settling: a timeout must not turn an incomplete rollout
+        # into a pass. Include Deployments added after the baseline as well.
+        for name, dep in current_deps.items():
             desired = dep.spec.replicas if dep.spec.replicas is not None else 1
-            if desired == 0:
+            if desired == 0 and name in self.replica_count:
                 print(f"❌ Deployment '{name}' was scaled to 0")
                 return self.fail("required_deployment_scaled_to_zero", deployment=name, namespace=namespace)
-            ready = dep.status.ready_replicas or 0
-            if ready < desired:
-                print(f"❌ Deployment '{name}' has {ready}/{desired} replicas ready")
+            ready = getattr(dep.status, "ready_replicas", None) or 0
+            if not deployment_rollout_complete(dep, allow_zero=name not in self.replica_count):
+                print(f"❌ Deployment '{name}' rollout is incomplete ({ready}/{desired} replicas ready)")
                 return self.fail(
                     "deployment_replicas_unready",
                     deployment=name,

--- a/sregym/conductor/oracles/mutating_webhook_resource_limits_mitigation.py
+++ b/sregym/conductor/oracles/mutating_webhook_resource_limits_mitigation.py
@@ -5,6 +5,7 @@ from kubernetes.utils.quantity import parse_quantity
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class MutatingWebhookResourceLimitsMitigationOracle(Oracle):
@@ -23,19 +24,7 @@ class MutatingWebhookResourceLimitsMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/namespace_memory_limit_mitigation.py
+++ b/sregym/conductor/oracles/namespace_memory_limit_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class NamespaceMemoryLimitMitigationOracle(Oracle):
@@ -25,20 +26,7 @@ class NamespaceMemoryLimitMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/network_policy_oracle.py
+++ b/sregym/conductor/oracles/network_policy_oracle.py
@@ -5,6 +5,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class NetworkPolicyMitigationOracle(Oracle):
@@ -22,20 +23,7 @@ class NetworkPolicyMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/priority_preemption_mitigation.py
+++ b/sregym/conductor/oracles/priority_preemption_mitigation.py
@@ -8,6 +8,7 @@ from kubernetes.utils.quantity import parse_quantity
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 _ROLLOUT_SETTLE_SECONDS = 60
 _ROLLOUT_POLL_INTERVAL = 5
@@ -54,13 +55,7 @@ class PriorityPreemptionMitigationOracle(Oracle):
             deployments = self.apps_v1.list_namespaced_deployment(namespace)
             all_settled = True
             for dep in deployments.items:
-                desired = dep.spec.replicas or 0
-                status = dep.status
-                if (
-                    (status.updated_replicas or 0) < desired
-                    or (status.ready_replicas or 0) < desired
-                    or (status.unavailable_replicas or 0) > 0
-                ):
+                if not deployment_rollout_complete(dep, allow_zero=True):
                     all_settled = False
                     break
             if all_settled:
@@ -97,8 +92,8 @@ class PriorityPreemptionMitigationOracle(Oracle):
         if desired < 1:
             print(f"❌ Deployment '{name}' has invalid desired replica count: {desired}")
             return self.fail("invalid_replica_count", deployment=name, desired=desired), deployment
-        if ready != desired:
-            print(f"❌ Deployment '{name}' has {ready}/{desired} replicas ready")
+        if not deployment_rollout_complete(deployment):
+            print(f"❌ Deployment '{name}' rollout is incomplete ({ready}/{desired} replicas ready)")
             return (
                 self.fail("deployment_replicas_unready", deployment=name, ready=ready, desired=desired),
                 deployment,
@@ -125,8 +120,8 @@ class PriorityPreemptionMitigationOracle(Oracle):
             if desired < 1:
                 print(f"❌ Deployment '{name}' was scaled below one replica")
                 return self.fail("required_deployment_scaled_to_zero", deployment=name)
-            if ready != desired:
-                print(f"❌ Deployment '{name}' has {ready}/{desired} replicas ready")
+            if not deployment_rollout_complete(deployment):
+                print(f"❌ Deployment '{name}' rollout is incomplete ({ready}/{desired} replicas ready)")
                 return self.fail("deployment_replicas_unready", deployment=name, ready=ready, desired=desired)
         return None
 

--- a/sregym/conductor/oracles/readiness_probe_mitigation.py
+++ b/sregym/conductor/oracles/readiness_probe_mitigation.py
@@ -5,6 +5,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class ReadinessProbeMitigationOracle(Oracle):
@@ -23,19 +24,7 @@ class ReadinessProbeMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/rolling_update_misconfiguration_mitigation.py
+++ b/sregym/conductor/oracles/rolling_update_misconfiguration_mitigation.py
@@ -9,6 +9,7 @@ import yaml
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class RollingUpdateMitigationOracle(Oracle):
@@ -85,19 +86,7 @@ class RollingUpdateMitigationOracle(Oracle):
 
     @staticmethod
     def _rollout_complete(deployment: dict) -> bool:
-        metadata = deployment.get("metadata") or {}
-        spec = deployment.get("spec") or {}
-        status = deployment.get("status") or {}
-        generation = metadata.get("generation", 0)
-        replicas = spec.get("replicas", 1)
-
-        return (
-            status.get("observedGeneration", 0) >= generation
-            and status.get("updatedReplicas", 0) == replicas
-            and status.get("readyReplicas", 0) == replicas
-            and status.get("availableReplicas", 0) == replicas
-            and status.get("unavailableReplicas", 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _rollout_failed(self, minimum_generation: int, *, require_continuous_availability: bool) -> dict | None:
         """Return a verdict if the rollout did not complete cleanly, else None.

--- a/sregym/conductor/oracles/scale_pod_zero_mitigation.py
+++ b/sregym/conductor/oracles/scale_pod_zero_mitigation.py
@@ -1,4 +1,5 @@
 from sregym.conductor.oracles.base import Oracle
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class ScalePodZeroMitigationOracle(Oracle):
@@ -23,7 +24,7 @@ class ScalePodZeroMitigationOracle(Oracle):
             desired_replicas = deployment.spec.replicas
             available_replicas = deployment.status.available_replicas
 
-            if desired_replicas != 1 or available_replicas != 1:
+            if desired_replicas != 1 or not deployment_rollout_complete(deployment):
                 print(
                     f"Faulty service {faulty_service} has {available_replicas} available replicas out of {desired_replicas} desired"
                 )

--- a/sregym/conductor/oracles/search_rate_retry_mitigation.py
+++ b/sregym/conductor/oracles/search_rate_retry_mitigation.py
@@ -8,6 +8,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class SearchRateRetryMitigationOracle(Oracle):
@@ -56,16 +57,7 @@ class SearchRateRetryMitigationOracle(Oracle):
 
     @staticmethod
     def _rollout_complete(deployment) -> bool:
-        desired = deployment.spec.replicas if deployment.spec.replicas is not None else 1
-        status = deployment.status
-        return desired >= 1 and (
-            (status.observed_generation or 0) >= (deployment.metadata.generation or 0)
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _cluster_shape_unhealthy(self) -> dict | None:
         try:

--- a/sregym/conductor/oracles/secret_rotation_stale_env_mitigation.py
+++ b/sregym/conductor/oracles/secret_rotation_stale_env_mitigation.py
@@ -9,6 +9,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger(__name__)
 
@@ -45,20 +46,7 @@ class SecretRotationStaleEnvMitigation(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-
-        generation = deployment.metadata.generation or 0
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == desired
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/service_endpoint_mitigation.py
+++ b/sregym/conductor/oracles/service_endpoint_mitigation.py
@@ -6,6 +6,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class ServiceEndpointMitigationOracle(Oracle):
@@ -37,17 +38,7 @@ class ServiceEndpointMitigationOracle(Oracle):
 
     @classmethod
     def _rollout_complete(cls, deployment) -> bool:
-        desired = cls._desired_replicas(deployment)
-        if desired < 1:
-            return False
-        status = deployment.status
-        return (
-            (status.observed_generation or 0) >= (deployment.metadata.generation or 0)
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/oracles/valkey_auth_mitigation.py
+++ b/sregym/conductor/oracles/valkey_auth_mitigation.py
@@ -1,5 +1,6 @@
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class ValkeyAuthMitigation(Oracle):
@@ -73,7 +74,7 @@ class ValkeyAuthMitigation(Oracle):
             if desired_replicas < 1:
                 print("❌ Cart deployment is scaled to zero")
                 return self.fail("required_deployment_scaled_to_zero", deployment="cart")
-            if available_replicas < desired_replicas:
+            if not deployment_rollout_complete(cart):
                 print(
                     f"❌ Cart deployment has not recovered: {available_replicas}/{desired_replicas} replicas available."
                 )

--- a/sregym/conductor/oracles/wrong_pod_selection_mitigation.py
+++ b/sregym/conductor/oracles/wrong_pod_selection_mitigation.py
@@ -8,6 +8,7 @@ from kubernetes.client.rest import ApiException
 
 from sregym.conductor.oracles.base import Oracle
 from sregym.conductor.oracles.failure import FailureClass
+from sregym.service.rollout import deployment_rollout_complete
 
 
 class WrongPodSelectionMitigationOracle(Oracle):
@@ -34,21 +35,7 @@ class WrongPodSelectionMitigationOracle(Oracle):
 
     @staticmethod
     def _rollout_complete(deployment) -> bool:
-        desired = deployment.spec.replicas
-        if desired is None:
-            desired = 1
-        if desired < 1:
-            return False
-
-        status = deployment.status
-        generation = deployment.metadata.generation or 0
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_current_rollout(self, deployment):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/problems/calico_route_reflector_label_drift.py
+++ b/sregym/conductor/problems/calico_route_reflector_label_drift.py
@@ -25,6 +25,7 @@ from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsA
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 
@@ -312,11 +313,7 @@ class CalicoRouteReflectorLabelDriftHotelReservation(Problem):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             deployment = self.apps_v1.read_namespaced_deployment(name=name, namespace=namespace)
-            desired = deployment.spec.replicas or 0
-            ready = deployment.status.ready_replicas or 0
-            updated = deployment.status.updated_replicas or 0
-            unavailable = deployment.status.unavailable_replicas or 0
-            if desired > 0 and ready == desired and updated == desired and unavailable == 0:
+            if deployment_rollout_complete(deployment):
                 return
             time.sleep(2)
         raise TimeoutError(f"Timed out waiting for deployment {namespace}/{name} to become ready")

--- a/sregym/conductor/problems/cumulative_admission_webhook_timeout_hotel_reservation.py
+++ b/sregym/conductor/problems/cumulative_admission_webhook_timeout_hotel_reservation.py
@@ -60,6 +60,7 @@ from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsA
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 logger = logging.getLogger(__name__)
@@ -866,13 +867,11 @@ srv.serve_forever()
                 raise
 
     def _wait_for_deployment_ready(self, name: str, namespace: str, timeout_s: int) -> None:
-        """Block until the deployment reports ready_replicas == spec.replicas."""
+        """Block until the Deployment completes its current rollout."""
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
             d = self.apps_v1.read_namespaced_deployment(name=name, namespace=namespace)
-            desired = d.spec.replicas or 1
-            ready = d.status.ready_replicas or 0
-            if ready >= desired:
+            if deployment_rollout_complete(d):
                 return
             time.sleep(2)
         raise RuntimeError(f"deployment '{name}' in '{namespace}' did not become Available in {timeout_s}s")
@@ -1198,9 +1197,7 @@ srv.serve_forever()
         deadline = time.monotonic() + self.RECOVERY_TIMEOUT_S
         while time.monotonic() < deadline:
             d = self.apps_v1.read_namespaced_deployment(name=self.TARGET_DEPLOYMENT, namespace=self.namespace)
-            desired = d.spec.replicas or 1
-            ready = d.status.ready_replicas or 0
-            if ready >= desired:
+            if deployment_rollout_complete(d):
                 return
             time.sleep(self.RECOVERY_POLL_INTERVAL_S)
         raise RuntimeError(

--- a/sregym/conductor/problems/finalizer_deadlock_controller.py
+++ b/sregym/conductor/problems/finalizer_deadlock_controller.py
@@ -13,6 +13,7 @@ from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsA
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 _CONTROLLER_NAME = "cleanup-controller"
@@ -434,7 +435,7 @@ class FinalizerDeadlockController(Problem):
                 self.namespace,
                 _request_timeout=10,
             )
-            if (dep.status.ready_replicas or 0) >= 1:
+            if deployment_rollout_complete(dep):
                 return
             time.sleep(2)
         raise TimeoutError(f"Timed out waiting for Deployment `{self.controller_name}` to become ready")

--- a/sregym/conductor/problems/namespace_memory_limit.py
+++ b/sregym/conductor/problems/namespace_memory_limit.py
@@ -5,6 +5,7 @@ from sregym.conductor.oracles.namespace_memory_limit_mitigation import Namespace
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 
@@ -51,16 +52,7 @@ class NamespaceMemoryLimit(Problem):
         if cls._desired_replicas(deployment) != expected:
             return False
 
-        status = deployment.status
-        generation = deployment.metadata.generation or 0
-        return (
-            (status.observed_generation or 0) >= generation
-            and (status.replicas or 0) == expected
-            and (status.updated_replicas or 0) == expected
-            and (status.ready_replicas or 0) == expected
-            and (status.available_replicas or 0) == expected
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment, allow_zero=True)
 
     def _wait_for_rollout(self, expected_replicas: int):
         deadline = time.monotonic() + self.rollout_timeout_seconds

--- a/sregym/conductor/problems/node_conntrack_exhaustion.py
+++ b/sregym/conductor/problems/node_conntrack_exhaustion.py
@@ -14,6 +14,7 @@ from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsA
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 
@@ -253,8 +254,8 @@ class NodeConntrackExhaustionHotelReservation(Problem):
     def _wait_for_deployment(self, name: str, replicas: int, timeout: int = 180):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            status = self.apps_v1.read_namespaced_deployment(name, self.namespace).status
-            if (status.available_replicas or 0) >= replicas:
+            deployment = self.apps_v1.read_namespaced_deployment(name, self.namespace)
+            if deployment.spec.replicas == replicas and deployment_rollout_complete(deployment, allow_zero=True):
                 return
             time.sleep(2)
         raise RuntimeError(f"Deployment {name} did not become ready")

--- a/sregym/conductor/problems/priority_preemption_cascade.py
+++ b/sregym/conductor/problems/priority_preemption_cascade.py
@@ -25,6 +25,7 @@ from sregym.conductor.oracles.priority_preemption_mitigation import PriorityPree
 from sregym.conductor.problems.base import Problem
 from sregym.service.apps.hotel_reservation import HotelReservation
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 from sregym.utils.decorators import mark_fault_injected
 
 
@@ -167,21 +168,7 @@ class PriorityPreemptionCascadeHotelReservation(Problem):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             deployment = self.apps_v1.read_namespaced_deployment(name=name, namespace=namespace)
-            desired = deployment.spec.replicas or 0
-            observed = deployment.status.observed_generation or 0
-            generation = deployment.metadata.generation or 0
-            updated = deployment.status.updated_replicas or 0
-            ready = deployment.status.ready_replicas or 0
-            available = deployment.status.available_replicas or 0
-            unavailable = deployment.status.unavailable_replicas or 0
-            if (
-                desired > 0
-                and observed >= generation
-                and updated == desired
-                and ready == desired
-                and available == desired
-                and unavailable == 0
-            ):
+            if deployment_rollout_complete(deployment):
                 return deployment
             time.sleep(2)
         raise TimeoutError(f"Timed out waiting for deployment {namespace}/{name} to become ready")

--- a/sregym/generators/fault/inject_kafka.py
+++ b/sregym/generators/fault/inject_kafka.py
@@ -10,6 +10,7 @@ from kubernetes import client
 
 from sregym.generators.fault.base import FaultInjector
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger("all.sregym.inject_kafka")
 logger.propagate = True
@@ -568,8 +569,7 @@ class KafkaFaultInjector(FaultInjector):
         deadline = time.time() + timeout
         while time.time() < deadline:
             dep = api.read_namespaced_deployment(name, self.namespace)
-            desired = dep.spec.replicas or 1
-            if (dep.status.ready_replicas or 0) >= desired:
+            if deployment_rollout_complete(dep):
                 logger.info("[Kafka pipeline] Deployment '%s' is ready", name)
                 return
             time.sleep(5)

--- a/sregym/generators/fault/inject_virtual.py
+++ b/sregym/generators/fault/inject_virtual.py
@@ -14,6 +14,7 @@ from sregym.generators.fault.base import FaultInjector
 from sregym.paths import CACHE_DIR, TARGET_MICROSERVICES
 from sregym.service.helm import Helm
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 
 DAEMON_SET_RECOVERY_STATE_DIR = CACHE_DIR / "daemon_set_recovery"
 
@@ -648,16 +649,7 @@ class VirtualizationFaultInjector(FaultInjector):
 
     @staticmethod
     def _deployment_rollout_complete(deployment) -> bool:
-        desired = deployment.spec.replicas if deployment.spec.replicas is not None else 1
-        status = deployment.status
-        return (
-            desired > 0
-            and (status.observed_generation or 0) >= (deployment.metadata.generation or 0)
-            and (status.updated_replicas or 0) == desired
-            and (status.ready_replicas or 0) == desired
-            and (status.available_replicas or 0) == desired
-            and (status.unavailable_replicas or 0) == 0
-        )
+        return deployment_rollout_complete(deployment)
 
     def _wait_for_services_ready(
         self,
@@ -1899,20 +1891,7 @@ class VirtualizationFaultInjector(FaultInjector):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             deployment = self.kubectl.apps_v1_api.read_namespaced_deployment(service, self.namespace)
-            desired = deployment.spec.replicas
-            if desired is None:
-                desired = 1
-
-            status = deployment.status
-            generation = deployment.metadata.generation or 0
-            if (
-                desired > 0
-                and (status.observed_generation or 0) >= generation
-                and (status.updated_replicas or 0) == desired
-                and (status.ready_replicas or 0) == desired
-                and (status.available_replicas or 0) == desired
-                and (status.unavailable_replicas or 0) == 0
-            ):
+            if deployment_rollout_complete(deployment):
                 return
 
             time.sleep(sleep)

--- a/sregym/generators/workload/trainticket_locust.py
+++ b/sregym/generators/workload/trainticket_locust.py
@@ -4,11 +4,13 @@ Extends the base LocustWorkloadManager to provide TrainTicket-specific
 workload generation capabilities.
 """
 
+import json
 import logging
 from typing import Any
 
 from sregym.generators.workload.locust import LocustWorkloadManager
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger(__name__)
 
@@ -121,11 +123,9 @@ class TrainTicketLocustWorkloadManager(LocustWorkloadManager):
         """
         try:
             # Check if Locust master is running
-            result = self.kubectl.exec_command(
-                f"kubectl get deployment locust-master -n {self.namespace} -o jsonpath='{{.status.readyReplicas}}'"
-            )
+            result = self.kubectl.exec_command(f"kubectl get deployment locust-master -n {self.namespace} -o json")
 
-            return result == "1"
+            return deployment_rollout_complete(json.loads(result))
 
         except Exception as e:
             logger.error(f"Error checking Locust readiness: {e}")

--- a/sregym/observer/ingress_nginx.py
+++ b/sregym/observer/ingress_nginx.py
@@ -1,6 +1,9 @@
+import json
 import logging
 import subprocess
 import time
+
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger("all.sregym.ingress_nginx")
 
@@ -38,11 +41,8 @@ class IngressNginx:
         t0 = time.time()
         while time.time() - t0 < timeout:
             try:
-                out = self.run_cmd(
-                    f"kubectl -n {self.namespace} get deployment ingress-nginx-controller "
-                    f"-o jsonpath='{{.status.readyReplicas}}'"
-                )
-                if out.strip("'") == "1":
+                out = self.run_cmd(f"kubectl -n {self.namespace} get deployment ingress-nginx-controller -o json")
+                if deployment_rollout_complete(json.loads(out)):
                     return
             except Exception:
                 pass

--- a/sregym/observer/otel_collector/otel_collector.py
+++ b/sregym/observer/otel_collector/otel_collector.py
@@ -1,7 +1,10 @@
+import json
 import logging
 import subprocess
 import time
 from pathlib import Path
+
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger("all.sregym.otel_collector")
 
@@ -46,10 +49,8 @@ class OtelCollector:
         t0 = time.time()
         while time.time() - t0 < timeout:
             try:
-                out = self.run_cmd(
-                    f"kubectl -n {self.namespace} get deployment otel-collector -o jsonpath='{{.status.readyReplicas}}'"
-                )
-                if out.strip("'") == "1":
+                out = self.run_cmd(f"kubectl -n {self.namespace} get deployment otel-collector -o json")
+                if deployment_rollout_complete(json.loads(out)):
                     return
             except Exception:
                 pass

--- a/sregym/service/mcp_server.py
+++ b/sregym/service/mcp_server.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import signal
@@ -9,6 +10,7 @@ import requests
 
 from sregym.paths import MCP_SERVER_K8S
 from sregym.service.kubectl import KubeCtl
+from sregym.service.rollout import deployment_rollout_complete
 
 logger = logging.getLogger("all.sregym.mcp_server")
 
@@ -27,13 +29,14 @@ class MCPServer:
     def _is_running(self) -> bool:
         """Check if the MCP server deployment already exists and is ready."""
         result = self.kubectl.exec_command(
-            f"kubectl get deployment {self.service_name} -n {self.namespace} "
-            f"--ignore-not-found -o jsonpath='{{.status.readyReplicas}}'"
+            f"kubectl get deployment {self.service_name} -n {self.namespace} --ignore-not-found -o json"
         )
-        value = result.strip().strip("'")
         # exec_command returns stderr on failure (e.g. "Error from server (NotFound)"),
-        # so only treat a purely numeric positive value as "running".
-        return value.isdigit() and int(value) > 0
+        # so an empty or non-JSON response is not a healthy Deployment.
+        try:
+            return deployment_rollout_complete(json.loads(result))
+        except (ValueError, TypeError):
+            return False
 
     def _ensure_rbac(self):
         """Ensure RBAC resources exist even if the MCP server pod is already running."""

--- a/sregym/service/rollout.py
+++ b/sregym/service/rollout.py
@@ -1,0 +1,45 @@
+"""Deployment rollout checks shared by setup, recovery, and mitigation grading."""
+
+from collections.abc import Mapping
+
+
+def _field(resource, attribute: str, json_key: str | None = None):
+    if isinstance(resource, Mapping):
+        return resource.get(json_key or attribute)
+    return getattr(resource, attribute, None)
+
+
+def deployment_rollout_complete(deployment, *, allow_zero: bool = False) -> bool:
+    """Check the current generation, not just surviving Ready pods.
+
+    Accept a Kubernetes client Deployment or its API JSON representation.
+    Every desired replica must be updated, Ready, and Available, with no extra
+    old replicas. Missing status and resources pending deletion fail closed.
+    Setup/recovery can explicitly allow a completed scale-down to zero; an
+    application required by a mitigation oracle must have at least one replica.
+    """
+    metadata = _field(deployment, "metadata")
+    spec = _field(deployment, "spec")
+    status = _field(deployment, "status")
+    if metadata is None or spec is None or status is None:
+        return False
+    if _field(metadata, "deletion_timestamp", "deletionTimestamp") is not None:
+        return False
+
+    desired = _field(spec, "replicas")
+    desired = 1 if desired is None else desired
+    if desired < (0 if allow_zero else 1):
+        return False
+
+    generation = _field(metadata, "generation")
+    observed = _field(status, "observed_generation", "observedGeneration")
+    if generation is None or observed is None or observed < generation:
+        return False
+
+    return (
+        (_field(status, "replicas") or 0) == desired
+        and (_field(status, "updated_replicas", "updatedReplicas") or 0) == desired
+        and (_field(status, "ready_replicas", "readyReplicas") or 0) == desired
+        and (_field(status, "available_replicas", "availableReplicas") or 0) == desired
+        and (_field(status, "unavailable_replicas", "unavailableReplicas") or 0) == 0
+    )

--- a/tests/generators/test_rolling_update_recovery.py
+++ b/tests/generators/test_rolling_update_recovery.py
@@ -31,6 +31,7 @@ class _InjectionKubeCtl:
             metadata=SimpleNamespace(generation=1),
             spec=SimpleNamespace(replicas=3),
             status=SimpleNamespace(
+                replicas=3,
                 observed_generation=1,
                 updated_replicas=3,
                 ready_replicas=3,

--- a/tests/oracles/test_admission_webhook_outage_mitigation.py
+++ b/tests/oracles/test_admission_webhook_outage_mitigation.py
@@ -19,6 +19,7 @@ def _deployment(
         metadata=SimpleNamespace(name="recommendation", generation=generation),
         spec=SimpleNamespace(replicas=replicas),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=updated,
             ready_replicas=ready,

--- a/tests/oracles/test_cpu_throttling_mitigation.py
+++ b/tests/oracles/test_cpu_throttling_mitigation.py
@@ -35,6 +35,7 @@ def _deployment(
             ),
         ),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=updated,
             ready_replicas=ready,

--- a/tests/oracles/test_dns_resolution_mitigation.py
+++ b/tests/oracles/test_dns_resolution_mitigation.py
@@ -33,6 +33,7 @@ def _deployment(
         metadata=SimpleNamespace(name=name, generation=generation),
         spec=SimpleNamespace(replicas=replicas, template=SimpleNamespace(spec=pod_spec)),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=updated,
             ready_replicas=ready,

--- a/tests/oracles/test_failure_regressions.py
+++ b/tests/oracles/test_failure_regressions.py
@@ -244,8 +244,15 @@ def test_hpa_transient_errors_do_not_bypass_consecutive_healthy_polls(monkeypatc
 def test_hpa_nested_observations_propagate_command_errors(monkeypatch, failure_at):
     oracle = _hpa_with_clock(monkeypatch, timeout=0)
     deployment = {
+        "metadata": {"generation": 1},
         "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "frontend"}}},
-        "status": {"readyReplicas": 1, "updatedReplicas": 1},
+        "status": {
+            "observedGeneration": 1,
+            "replicas": 1,
+            "readyReplicas": 1,
+            "updatedReplicas": 1,
+            "availableReplicas": 1,
+        },
     }
     pods = {"items": [{"metadata": {"name": "frontend-1"}, "status": {"phase": "Running"}}]}
     responses = [json.dumps(deployment), json.dumps(pods), '{"items": []}']

--- a/tests/oracles/test_finalizer_deadlock_controller_mitigation.py
+++ b/tests/oracles/test_finalizer_deadlock_controller_mitigation.py
@@ -16,6 +16,7 @@ def _deployment(*, replicas=1, ready=1, generation=2, observed_generation=2):
         metadata=SimpleNamespace(name="cleanup-controller", generation=generation),
         spec=SimpleNamespace(replicas=replicas),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=ready,
             ready_replicas=ready,

--- a/tests/oracles/test_incorrect_port_assignment_mitigation.py
+++ b/tests/oracles/test_incorrect_port_assignment_mitigation.py
@@ -33,6 +33,7 @@ def _deployment(
         metadata=SimpleNamespace(name="checkout", generation=generation),
         spec=SimpleNamespace(replicas=replicas, template=template),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=updated,
             ready_replicas=ready,

--- a/tests/oracles/test_mitigation_oracle_baseline.py
+++ b/tests/oracles/test_mitigation_oracle_baseline.py
@@ -30,9 +30,12 @@ def _deployment(name, *, replicas=1, ready=None, updated=None, unavailable=0):
     ready = replicas if ready is None else ready
     updated = replicas if updated is None else updated
     return SimpleNamespace(
-        metadata=SimpleNamespace(name=name),
+        metadata=SimpleNamespace(generation=1, name=name),
         spec=SimpleNamespace(replicas=replicas),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
+            observed_generation=1,
+            available_replicas=ready,
             updated_replicas=updated,
             ready_replicas=ready,
             unavailable_replicas=unavailable,

--- a/tests/oracles/test_mutating_webhook_resource_limits_mitigation.py
+++ b/tests/oracles/test_mutating_webhook_resource_limits_mitigation.py
@@ -90,6 +90,7 @@ def _deployment(
             template=SimpleNamespace(spec=SimpleNamespace(containers=[_container(request=request, limit=limit)])),
         ),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=updated,
             ready_replicas=ready,

--- a/tests/oracles/test_priority_preemption_mitigation.py
+++ b/tests/oracles/test_priority_preemption_mitigation.py
@@ -23,7 +23,7 @@ def _oracle():
 
 def _deployment(name, replicas=1, ready=1, priority_class=None, memory="512Mi"):
     return SimpleNamespace(
-        metadata=SimpleNamespace(name=name),
+        metadata=SimpleNamespace(generation=1, name=name),
         spec=SimpleNamespace(
             replicas=replicas,
             template=SimpleNamespace(
@@ -39,7 +39,13 @@ def _deployment(name, replicas=1, ready=1, priority_class=None, memory="512Mi"):
                 )
             ),
         ),
-        status=SimpleNamespace(ready_replicas=ready),
+        status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
+            observed_generation=1,
+            updated_replicas=1 if replicas is None else replicas,
+            available_replicas=ready,
+            ready_replicas=ready,
+        ),
     )
 
 

--- a/tests/oracles/test_readiness_probe_mitigation.py
+++ b/tests/oracles/test_readiness_probe_mitigation.py
@@ -118,7 +118,8 @@ def _oracle(kubectl):
 
 def test_accepts_current_endpoint_while_ignoring_old_failed_and_unrelated_pods():
     core_v1 = _CoreV1()
-    deployment = _deployment(total_replicas=2)
+    # Terminal pods are not counted in Deployment.status.replicas.
+    deployment = _deployment(total_replicas=1)
     pods = [
         _pod("user-current", "user-current-rs"),
         _pod("user-old-error", "user-old-rs", phase="Failed"),
@@ -137,6 +138,14 @@ def test_accepts_current_endpoint_while_ignoring_old_failed_and_unrelated_pods()
 def test_rejects_injected_not_ready_rollout_without_starting_check():
     core_v1 = _CoreV1()
     deployment = _deployment(total_replicas=1, updated=1, ready=0, available=0, unavailable=1)
+
+    assert _oracle(_KubeCtl(deployment=deployment, core_v1=core_v1)).evaluate()["success"] is False
+    assert core_v1.created_pods == []
+
+
+def test_rejects_extra_nonterminal_old_replica_without_starting_check():
+    core_v1 = _CoreV1()
+    deployment = _deployment(total_replicas=2)
 
     assert _oracle(_KubeCtl(deployment=deployment, core_v1=core_v1)).evaluate()["success"] is False
     assert core_v1.created_pods == []

--- a/tests/oracles/test_rolling_update_misconfiguration_mitigation.py
+++ b/tests/oracles/test_rolling_update_misconfiguration_mitigation.py
@@ -45,6 +45,7 @@ def _deployment(
             },
         },
         "status": {
+            "replicas": replicas,
             "observedGeneration": observed_generation,
             "updatedReplicas": updated,
             "readyReplicas": ready,

--- a/tests/oracles/test_rollout_completion.py
+++ b/tests/oracles/test_rollout_completion.py
@@ -1,0 +1,197 @@
+"""The same rollout contract must hold for every Deployment-based oracle."""
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from kubernetes import client
+
+from sregym.conductor.oracles.mitigation import MitigationOracle
+from sregym.service.rollout import deployment_rollout_complete
+
+ROLLOUT_CHECKS = [
+    ("admission_webhook_outage_mitigation", "AdmissionWebhookOutageMitigationOracle"),
+    ("mutating_webhook_resource_limits_mitigation", "MutatingWebhookResourceLimitsMitigationOracle"),
+    ("readiness_probe_mitigation", "ReadinessProbeMitigationOracle"),
+    ("service_endpoint_mitigation", "ServiceEndpointMitigationOracle"),
+    ("incorrect_port", "IncorrectPortAssignmentMitigationOracle"),
+    ("cpu_throttling_mitigation", "CpuThrottlingMitigationOracle"),
+    ("dns_resolution_mitigation", "DNSResolutionMitigationOracle"),
+    ("wrong_pod_selection_mitigation", "WrongPodSelectionMitigationOracle"),
+    ("rolling_update_misconfiguration_mitigation", "RollingUpdateMitigationOracle"),
+    ("env_variable_shadowing_mitigation", "EnvVariableShadowingMitigationOracle"),
+    ("secret_rotation_stale_env_mitigation", "SecretRotationStaleEnvMitigation"),
+    ("namespace_memory_limit_mitigation", "NamespaceMemoryLimitMitigationOracle"),
+    ("network_policy_oracle", "NetworkPolicyMitigationOracle"),
+    ("duplicate_pvc_mounts_mitigation", "DuplicatePVCMountsMitigationOracle"),
+    ("edge_request_filter_mitigation", "EdgeRequestFilterMitigationOracle"),
+    ("search_rate_retry_mitigation", "SearchRateRetryMitigationOracle"),
+]
+
+
+def deployment(**status):
+    fields = dict(
+        observed_generation=2,
+        replicas=1,
+        updated_replicas=1,
+        ready_replicas=1,
+        available_replicas=1,
+        unavailable_replicas=0,
+    )
+    fields.update(status)
+    return client.V1Deployment(
+        metadata=client.V1ObjectMeta(name="frontend", generation=2),
+        spec=client.V1DeploymentSpec(
+            replicas=1,
+            selector=client.V1LabelSelector(match_labels={"app": "frontend"}),
+            template=client.V1PodTemplateSpec(),
+        ),
+        status=client.V1DeploymentStatus(**fields),
+    )
+
+
+@pytest.mark.parametrize("module_name,class_name", ROLLOUT_CHECKS)
+@pytest.mark.parametrize("total,expected", [(1, True), (2, False)])
+def test_all_oracles_reject_extra_old_replicas(module_name, class_name, total, expected):
+    oracle = getattr(import_module(f"sregym.conductor.oracles.{module_name}"), class_name)
+    dep = deployment(replicas=total)
+    if module_name == "rolling_update_misconfiguration_mitigation":
+        dep = client.ApiClient().sanitize_for_serialization(dep)
+    assert oracle._rollout_complete(dep) is expected
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+@pytest.mark.parametrize(
+    "status",
+    [
+        {"replicas": 2},
+        {"replicas": 0},
+        {"replicas": None},
+        {"observed_generation": 1},
+        {"observed_generation": None},
+        {"updated_replicas": 0},
+        {"ready_replicas": 0},
+        {"ready_replicas": 2},
+        {"available_replicas": 0},
+        {"unavailable_replicas": 1},
+    ],
+)
+def test_shared_predicate_rejects_incomplete_status(status, as_json):
+    dep = deployment(**status)
+    if as_json:
+        dep = client.ApiClient().sanitize_for_serialization(dep)
+    assert not deployment_rollout_complete(dep)
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+def test_scale_to_zero_requires_explicit_setup_or_recovery_opt_in(as_json):
+    dep = deployment(replicas=0, updated_replicas=0, ready_replicas=0, available_replicas=0)
+    dep.spec.replicas = 0
+    if as_json:
+        dep = client.ApiClient().sanitize_for_serialization(dep)
+    assert not deployment_rollout_complete(dep)
+    assert deployment_rollout_complete(dep, allow_zero=True)
+
+
+@pytest.mark.parametrize("replicas", [None, 1, 3])
+def test_default_and_scaled_healthy_deployments(replicas):
+    count = 1 if replicas is None else replicas
+    dep = deployment(replicas=count, updated_replicas=count, ready_replicas=count, available_replicas=count)
+    dep.spec.replicas = replicas
+    assert deployment_rollout_complete(dep)
+
+
+@pytest.mark.parametrize("field", ["metadata", "spec", "status"])
+def test_missing_resources_and_status_fail_closed(field):
+    dep = client.ApiClient().sanitize_for_serialization(deployment())
+    dep[field] = None
+    assert not deployment_rollout_complete(dep)
+    assert not deployment_rollout_complete(None)
+    assert not deployment_rollout_complete({})
+
+
+def test_deleting_deployment_is_not_a_completed_rollout():
+    dep = client.ApiClient().sanitize_for_serialization(deployment())
+    dep["metadata"]["deletionTimestamp"] = "2026-09-09T00:00:00Z"
+    assert not deployment_rollout_complete(dep)
+
+
+@pytest.mark.parametrize("baseline", [True, False])
+@pytest.mark.parametrize("status", [{"replicas": 2}, {"updated_replicas": 0}, {"observed_generation": 1}, None])
+def test_generic_final_check_rejects_stale_rollout_after_settle_timeout(baseline, status):
+    dep = deployment(**(status or {}))
+    if status is None:
+        dep.status = None
+    kube = Mock()
+    kube.list_deployments.return_value = SimpleNamespace(items=[dep])
+    oracle = MitigationOracle(SimpleNamespace(kubectl=kube, namespace="example"))
+    oracle.rollout_time = 0
+    oracle.replica_count = {"frontend": 1} if baseline else {}
+    result = oracle.evaluate()
+    assert result["success"] is False
+    assert result["reason"] == "deployment_replicas_unready"
+    kube.list_pods.assert_not_called()
+
+
+def test_generic_wait_rechecks_until_rollout_finishes(monkeypatch):
+    import sregym.conductor.oracles.mitigation as module
+
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    kube = Mock()
+    kube.list_deployments.side_effect = [
+        SimpleNamespace(items=[deployment(replicas=2)]),
+        SimpleNamespace(items=[deployment()]),
+    ]
+    oracle = MitigationOracle(SimpleNamespace(kubectl=kube, namespace="example"))
+    oracle._wait_for_rollouts(kube, "example")
+    assert kube.list_deployments.call_count == 2
+
+
+@pytest.mark.parametrize("total,expected", [(1, True), (2, False)])
+def test_non_lite_status_checks_use_the_same_contract(total, expected):
+    from sregym.conductor.oracles.calico_route_reflector_mitigation import CalicoRouteReflectorMitigationOracle
+    from sregym.conductor.oracles.cronjob_sidecar_mitigation import CronJobSidecarBlocksCompletionMitigationOracle
+    from sregym.conductor.oracles.cumulative_admission_webhook_timeout_mitigation import (
+        CumulativeAdmissionWebhookTimeoutMitigationOracle,
+    )
+    from sregym.conductor.oracles.finalizer_deadlock_controller_mitigation import (
+        FinalizerDeadlockControllerMitigationOracle,
+    )
+    from sregym.conductor.oracles.hpa_control_plane_mitigation import HPAControlPlaneMitigationOracle
+    from sregym.conductor.oracles.priority_preemption_mitigation import PriorityPreemptionMitigationOracle
+
+    dep = deployment(replicas=total)
+    api = Mock()
+    api.list_namespaced_deployment.return_value = SimpleNamespace(items=[dep])
+    api.read_namespaced_deployment.return_value = dep
+
+    for klass, method in [
+        (CalicoRouteReflectorMitigationOracle, "_deployments_unready"),
+        (PriorityPreemptionMitigationOracle, "_any_deployment_unready"),
+        (CronJobSidecarBlocksCompletionMitigationOracle, "_unhealthy_deployment"),
+    ]:
+        oracle = object.__new__(klass)
+        oracle.apps_v1 = api
+        assert (getattr(oracle, method)("example") is None) is expected
+
+    controller = object.__new__(FinalizerDeadlockControllerMitigationOracle)
+    controller.controller_deployment_name = "frontend"
+    assert controller._check_controller_healthy(SimpleNamespace(apps_v1_api=api), "example")[0] is expected
+
+    webhook = object.__new__(CumulativeAdmissionWebhookTimeoutMitigationOracle)
+    webhook.problem = SimpleNamespace(TARGET_DEPLOYMENT="frontend", namespace="example")
+    webhook.apps_v1 = api
+    webhook.core_v1 = Mock()
+    webhook.core_v1.read_namespaced_endpoints.return_value = SimpleNamespace(
+        subsets=[SimpleNamespace(addresses=["pod"])]
+    )
+    assert webhook._pod_healthy()[0] is expected
+
+    hpa = HPAControlPlaneMitigationOracle(
+        SimpleNamespace(namespace="example"), deployment_name="frontend", hpa_name="frontend"
+    )
+    hpa._kubectl_json = Mock(
+        return_value={"items": [{"metadata": {"name": "frontend"}, "status": {"phase": "Running"}}]}
+    )
+    assert hpa._deployment_ready(client.ApiClient().sanitize_for_serialization(dep))[0] is expected

--- a/tests/oracles/test_service_endpoint_mitigation.py
+++ b/tests/oracles/test_service_endpoint_mitigation.py
@@ -8,6 +8,7 @@ def _deployment(name, replicas=1, ready=1):
         metadata=SimpleNamespace(name=name, generation=1),
         spec=SimpleNamespace(replicas=replicas, selector=SimpleNamespace(match_labels={"service": name})),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=1,
             updated_replicas=ready,
             ready_replicas=ready,

--- a/tests/oracles/test_valkey_auth_mitigation.py
+++ b/tests/oracles/test_valkey_auth_mitigation.py
@@ -29,8 +29,15 @@ class _KubeCtl:
     def get_deployment(self, name, namespace):
         assert name == "cart"
         return SimpleNamespace(
+            metadata=SimpleNamespace(generation=1),
             spec=SimpleNamespace(replicas=1),
-            status=SimpleNamespace(available_replicas=self.cart_available),
+            status=SimpleNamespace(
+                replicas=1,
+                observed_generation=1,
+                updated_replicas=1,
+                ready_replicas=1,
+                available_replicas=self.cart_available,
+            ),
         )
 
 

--- a/tests/oracles/test_wrong_pod_selection_mitigation.py
+++ b/tests/oracles/test_wrong_pod_selection_mitigation.py
@@ -10,6 +10,7 @@ def _deployment(name, replicas=1, ready=1, generation=1, observed_generation=1):
         metadata=SimpleNamespace(name=name, generation=generation),
         spec=SimpleNamespace(replicas=replicas),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             observed_generation=observed_generation,
             updated_replicas=ready,
             ready_replicas=ready,

--- a/tests/problems/test_priority_preemption_cascade.py
+++ b/tests/problems/test_priority_preemption_cascade.py
@@ -19,7 +19,7 @@ def _problem():
 
 def _deployment(name, replicas=1, ready=1, priority_class=None, memory="512Mi", node_selector=None):
     return SimpleNamespace(
-        metadata=SimpleNamespace(name=name),
+        metadata=SimpleNamespace(generation=1, name=name),
         spec=SimpleNamespace(
             replicas=replicas,
             selector=SimpleNamespace(match_labels={"app": name}),
@@ -40,6 +40,7 @@ def _deployment(name, replicas=1, ready=1, priority_class=None, memory="512Mi", 
             ),
         ),
         status=SimpleNamespace(
+            replicas=1 if replicas is None else replicas,
             ready_replicas=ready,
             updated_replicas=ready,
             available_replicas=ready,

--- a/tests/service/test_benign_absence.py
+++ b/tests/service/test_benign_absence.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -92,9 +93,30 @@ def test_social_network_tls_lookup_keeps_existing_secret():
     assert fake.commands == [lookup]
 
 
-@pytest.mark.parametrize(("output", "expected"), [("", False), ("1", True)])
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("", False),
+        (
+            json.dumps(
+                {
+                    "metadata": {"generation": 1},
+                    "spec": {"replicas": 1},
+                    "status": {
+                        "observedGeneration": 1,
+                        "replicas": 1,
+                        "updatedReplicas": 1,
+                        "readyReplicas": 1,
+                        "availableReplicas": 1,
+                    },
+                }
+            ),
+            True,
+        ),
+    ],
+)
 def test_mcp_lookup_ignores_expected_absence(output, expected):
-    command = "kubectl get deployment mcp-server -n sregym --ignore-not-found -o jsonpath='{.status.readyReplicas}'"
+    command = "kubectl get deployment mcp-server -n sregym --ignore-not-found -o json"
     fake = _FakeKubeCtl({command: output})
     server = object.__new__(MCPServer)
     server.service_name = "mcp-server"

--- a/tests/service/test_rollout_consumers.py
+++ b/tests/service/test_rollout_consumers.py
@@ -1,0 +1,63 @@
+"""Setup checks must not reuse an old Ready pod from an unfinished rollout."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from sregym.conductor.conductor import Conductor
+from sregym.generators.workload.trainticket_locust import TrainTicketLocustWorkloadManager
+from sregym.observer.ingress_nginx import IngressNginx
+from sregym.observer.otel_collector.otel_collector import OtelCollector
+from sregym.service.mcp_server import MCPServer
+
+
+def response(total=1, updated=1):
+    return json.dumps(
+        {
+            "metadata": {"generation": 2},
+            "spec": {"replicas": 1},
+            "status": {
+                "observedGeneration": 2,
+                "replicas": total,
+                "updatedReplicas": updated,
+                "readyReplicas": 1,
+                "availableReplicas": 1,
+            },
+        }
+    )
+
+
+@pytest.mark.parametrize("klass", [IngressNginx, OtelCollector])
+def test_observer_waits_for_the_current_rollout(monkeypatch, klass):
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    observer = klass()
+    observer.run_cmd = Mock(side_effect=[response(total=2), response(updated=0), response()])
+    observer._wait_for_ready(timeout=1)
+    assert observer.run_cmd.call_count == 3
+    assert "-o json" in observer.run_cmd.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (response(), True),
+        (response(total=2), False),
+        (response(updated=0), False),
+        ("", False),
+        ("Error from server (Forbidden)", False),
+    ],
+)
+def test_reused_infrastructure_requires_a_complete_deployment(data, expected):
+    for klass, method in [
+        (MCPServer, "_is_running"),
+        (TrainTicketLocustWorkloadManager, "_is_locust_ready"),
+        (Conductor, "_openebs_ready"),
+    ]:
+        obj = object.__new__(klass)
+        obj.namespace = "example"
+        obj.service_name = "mcp-server"
+        obj.kubectl = Mock()
+        obj.kubectl.exec_command.return_value = data
+        args = (True,) if klass is Conductor else ()
+        assert getattr(obj, method)(*args) is expected


### PR DESCRIPTION
Some mitigation oracles accepted incomplete Deployment rollouts. For example, one new pod was Ready while an extra old pod remained. The generic oracle also accepted stalled rollouts after its wait timed out because its final check only counted Ready replicas.

This PR replaces duplicated rollout checks with one shared function across mitigation grading, setup, recovery, and infrastructure readiness. It requires the controller to observe the latest Deployment generation. Total, updated, Ready, and Available replica counts must match the desired count, with no unavailable replicas.

The final oracle checks enforce this rule even after a rollout timeout (previously it would just continue).

/validate-problem skip