### PR TITLE
Add isolated Docker-in-Docker runtime for parallel SREGym runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ SREGym runs on a self-managed Kubernetes cluster that you provision on Linux hos
 ### b) Emulated cluster
 SREGym can be run on an emulated cluster using [kind](https://kind.sigs.k8s.io/) on your local machine. However, not all problems are supported.
 
+For an experimental Docker-in-Docker environment with a private cluster per run,
+including parallel problem execution, see the [DinD guide](./docker/dind/README.md).
+
 **Note:** If you run into pod crashes or "too many open files" errors, see the [kind README](./kind/README.md) for required host kernel settings and troubleshooting.
 
 ```bash

--- a/clients/claudecode/driver.py
+++ b/clients/claudecode/driver.py
@@ -46,13 +46,23 @@ def run_preflight() -> None:
     if reasoning_effort:
         command.extend(["--effort", reasoning_effort])
 
-    r = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        timeout=60,
-        env=env,
-    )
+    timeout_seconds = 150
+    try:
+        r = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=env,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired as exc:
+        if exc.stdout:
+            print(exc.stdout)
+        if exc.stderr:
+            print(exc.stderr)
+        print(f"Claude Code preflight timed out after {timeout_seconds} seconds")
+        sys.exit(1)
     if r.returncode:
         print(r.stdout or r.stderr)
     sys.exit(r.returncode)

--- a/docker/dind/Dockerfile
+++ b/docker/dind/Dockerfile
@@ -1,0 +1,40 @@
+FROM ghcr.io/astral-sh/uv:0.8.22 AS uv
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git docker.io iptables iproute2 procps util-linux \
+    python3 python3-dev python3-venv build-essential libffi-dev libssl-dev \
+    sudo jq wget unzip socat udev tini e2fsprogs \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+ARG KIND_VERSION=v0.27.0
+ARG KUBECTL_VERSION=v1.32.1
+ARG HELM_VERSION=v4.0.0
+RUN set -eu; arch="$(dpkg --print-architecture)"; \
+    curl -fsSL "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${arch}" -o /usr/local/bin/kind; \
+    curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" -o /usr/local/bin/kubectl; \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz" -o /tmp/helm.tar.gz; \
+    tar -xzf /tmp/helm.tar.gz -C /tmp; \
+    mv "/tmp/linux-${arch}/helm" /usr/local/bin/helm; \
+    chmod +x /usr/local/bin/kind /usr/local/bin/kubectl; \
+    rm -rf /tmp/helm.tar.gz "/tmp/linux-${arch}"
+
+WORKDIR /opt/sregym
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+COPY . .
+RUN test -f SREGym-applications/README.md && uv sync --frozen --no-dev --no-build-isolation \
+    && chmod +x docker/dind/entrypoint.sh docker/dind/smoke.sh
+
+# The benchmark, daemon and all nested bind-mount sources share this filesystem.
+# Every outer container gets its own Docker data volume, kubeconfig and cache.
+ENV PATH="/opt/sregym/.venv/bin:${PATH}" \
+    DOCKER_HOST=unix:///var/run/docker.sock \
+    KIND_EXPERIMENTAL_PROVIDER=docker \
+    CALICO_TIMEOUT=600s \
+    WAIT_FOR_POD_READY_TIMEOUT=1800
+VOLUME /var/lib/docker
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/opt/sregym/docker/dind/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/docker/dind/Dockerfile.dockerignore
+++ b/docker/dind/Dockerfile.dockerignore
@@ -1,0 +1,16 @@
+.git
+.venv
+.runtime
+_running_*_results.csv
+**/.git
+**/__pycache__
+**/node_modules
+**/.venv
+**/.env*
+.env*
+results
+logs
+cache_dir
+docker/agents/build-context
+*.pem
+*.key

--- a/docker/dind/README.md
+++ b/docker/dind/README.md
@@ -1,0 +1,202 @@
+# SREGym in Docker-in-Docker (experimental)
+
+Each outer container owns a Docker daemon, the existing four-node KIND/Calico
+cluster, SREGym, and its nested agent containers. Run one problem per outer
+container for parallel evaluation. Fixed ports, cluster names, the baseline
+cache, application metadata and agent build directories are private to each run.
+The daemon and benchmark share a filesystem, so nested agent bind mounts work
+without translating host paths. No host Docker socket or host network is used.
+
+DinD builds the node image from `kindest/node:v1.32.11`, with SREGym's udev/socat
+additions. This contains containerd 2.2.0; the older custom images contain 2.0.2
+and exhibited CNI startup hangs during validation. Override the base with
+`SREGYM_KIND_BASE_IMAGE` in the env file when testing another compatible node image.
+The existing host KIND setup retains its default image unless `KIND_NODE_IMAGE`
+is explicitly set.
+
+The disposable etcd database uses a 512 MiB tmpfs limit per run to avoid API
+timeouts when concurrent image extraction saturates the host disk. This memory
+counts toward the outer container's limit. Application volumes remain on disk.
+Set `SREGYM_ETCD_TMPFS_SIZE=0` in the env file to use disk-backed etcd, or change
+the size for larger campaigns. Do not use tmpfs mode to evaluate etcd disk faults
+or persistence behavior.
+
+## Requirements
+
+Use a Linux Docker host with the Buildx plugin (or a Linux VM behind Docker Desktop) that permits
+privileged containers and writable cgroups. Start with **8 CPUs and 16 GiB RAM
+per concurrent SREGym-Lite run**, plus disk space for each daemon's image cache.
+Larger problems need more resources. This retains KIND's problem limitations;
+it does not add support for problems requiring real machines or Khaos.
+
+Configure the host's inotify limits as described in the [KIND guide](../../kind/README.md).
+These limits are shared across containers, so parallel runs may require higher
+values. Privileged DinD is intended for trusted benchmarking infrastructure;
+outer containers share the host kernel, and host-wide OS faults are not isolated
+like they would be in separate VMs. Agent containers still use SREGym's existing
+isolation and proxy configuration inside the private daemon.
+
+Some application images, including the current HotelReservation image, are
+AMD64-only. On ARM64, those workloads additionally require host binfmt/QEMU
+emulation or rebuilt ARM64 application images. The outer runtime and KIND nodes
+run natively on ARM64; DinD does not itself translate application binaries.
+
+## Build and run
+
+From the repository root:
+
+```bash
+git submodule update --init --recursive
+python3 docker/dind/run.py build
+
+# No LLM credentials: cluster, mounts, networking, workload and recovery checks.
+python3 docker/dind/run.py run -- bash docker/dind/smoke.sh
+
+# Uses OPENAI_API_KEY from the host environment (also supports Anthropic,
+# Google and AWS environment credentials; see run.py for the allowlist).
+python3 docker/dind/run.py run --name sregym-image -- \
+  uv run --frozen main.py --problem incorrect_image --agent stratus --model gpt-5
+```
+
+Use `run --env-file /path/to/credentials.env` for other environment settings.
+Credential files must stay outside the image. Host login directories are not
+automatically mounted. The image build excludes common secret and output paths;
+review your checkout for other private files before building.
+
+Results and daemon logs survive container removal in `results/dind/<run-name>/`.
+Set `--output /absolute/path` to change this; always use a distinct directory for
+each concurrent run. Files are written by container root. Docker data uses a
+private anonymous volume removed by `docker run --rm`, so images are downloaded
+again on each run. Initial cluster and agent-image startup can take several minutes.
+
+Run two smoke checks simultaneously to exercise isolation (both create the same
+cluster name, namespace and local listener port):
+
+```bash
+python3 docker/dind/run.py run --name sregym-check-a -- bash docker/dind/smoke.sh > /tmp/sregym-a.log 2>&1 &
+first=$!
+python3 docker/dind/run.py run --name sregym-check-b -- bash docker/dind/smoke.sh > /tmp/sregym-b.log 2>&1 &
+second=$!
+wait "$first"; first_status=$?
+wait "$second"; second_status=$?
+test "$first_status" -eq 0 && test "$second_status" -eq 0
+```
+
+Replace each smoke command with a different `main.py --problem ...` command to
+run problems concurrently. Each `main.py` campaign remains serial internally.
+Use `--cpus` and `--memory` before `--` to set outer container limits.
+
+For disposable evaluations on a slow disk, `--docker-tmpfs-size 24g --memory 32g`
+puts the entire private Docker data directory in memory, using a sparse ext4
+loop image in tmpfs so image-layer extended attributes work on older kernels.
+This requires loop-device support on the host. The tmpfs limit counts
+toward the outer memory limit, so leave room for Kubernetes, applications and the
+agent. Results still persist on the host. This option changes all nested storage
+behavior: use disk-backed runs for disk faults, persistence or I/O measurements.
+
+To keep an environment available, omit the command and use a second terminal:
+
+```bash
+python3 docker/dind/run.py run --name sregym-dev
+# Wait until this succeeds before issuing cluster commands:
+docker exec sregym-dev test -f /run/sregym-ready
+docker exec -it sregym-dev bash
+docker stop sregym-dev
+```
+
+The entrypoint starts the daemon, waits for Docker, creates the cluster, waits
+for Calico/nodes, then starts the requested command. It propagates command exit
+status, handles termination and shuts down the daemon. Startup failures leave
+diagnostics under the run's `dind/` directory. An existing Docker socket is rejected.
+On cgroup v2 it first moves its processes into an `init` child group and delegates
+controllers to nested containers; skipping this makes nested systemd fail with
+`Failed to create /init.scope control group: Structure needs cleaning`. The launcher
+explicitly requests a private cgroup namespace. Failed KIND nodes are retained
+until their logs have been exported, then removed with the outer environment.
+If overlay2 is unavailable on the backing filesystem, try setting
+`SREGYM_DOCKER_STORAGE_DRIVER=vfs` via the env file (slower and larger).
+
+## Harbor integration boundary
+
+[Harbor's Docker environment](https://www.harborframework.com/docs/tasks) supports
+Compose definitions in `environment/docker-compose.yaml`. A privileged service
+using this image can supply the SREGym backend for a task. Its entrypoint must be
+preserved, and callers must wait for `/run/sregym-ready` before starting evaluation.
+Providers must explicitly support privileged nested Docker; a generic sandbox
+that only accepts a Dockerfile is not sufficient.
+
+This adds the container runtime building block, **not a Harbor task adapter**.
+A complete adapter still needs task instructions, fault initialization, agent
+access through SREGym's proxies, and a verifier mapping SREGym's oracle results
+to Harbor rewards. Do not give a Harbor agent a root shell in this backend:
+it contains benchmark definitions and grading code. Keep the agent in a separate
+container, as the existing SREGym runner does.
+
+Prior work inspected while implementing this runtime:
+
+- [SREGym's Harbor k3s adapter](https://github.com/SREGym/harbor/tree/039df85ded8a4a61a1826bc882f0a09868800f6b/adapters/sregym)
+  provides task generation, readiness checks and mitigation-oracle reward mapping.
+  Its single-node k3s backend excludes multi-node problems. Its generated solution
+  script calls `run-oracle.py`, which evaluates rather than repairs a fault in the
+  current SREGym checkout; recovery validation must call `recover_fault()` first.
+- [The terminal-bench k3d task](https://github.com/SREGym/terminal-bench/tree/main/tasks/k8s-target-port-misconfiguration)
+  mounts the host Docker socket and reuses fixed cluster names. That startup and
+  deletion behavior needs private daemons before it can safely run concurrently.
+
+## Validation status
+
+Run real problem lifecycles without API keys using the existing validator:
+
+```bash
+python3 docker/dind/run.py run --name sregym-network-policy -- \
+  python tests/integration/validate_problem.py --problem network_policy_block \
+  --summary results/network-policy-validation.md
+```
+
+This deploys the application, injects the fault, requires the mitigation oracle
+to report failure, calls `recover_fault()`, and requires the oracle to report success.
+For a noop agent run through the complete benchmark/agent-container path:
+
+```bash
+python3 docker/dind/run.py run --name sregym-noop -- \
+  python main.py --problem wrong_service_selector_hotel_reservation \
+  --agent autosubmit --stages mitigation
+```
+
+The noop run should complete with mitigation failure because the agent does not
+repair the fault. A zero process exit status alone is not evidence of successful
+recovery; inspect the oracle result and phase artifacts.
+
+Host-only tests: `python3 -m unittest discover -s tests/dind -v`.
+The live smoke script covers four ready nodes, nested bind mounts and host
+networking, service connectivity, and deployment scale-down/recovery.
+
+Live validation on an Ubuntu 22.04 ARM64 host used Docker 29.1.3, cgroup v2,
+8 CPUs/16 GiB per disk-backed environment, and QEMU for AMD64-only application images.
+Two concurrent environments each reached four Ready nodes with distinct Docker
+daemon IDs and Kubernetes namespace UIDs; both passed the smoke script. One
+environment was used to debug startup; the other started directly from the
+image with no manual cluster changes. A third environment passed the smoke test
+with memory-backed ext4 Docker storage. Its data limit was increased from 20 to
+24 GiB, with a 32 GiB container memory limit. The nine launcher tests and six
+campaign/publication/judge-preflight tests passed.
+
+Real oracle lifecycles passed for `wrong_service_selector_hotel_reservation`
+(disk-backed) and `network_policy_block` (memory-backed). Both detected the
+injected fault and confirmed recovery. This host's slow disk caused the initial
+600-second selector deployment and a separate 1800-second network-policy
+deployment to time out; those failed attempts were retained alongside the
+successful validation reports. Memory-backed storage is useful here, but it
+changes storage behavior and is not a substitute for validating disk faults.
+
+The DinD image defaults to `CALICO_TIMEOUT=600s` and
+`WAIT_FOR_POD_READY_TIMEOUT=1800` to allow cold image downloads and extraction.
+Override these through an env file if needed. These extend waits without bypassing
+readiness checks; the existing host setup keeps its original defaults.
+Mitigation-only campaigns skip the unused diagnosis-judge API preflight.
+Temporary CSVs and opaque agent artifacts are staged on the results filesystem,
+so final publication also works when `results/` is a bind mount.
+The full `autosubmit --stages mitigation` campaign completed with
+`run_status=complete`, the expected `Mitigation.success=False`, published agent
+artifacts, and per-problem/aggregate CSVs. This included the filtered agent
+container, API submission, executable oracle and teardown, without API keys.

--- a/docker/dind/entrypoint.sh
+++ b/docker/dind/entrypoint.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $(id -u) != 0 ]]; then
+    echo 'SREGym DinD must run as root in a privileged container.' >&2
+    exit 1
+fi
+if [[ ${DOCKER_HOST:-unix:///var/run/docker.sock} != unix:///var/run/docker.sock ]]; then
+    echo 'SREGym DinD requires its private local Docker daemon.' >&2
+    exit 1
+fi
+if [[ -S /var/run/docker.sock ]]; then
+    echo 'Refusing an existing Docker socket. Do not mount the host Docker socket.' >&2
+    exit 1
+fi
+unset DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_CONTEXT KUBECONFIG
+export DOCKER_HOST=unix:///var/run/docker.sock
+export KIND_RETAIN_ON_FAILURE=true
+mkdir -p /run/udev /root/.kube /opt/sregym/results/dind
+daemon_log=/opt/sregym/results/dind/dockerd.log
+daemon_pid=
+child_pid=
+cleanup() {
+    local status=$?
+    trap - EXIT TERM INT
+    if [[ -n $child_pid ]]; then
+        kill -TERM -- "-$child_pid" 2>/dev/null || true
+    fi
+    if [[ -n $daemon_pid ]]; then
+        kill -TERM "$daemon_pid" 2>/dev/null || true
+        # Bound shutdown even if dockerd or a nested container is stuck.
+        for ((i=0; i<20; i++)); do
+            kill -0 "$daemon_pid" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL "$daemon_pid" 2>/dev/null || true
+        wait "$daemon_pid" 2>/dev/null || true
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 143' TERM
+trap 'exit 130' INT
+
+# Delegate only the outer container's private cgroup subtree.
+bash /opt/sregym/docker/dind/prepare-cgroups.sh
+if [[ -n ${SREGYM_DOCKER_TMPFS_SIZE:-} ]]; then
+    # Older kernels' tmpfs lacks user xattrs found in container image layers.
+    # A sparse ext4 image in tmpfs provides them without physical disk I/O.
+    if ! mountpoint -q /run/sregym-docker-data || \
+        [[ $(findmnt -n -o FSTYPE /run/sregym-docker-data) != tmpfs ]]; then
+        echo 'Memory-backed Docker requires the launcher --docker-tmpfs-size option.' >&2
+        exit 1
+    fi
+    docker_data_image=/run/sregym-docker-data/docker.img
+    truncate -s "$(numfmt --from=iec "${SREGYM_DOCKER_TMPFS_SIZE^^}")" "$docker_data_image"
+    mkfs.ext4 -q -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0 "$docker_data_image"
+    # mount's loop devices use autoclear and detach when the mount is released.
+    mount -o loop,noatime "$docker_data_image" /var/lib/docker
+fi
+export container=docker
+dockerd --host=unix:///var/run/docker.sock \
+    --storage-driver="${SREGYM_DOCKER_STORAGE_DRIVER:-overlay2}" >"$daemon_log" 2>&1 &
+daemon_pid=$!
+ready=false
+for ((i=0; i<120; i++)); do
+    if docker info >/dev/null 2>&1; then
+        ready=true
+        break
+    fi
+    kill -0 "$daemon_pid" 2>/dev/null || break
+    sleep 1
+done
+if [[ $ready != true ]]; then
+    cat "$daemon_log" >&2
+    echo 'Private Docker daemon failed to start; check privileged mode and cgroup support.' >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64) arch=x86 ;;
+    aarch64|arm64) arch=arm ;;
+    *) echo 'Unsupported architecture' >&2; exit 1 ;;
+esac
+# The older custom node images contain containerd 2.0.2, which can deadlock
+# while Calico initializes. Build the same udev/socat additions on a patched
+# Kubernetes 1.32 base, once per private daemon.
+setsid docker build --build-arg "KIND_NODE_IMAGE=${SREGYM_KIND_BASE_IMAGE:-kindest/node:v1.32.11}" \
+    -t sregym-kind:local kind &
+child_pid=$!
+wait "$child_pid"
+child_pid=
+export KIND_NODE_IMAGE=sregym-kind:local
+# etcd is disposable in these per-run clusters. Keeping its small database in
+# memory prevents image extraction on the shared host disk from stalling API
+# writes. Application volumes still use the daemon's disk-backed storage.
+if [[ ${SREGYM_ETCD_TMPFS_SIZE:-512m} != 0 ]]; then
+    mkdir -p /run/sregym-etcd
+    mount -t tmpfs -o "size=${SREGYM_ETCD_TMPFS_SIZE:-512m}" tmpfs /run/sregym-etcd
+    export KIND_CONFIG=/run/sregym-kind.yaml
+    python - "$arch" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+config = yaml.safe_load(Path(f"kind/kind-config-{sys.argv[1]}.yaml").read_text())
+config["nodes"][0].setdefault("extraMounts", []).append(
+    {"hostPath": "/run/sregym-etcd", "containerPath": "/var/lib/etcd"}
+)
+Path(os.environ["KIND_CONFIG"]).write_text(yaml.safe_dump(config))
+PY
+fi
+# Keep the existing four-node topology and Calico behavior used by SREGym.
+setsid bash kind/setup_kind_cluster.sh "$arch" &
+child_pid=$!
+if wait "$child_pid"; then
+    child_pid=
+else
+    status=$?
+    child_pid=
+    timeout 120 kind export logs /opt/sregym/results/dind/kind-logs || true
+    exit "$status"
+fi
+touch /run/sregym-ready
+setsid "$@" &
+child_pid=$!
+status=0
+wait "$child_pid" || status=$?
+child_pid=
+exit "$status"

--- a/docker/dind/prepare-cgroups.sh
+++ b/docker/dind/prepare-cgroups.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Enable nested cgroup v2 controllers in the outer container's private namespace.
+# Based on the nesting procedure in https://github.com/moby/moby/blob/master/hack/dind.
+set -euo pipefail
+
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+    if [[ $(cat /proc/1/cgroup) != '0::/' ]]; then
+        echo 'DinD requires a private cgroup namespace; use --cgroupns=private.' >&2
+        exit 1
+    fi
+    mkdir -p /sys/fs/cgroup/init
+    read -ra controllers < /sys/fs/cgroup/cgroup.controllers
+    enabled=false
+    for ((attempt=0; attempt<10; attempt++)); do
+        # cgroup v2 forbids processes in a group that delegates controllers.
+        # Ignore processes that exit between reading the list and moving them.
+        xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || true
+        if printf '+%s ' "${controllers[@]}" > /sys/fs/cgroup/cgroup.subtree_control; then
+            enabled=true
+            break
+        fi
+        sleep 1
+    done
+    if [[ $enabled != true ]]; then
+        echo 'Unable to delegate cgroup controllers for nested containers.' >&2
+        exit 1
+    fi
+fi
+
+# Nested systemd and Kubernetes hostPath mounts need shared mount propagation.
+mount --make-rshared /

--- a/docker/dind/run.py
+++ b/docker/dind/run.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build and run isolated SREGym environments using only host Python and Docker."""
+
+import argparse
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+IMAGE = "sregym-dind:local"
+# Forward values by name: secrets never appear in the Docker command line.
+CREDENTIALS = (
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+)
+
+
+def run_command(args):
+    run_id = args.name or f"sregym-{uuid.uuid4().hex[:12]}"
+    output = (args.output or REPO / "results" / "dind" / run_id).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "--privileged",
+        "--cgroupns=private",
+        "--name",
+        run_id,
+        "--stop-timeout",
+        "45",
+        "--cpus",
+        str(args.cpus),
+        "--memory",
+        args.memory,
+        "--mount",
+        f"type=bind,src={output},dst=/opt/sregym/results",
+    ]
+    if args.docker_tmpfs_size:
+        command.extend(
+            [
+                "--tmpfs",
+                f"/run/sregym-docker-data:rw,size={args.docker_tmpfs_size}",
+                "--env",
+                f"SREGYM_DOCKER_TMPFS_SIZE={args.docker_tmpfs_size}",
+            ]
+        )
+    for name in CREDENTIALS:
+        if name in os.environ:
+            command.extend(["--env", name])
+    if args.env_file:
+        command.extend(["--env-file", str(args.env_file.resolve())])
+    command.append(args.image)
+    payload = args.command
+    if payload[:1] == ["--"]:
+        payload = payload[1:]
+    command.extend(payload or ["sleep", "infinity"])
+    return command
+
+
+def parser():
+    result = argparse.ArgumentParser(description=__doc__)
+    commands = result.add_subparsers(dest="action", required=True)
+    build = commands.add_parser("build")
+    build.add_argument("--image", default=IMAGE)
+    run = commands.add_parser("run")
+    run.add_argument("--image", default=IMAGE)
+    run.add_argument("--name")
+    run.add_argument("--output", type=Path)
+    run.add_argument("--cpus", type=float, default=8)
+    run.add_argument("--memory", default="16g")
+    run.add_argument(
+        "--docker-tmpfs-size",
+        help="Store private Docker data in tmpfs (e.g. 20g); counts against --memory and changes disk behavior",
+    )
+    run.add_argument("--env-file", type=Path)
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    return result
+
+
+def main():
+    args = parser().parse_args()
+    if args.action == "build":
+        if not (REPO / "SREGym-applications" / "README.md").is_file():
+            raise SystemExit("Initialize applications first: git submodule update --init --recursive")
+        # BuildKit is required for the Dockerfile-specific ignore file.
+        command = [
+            "docker",
+            "buildx",
+            "build",
+            "--load",
+            "-t",
+            args.image,
+            "-f",
+            str(REPO / "docker/dind/Dockerfile"),
+            str(REPO),
+        ]
+    else:
+        command = run_command(args)
+    try:
+        return subprocess.call(command)
+    except FileNotFoundError:
+        raise SystemExit("Docker is required on the host; install and start Docker first.") from None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/dind/smoke.sh
+++ b/docker/dind/smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run inside a ready DinD environment. No LLM credentials required.
+set -euo pipefail
+kubectl wait --for=condition=Ready nodes --all --timeout=120s
+[[ $(kind get nodes | wc -l) -eq 4 ]]
+[[ $(docker ps --filter label=io.x-k8s.kind.cluster=kind -q | wc -l) -eq 4 ]]
+
+# Validate the nested bind mounts and host networking used by agent containers.
+probe=$(mktemp)
+server_pid=
+trap '[[ -z $server_pid ]] || kill "$server_pid"; rm -f "$probe"; kubectl delete namespace dind-smoke --ignore-not-found --wait=false' EXIT
+echo nested-mount-ok > "$probe"
+docker run --rm -v "$probe:/probe:ro" alpine:3.21 grep -q nested-mount-ok /probe
+python -m http.server 18765 --bind 127.0.0.1 --directory "$(dirname "$probe")" >/dev/null 2>&1 &
+server_pid=$!
+docker run --rm --network host curlimages/curl:8.12.1 \
+    --fail --silent --retry 10 --retry-connrefused "http://127.0.0.1:18765/$(basename "$probe")" \
+    | grep -q nested-mount-ok
+
+kubectl create namespace dind-smoke
+kubectl -n dind-smoke create deployment web --image=nginx:1.27-alpine
+kubectl -n dind-smoke rollout status deployment/web --timeout=300s
+kubectl -n dind-smoke expose deployment web --port=80
+kubectl -n dind-smoke run client --image=curlimages/curl:8.12.1 \
+    --restart=Never --command -- curl --fail --retry 20 --retry-all-errors --retry-delay 2 http://web
+kubectl -n dind-smoke wait --for=jsonpath='{.status.phase}'=Succeeded pod/client --timeout=120s
+# Exercise a reversible Kubernetes fault and recovery.
+kubectl -n dind-smoke scale deployment web --replicas=0
+kubectl -n dind-smoke wait --for=delete pod -l app=web --timeout=120s
+kubectl -n dind-smoke scale deployment web --replicas=1
+kubectl -n dind-smoke rollout status deployment/web --timeout=120s
+echo 'DinD smoke test passed'

--- a/kind/Dockerfile
+++ b/kind/Dockerfile
@@ -1,4 +1,5 @@
-FROM kindest/node:v1.32.1
+ARG KIND_NODE_IMAGE=kindest/node:v1.32.1
+FROM ${KIND_NODE_IMAGE}
 
 # Install udev and related packages
-RUN apt-get update && apt-get install -y udev socat
+RUN apt-get update && apt-get install -y udev socat && rm -rf /var/lib/apt/lists/*

--- a/kind/setup_kind_cluster.sh
+++ b/kind/setup_kind_cluster.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 CALICO_VERSION="v3.27.0"
 ARCH="${1:-x86}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-KIND_CONFIG="${SCRIPT_DIR}/kind-config-${ARCH}.yaml"
+KIND_CONFIG="${KIND_CONFIG:-${SCRIPT_DIR}/kind-config-${ARCH}.yaml}"
 
 if [[ ! -f "${KIND_CONFIG}" ]]; then
     echo "❌ Config file not found: ${KIND_CONFIG}"
@@ -23,10 +23,28 @@ if [[ ! -f "${KIND_CONFIG}" ]]; then
 fi
 
 echo "==> Step 1: Create Kind cluster (arch: ${ARCH})"
-kind create cluster --config "${KIND_CONFIG}"
+CREATE_ARGS=(--config "${KIND_CONFIG}")
+if [[ -n ${KIND_NODE_IMAGE:-} ]]; then
+    CREATE_ARGS+=(--image "${KIND_NODE_IMAGE}")
+fi
+if [[ ${KIND_RETAIN_ON_FAILURE:-false} == true ]]; then
+    CREATE_ARGS+=(--retain)
+fi
+kind create cluster "${CREATE_ARGS[@]}"
 
 echo "==> Step 2: Install Calico CNI"
-kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
+# Cold parallel starts can briefly overload etcd while node images unpack.
+# Apply is declarative, so retrying also handles a partially applied manifest.
+for attempt in 1 2 3; do
+    if kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"; then
+        break
+    fi
+    if [[ $attempt == 3 ]]; then
+        echo "Calico installation failed after ${attempt} attempts." >&2
+        exit 1
+    fi
+    sleep 5
+done
 
 echo "==> Step 3: Wait for Calico to be ready"
 # 300s (vs 120s) accommodates first-time image pulls on slow CI runners,

--- a/main.py
+++ b/main.py
@@ -130,6 +130,12 @@ def run_judge_preflight_check() -> None:
     logger.info("✅ Judge pre-flight check passed")
 
 
+def _problem_result_paths(base_dir: Path, agent: str, problem_id: str) -> tuple[Path, Path]:
+    final_path = base_dir / agent / problem_id / f"{problem_id}_{agent}_results.csv"
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    return final_path.with_name(f"_running_{final_path.name}"), final_path
+
+
 def get_current_datetime_formatted():
     now = datetime.now()
     formatted_datetime = now.strftime("%m%d_%H%M")
@@ -353,8 +359,9 @@ def driver_loop(
 
             conductor.problem_id = pid
 
-            # Keep a record of results for this problem in a temp file in case an attempt fails
-            tmp_path = f"_running_{pid}_{agent_to_run}_results.csv"
+            # Keep partial results on the destination filesystem so publication
+            # remains atomic when results/ is a container bind mount.
+            tmp_path, final_csv_path = _problem_result_paths(base_dir, str(agent_to_run), pid)
 
             attempts_to_run = [
                 attempt for attempt in range(1, n_attempts + 1) if attempt not in completed_attempts.get(pid, set())
@@ -443,8 +450,6 @@ def driver_loop(
                         writer.writeheader()
                         writer.writerows(all_results_for_agent)
                     if deploy_cleanup_failed:
-                        final_csv_path = base_dir / str(agent_to_run) / pid / f"{pid}_{agent_to_run}_results.csv"
-                        final_csv_path.parent.mkdir(parents=True, exist_ok=True)
                         os.replace(tmp_path, final_csv_path)
                         progress.advance(task_id, len(attempts_to_run) - attempt_position)
                         progress.stop()
@@ -483,7 +488,9 @@ def driver_loop(
                 assert agent_to_run is not None
 
                 run = RunArtifacts.create(
-                    staging_root=Path(".runtime"),
+                    # Opaque artifacts must share the final output filesystem
+                    # too: finalization publishes them with an atomic rename.
+                    staging_root=base_dir / ".runtime",
                     results_root=base_dir,
                     problem_id=pid,
                     agent=agent_to_run,
@@ -724,8 +731,6 @@ def driver_loop(
                         logger.warning(f"⚠️ ATIF trajectory conversion skipped for {published_run_dir}")
 
                 if attempt == attempts_to_run[-1] or abort_campaign_after_attempt:
-                    final_csv_path = base_dir / agent_to_run / pid / f"{pid}_{agent_to_run}_results.csv"
-                    final_csv_path.parent.mkdir(parents=True, exist_ok=True)
                     os.replace(tmp_path, final_csv_path)
                     if abort_campaign_after_attempt:
                         logger.error(
@@ -857,7 +862,9 @@ def main(args):
             "Run it with --internet-access open or enable container isolation."
         )
 
-    if not args.use_external_harness:
+    # Mitigation-only runs use the problem's executable oracle, not the
+    # diagnosis judge. They must also work with key-free agents like autosubmit.
+    if not args.use_external_harness and (args.stages is None or "diagnosis" in args.stages):
         run_judge_preflight_check()
 
     k8s_proxy_listen_host = (

--- a/tests/dind/test_launcher.py
+++ b/tests/dind/test_launcher.py
@@ -1,0 +1,111 @@
+"""Host-only tests: no project dependencies or Docker daemon required."""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("dind_run", ROOT / "docker/dind/run.py")
+launcher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(launcher)
+
+
+class LauncherTests(unittest.TestCase):
+    def test_parallel_runs_have_separate_names_and_storage(self):
+        with tempfile.TemporaryDirectory() as directory, patch.object(launcher, "REPO", Path(directory)):
+            args = launcher.parser().parse_args(["run"])
+            first = launcher.run_command(args)
+            second = launcher.run_command(args)
+            self.assertNotEqual(first[first.index("--name") + 1], second[second.index("--name") + 1])
+            self.assertNotEqual(first[first.index("--mount") + 1], second[second.index("--mount") + 1])
+            self.assertNotIn("--network", first)
+            self.assertNotIn("-p", first)
+            self.assertNotIn("docker.sock", " ".join(first))
+            self.assertNotIn("/var/lib/docker", " ".join(first))
+
+    def test_command_arguments_are_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            payload = ["bash", "-c", "echo 'spaces; $literal'"]
+            args = launcher.parser().parse_args(["run", "--output", directory, "--", *payload])
+            command = launcher.run_command(args)
+            self.assertEqual(command[-3:], payload)
+
+    def test_optional_memory_backed_docker_data_keeps_results_on_host(self):
+        with tempfile.TemporaryDirectory() as directory:
+            args = launcher.parser().parse_args(
+                ["run", "--output", directory, "--docker-tmpfs-size", "20g", "--memory", "28g"]
+            )
+            command = launcher.run_command(args)
+            self.assertEqual(command[command.index("--tmpfs") + 1], "/run/sregym-docker-data:rw,size=20g")
+            self.assertIn("SREGYM_DOCKER_TMPFS_SIZE=20g", command)
+            self.assertEqual(command[command.index("--memory") + 1], "28g")
+            self.assertIn("dst=/opt/sregym/results", command[command.index("--mount") + 1])
+
+    def test_credentials_forwarded_by_name_only(self):
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.dict(os.environ, {"OPENAI_API_KEY": "test-secret", "UNRELATED_SECRET": "not-forwarded"}, clear=True),
+        ):
+            args = launcher.parser().parse_args(["run", "--output", directory])
+            command = launcher.run_command(args)
+            self.assertIn("OPENAI_API_KEY", command)
+            self.assertNotIn("test-secret", " ".join(command))
+            self.assertNotIn("UNRELATED_SECRET", command)
+
+    def test_exit_code_is_propagated(self):
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.object(sys, "argv", ["run.py", "run", "--output", directory, "--", "false"]),
+            patch.object(launcher.subprocess, "call", return_value=17),
+        ):
+            self.assertEqual(launcher.main(), 17)
+
+    def test_missing_docker_has_actionable_error(self):
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.object(sys, "argv", ["run.py", "run", "--output", directory]),
+            patch.object(launcher.subprocess, "call", side_effect=FileNotFoundError),
+            self.assertRaisesRegex(SystemExit, "Docker is required"),
+        ):
+            launcher.main()
+
+    def test_shell_syntax(self):
+        for name in ("entrypoint.sh", "prepare-cgroups.sh", "smoke.sh"):
+            subprocess.run(["bash", "-n", str(ROOT / "docker/dind" / name)], check=True)
+
+    def test_entrypoint_rejects_remote_daemon_before_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fake_id = Path(directory) / "id"
+            fake_id.write_text("#!/bin/sh\necho 0\n")
+            fake_id.chmod(0o755)
+            result = subprocess.run(
+                ["bash", str(ROOT / "docker/dind/entrypoint.sh"), "true"],
+                env={**os.environ, "PATH": f"{directory}:{os.environ['PATH']}", "DOCKER_HOST": "tcp://example:2375"},
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("private local Docker daemon", result.stderr)
+
+    def test_entrypoint_rejects_nonroot_before_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fake_id = Path(directory) / "id"
+            fake_id.write_text("#!/bin/sh\necho 1000\n")
+            fake_id.chmod(0o755)
+            result = subprocess.run(
+                ["bash", str(ROOT / "docker/dind/entrypoint.sh"), "true"],
+                env={**os.environ, "PATH": f"{directory}:{os.environ['PATH']}"},
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("must run as root", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_campaign_abort.py
+++ b/tests/test_main_campaign_abort.py
@@ -1,6 +1,10 @@
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
 def _load_main_module():
@@ -41,3 +45,51 @@ def test_driver_wrapper_preserves_partial_results_and_failure(monkeypatch):
     assert benchmark_main._driver_results == partial_results
     assert isinstance(benchmark_main._driver_error, benchmark_main.BenchmarkCampaignAborted)
     assert shutdown_called == [True]
+
+
+def test_result_csv_publication_with_results_on_another_filesystem(tmp_path, monkeypatch):
+    benchmark_main = _load_main_module()
+    shared_memory = Path("/dev/shm")
+    if not shared_memory.is_dir() or shared_memory.stat().st_dev == tmp_path.stat().st_dev:
+        pytest.skip("requires a second writable filesystem")
+    monkeypatch.chdir(tmp_path)
+    with tempfile.TemporaryDirectory(dir=shared_memory) as directory:
+        partial, final = benchmark_main._problem_result_paths(Path(directory), "autosubmit", "problem")
+        partial.write_text("run_status,Mitigation.success\ncomplete,False\n")
+        benchmark_main.os.replace(partial, final)
+        assert final.read_text() == "run_status,Mitigation.success\ncomplete,False\n"
+        assert not partial.exists()
+
+
+@pytest.mark.parametrize(
+    ("stages", "external", "expected_calls"),
+    [(None, False, 1), (["diagnosis"], False, 1), (["mitigation"], False, 0), (None, True, 0)],
+)
+def test_judge_preflight_only_when_diagnosis_can_run(monkeypatch, stages, external, expected_calls):
+    benchmark_main = _load_main_module()
+    monkeypatch.setattr(benchmark_main.os, "environ", benchmark_main.os.environ.copy())
+    calls = []
+    monkeypatch.setattr(benchmark_main, "init_logger", lambda: None)
+    monkeypatch.setattr(benchmark_main, "_configure_model_environment", lambda args: ("unused", "unused"))
+    monkeypatch.setattr(benchmark_main, "set_profile", lambda profile: None)
+    monkeypatch.setattr(benchmark_main, "run_judge_preflight_check", lambda: calls.append(True))
+
+    class ReachedConductor(Exception):
+        pass
+
+    def stop_before_deployment(**kwargs):
+        raise ReachedConductor
+
+    monkeypatch.setattr(benchmark_main, "ConductorConfig", stop_before_deployment)
+    args = SimpleNamespace(
+        agent=None,
+        internet_access="open",
+        container_hardening="on",
+        profile="full",
+        noise=False,
+        use_external_harness=external,
+        stages=stages,
+    )
+    with pytest.raises(ReachedConductor):
+        benchmark_main.main(args)
+    assert len(calls) == expected_calls


### PR DESCRIPTION
SREGym's fixed cluster names, ports and Docker state prevent independent problems from sharing a host safely. This adds an experimental Docker-in-Docker runtime: each outer container owns a Docker daemon, the existing four-node KIND/Calico cluster, nested agent containers and its own results directory. Separate launcher invocations can run problems concurrently.

- Add a build/run launcher, cgroup delegation, readiness checks, bounded shutdown, startup diagnostics and a live smoke test. Use a newer KIND node base for DinD while preserving the existing host setup's default.
- Persist results through a bind mount. Stage temporary CSVs and opaque run artifacts on that same filesystem so atomic publication avoids cross-device rename failures.
- Skip the unused diagnosis-judge preflight for mitigation-only campaigns, enabling credential-free autosubmit/noop runs.
- Document parallel execution, resource requirements, optional memory-backed Docker storage, and the integration boundary for Harbor. This supplies the runtime building block; a complete Harbor task adapter remains separate work.

Validation:

- Nine launcher tests and six campaign/publication/preflight tests passed; shell syntax, Ruff and diff checks passed.
- Concurrent environments each reached four Ready nodes, with distinct Docker daemon IDs and Kubernetes namespace UIDs. Nested mounts, networking, Kubernetes service connectivity and workload recovery passed smoke checks.
- Real fault/recovery oracle lifecycles passed for `wrong_service_selector_hotel_reservation` (disk-backed Docker) and `network_policy_block` (memory-backed Docker).
- A complete `autosubmit --stages mitigation` campaign finished with `run_status=complete`, expected `Mitigation.success=False`, published agent artifacts and per-problem/aggregate CSVs, without API keys.

Validation used an ARM64 Ubuntu host with QEMU for AMD64 application images. Initial cold deployments on its slow disk timed out; successful retries and the memory-backed run are described in the guide. Privileged Linux containers share the host kernel and retain existing KIND problem limitations. Default tmpfs etcd and optional memory-backed Docker change storage behavior; disk/persistence fault evaluations need disk-backed settings.
