### PR TITLE
Fix Khaos capability checks and corruption storage on kind

### DIFF
--- a/kind/README.md
+++ b/kind/README.md
@@ -56,6 +56,39 @@ The cluster is now ready to run SREGym.
 
 ## Troubleshooting
 
+### Khaos problems
+
+Khaos checks the capabilities of every required node. Worker pods use nodes
+without the control-plane or legacy master role; a worker role label is not
+required. The manifest creates `/var/openebs` when it is absent.
+
+eBPF problems require a Khaos image containing the nested PID namespace support
+and `--check` interface from Khaos PR #37. An older image is a deployment error,
+not an unsupported host kernel. To test an unpublished image after building it
+from the desired Khaos checkout:
+
+```bash
+kind load docker-image khaos:pr37-test --name kind
+export KHAOS_IMAGE=khaos:pr37-test
+export KHAOS_IMAGE_PULL_POLICY=Never
+```
+
+For a published image, `KHAOS_IMAGE` can instead contain an immutable registry
+digest. Leave `KHAOS_IMAGE_PULL_POLICY` unset to retain the manifest's policy.
+
+Silent data corruption requires the kernel's `random_read_corrupt` and
+`random_write_corrupt` dm-flakey features. Merely loading `dm_flakey` is not
+sufficient. Preflight creates and removes a small disposable device to verify
+formatting, mounting, and the requested table features. Older kernels can
+support basic dm-flakey while rejecting random corruption; those hosts are
+reported as unsupported before application deployment.
+
+kind nodes share device-mapper and loop devices. SREGym uses node-UID-specific
+device names and backing files, skips udev synchronization, and creates device
+nodes explicitly. The faulted application's PVCs use the non-default
+`sregym-dm-flakey` storage class at `/var/openebs/khaos`; observability storage
+stays on its original class. Stop the application before removing its devices.
+
 ### Docker issues
 
 Ensure Docker is running and accessible to your user:

--- a/sregym/conductor/problems/silent_data_corruption.py
+++ b/sregym/conductor/problems/silent_data_corruption.py
@@ -6,7 +6,7 @@ from sregym.conductor.oracles.llm_as_a_judge.llm_as_a_judge_oracle import LLMAsA
 from sregym.conductor.problems.base import Problem
 from sregym.generators.fault.inject_kernel import KernelInjector
 from sregym.service.apps.hotel_reservation import HotelReservation
-from sregym.service.dm_flakey_manager import DM_FLAKEY_DEVICE_NAME, DmFlakeyManager
+from sregym.service.dm_flakey_manager import DM_FLAKEY_STORAGE_CLASS, DmFlakeyManager
 from sregym.service.khaos_capabilities import KhaosCapability
 from sregym.service.kubectl import KubeCtl
 from sregym.utils.decorators import mark_fault_injected
@@ -63,7 +63,7 @@ class SilentDataCorruption(Problem):
         return True
 
     def khaos_capabilities(self) -> frozenset[KhaosCapability]:
-        return frozenset({KhaosCapability.DM_FLAKEY})
+        return frozenset({KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION})
 
     def _discover_node_for_deploy(self) -> str | None:
         """Return the node where the target deployment is running."""
@@ -179,10 +179,11 @@ class SilentDataCorruption(Problem):
         # Set up dm-flakey infrastructure, then redeploy the app so its PVs
         # land on the dm-flakey-backed storage where corruption can be injected.
         print("[SDC] Setting up dm-flakey infrastructure...")
+        self.app.cleanup()
         self.dm_flakey_manager.setup_openebs_dm_flakey_infrastructure()
 
         print("[SDC] Redeploying app onto dm-flakey-backed storage...")
-        self.app.cleanup()
+        self.app.storage_class_name = DM_FLAKEY_STORAGE_CLASS
         self.app.deploy()
         self.app.start_workload()
 
@@ -203,7 +204,7 @@ class SilentDataCorruption(Problem):
         print("[SDC] Configuring dm-flakey device for corruption...")
         self.injector.dm_flakey_reload(
             self.target_node,
-            DM_FLAKEY_DEVICE_NAME,
+            self.dm_flakey_manager.device_name(self.target_node),
             up_interval=self.up_interval,
             down_interval=self.down_interval,
             features=features,
@@ -236,7 +237,11 @@ class SilentDataCorruption(Problem):
         if hasattr(self, "target_node") and self.target_node:
             print(f"[SDC] Restoring dm-flakey device to normal operation on {self.target_node}")
             self.injector.dm_flakey_reload(
-                self.target_node, DM_FLAKEY_DEVICE_NAME, up_interval=1, down_interval=0, features=""
+                self.target_node,
+                self.dm_flakey_manager.device_name(self.target_node),
+                up_interval=1,
+                down_interval=0,
+                features="",
             )
             print("[SDC] ✅ dm-flakey device restored to normal operation")
 
@@ -258,6 +263,8 @@ class SilentDataCorruption(Problem):
 
         # Tear down dm-flakey to restore direct host storage, then redeploy clean
         self.dm_flakey_manager.teardown_openebs_dm_flakey_infrastructure()
+        self.kubectl.exec_command_checked(f"kubectl delete storageclass {DM_FLAKEY_STORAGE_CLASS} --ignore-not-found")
+        self.app.storage_class_name = None
         self.app.deploy()
         self.app.start_workload()
 

--- a/sregym/generators/fault/inject_kernel.py
+++ b/sregym/generators/fault/inject_kernel.py
@@ -239,7 +239,7 @@ class KernelInjector:
             "-c",
             script,
         ]
-        out = self.kubectl.exec_command(" ".join(shlex.quote(x) for x in cmd))
+        out = self.kubectl.exec_command_checked(" ".join(shlex.quote(x) for x in cmd))
         return out or ""
 
     def _exec_with_nsenter_mount(self, node: str, script: str, check: bool = True) -> tuple[int, str, str]:
@@ -348,7 +348,7 @@ echo "Underlying device: $UNDERLYING, Sectors: $SECTORS"
 dmsetup reload {name_q} --table "0 $SECTORS flakey $UNDERLYING {int(offset_sectors)} {int(up_interval)} {int(down_interval)}{feat_tail}"
 
 # Activate the new table (this is atomic, no unmount needed)
-dmsetup resume {name_q}
+dmsetup resume --noudevsync {name_q}
 
 echo "dm-flakey device reloaded successfully"
 dmsetup status {name_q}

--- a/sregym/service/apps/hotel_reservation.py
+++ b/sregym/service/apps/hotel_reservation.py
@@ -26,6 +26,7 @@ class HotelReservation(Application):
         self,
         mount_failure_scripts: bool = True,
         deployment_env_overrides: dict[str, dict[str, dict[str, str]]] | None = None,
+        storage_class_name: str | None = None,
     ):
         super().__init__(HOTEL_RES_METADATA)
         self.kubectl = KubeCtl()
@@ -33,6 +34,7 @@ class HotelReservation(Application):
         self.helm_deploy = False
         self.mount_failure_scripts = mount_failure_scripts
         self.deployment_env_overrides = deployment_env_overrides or {}
+        self.storage_class_name = storage_class_name
 
         self.load_app_json()
 
@@ -143,7 +145,7 @@ class HotelReservation(Application):
         Deployment/container overrides. Rendering a temporary manifest tree
         avoids a setup rollout and its misleading ReplicaSet history.
         """
-        if not self.deployment_env_overrides:
+        if not self.deployment_env_overrides and not self.storage_class_name:
             yield Path(self.k8s_deploy_path)
             return
 
@@ -162,6 +164,13 @@ class HotelReservation(Application):
 
                 changed = False
                 for document in documents:
+                    if (
+                        isinstance(document, dict)
+                        and document.get("kind") == "PersistentVolumeClaim"
+                        and self.storage_class_name
+                    ):
+                        document.setdefault("spec", {})["storageClassName"] = self.storage_class_name
+                        changed = True
                     if not isinstance(document, dict) or document.get("kind") != "Deployment":
                         continue
                     deployment_name = document.get("metadata", {}).get("name")

--- a/sregym/service/dm_flakey_manager.py
+++ b/sregym/service/dm_flakey_manager.py
@@ -1,280 +1,200 @@
+import hashlib
 import json
 import shlex
 import subprocess
 
 from sregym.service.kubectl import KubeCtl
 
-# Constants
 DEFAULT_KHAOS_NS = "khaos"
 DEFAULT_KHAOS_LABEL = "app=khaos"
 DM_FLAKEY_DEVICE_NAME = "openebs_flakey"
-DM_FLAKEY_BACKING_FILE = "/var/tmp/openebs_dm_flakey.img"
 DM_FLAKEY_BACKING_FILE_SIZE_GB = 5
-OPENEBS_LOCAL_PATH = "/var/openebs/local"
-DEFAULT_BLOCK_SIZE = 512
+OPENEBS_LOCAL_PATH = "/var/openebs/khaos"
+DM_FLAKEY_STORAGE_CLASS = "sregym-dm-flakey"
 SETUP_TIMEOUT_SECONDS = 120
+RANDOM_CORRUPTION_FEATURES = "random_read_corrupt 1000000000 random_write_corrupt 1000000000"
+
+
+def dm_flakey_preflight_script(*, random_corruption: bool = False) -> str:
+    """Exercise a disposable device; module presence alone is insufficient."""
+    features = f"4 {RANDOM_CORRUPTION_FEATURES}" if random_corruption else "0"
+    return f"""set -eu
+command -v dmsetup >/dev/null
+command -v losetup >/dev/null
+command -v mkfs.ext4 >/dev/null
+modprobe dm_flakey
+dmsetup targets | grep -qw flakey
+workdir=$(mktemp -d /var/tmp/khaos-dm-check.XXXXXXXX)
+device=khaos_check_$(basename "$workdir")
+loop=
+cleanup() {{
+    umount "$workdir/mount" 2>/dev/null || true
+    dmsetup remove --noudevsync "$device" 2>/dev/null || true
+    if [ -n "$loop" ]; then losetup -d "$loop"; fi
+    rm -rf "$workdir"
+}}
+trap cleanup EXIT
+trap 'exit 124' TERM INT
+truncate -s 32M "$workdir/backing.img"
+loop=$(losetup --find --show "$workdir/backing.img")
+sectors=$(blockdev --getsz "$loop")
+dmsetup create --noudevsync "$device" --table "0 $sectors flakey $loop 0 1 0"
+dmsetup mknodes "$device"
+mkfs.ext4 -q -F "/dev/mapper/$device"
+mkdir "$workdir/mount"
+mount "/dev/mapper/$device" "$workdir/mount"
+umount "$workdir/mount"
+if ! dmsetup reload --noudevsync "$device" --table "0 $sectors flakey $loop 0 0 1 {features}"; then
+    echo 'dm-flakey does not support the requested corruption features: {features}' >&2
+    exit 1
+fi
+"""
 
 
 class DmFlakeyManager:
-    """
-    Manages dm-flakey infrastructure setup for fault injection.
+    """Mount node-specific, loop-backed dm-flakey storage beneath OpenEBS.
 
-    This class sets up dm-flakey devices to intercept all OpenEBS local storage,
-    allowing any application using OpenEBS to have fault injection capabilities
-    without needing to know specific service names or PVC details.
-
-    The setup process:
-    1. Creates a large dm-flakey device
-    2. Mounts it at /var/openebs/local
-    3. All PVs created by OpenEBS will automatically use this dm-flakey device
+    Device-mapper and loop devices are shared by kind nodes. Both device names
+    and backing-file paths therefore include the Kubernetes node UID. Avoid
+    udev synchronization: a kind node has no udev daemon to acknowledge events.
     """
 
-    def __init__(
-        self,
-        kubectl: KubeCtl,
-        khaos_ns: str = DEFAULT_KHAOS_NS,
-        khaos_label: str = DEFAULT_KHAOS_LABEL,
-    ):
+    def __init__(self, kubectl: KubeCtl, khaos_ns: str = DEFAULT_KHAOS_NS, khaos_label: str = DEFAULT_KHAOS_LABEL):
         self.kubectl = kubectl
         self.khaos_ns = khaos_ns
         self.khaos_label = khaos_label
-        self._pod_cache: dict[str, str] = {}  # Cache pod names by node
+        self._device_names: dict[str, str] = {}
+
+    def device_name(self, node: str) -> str:
+        if node not in self._device_names:
+            data = json.loads(self.kubectl.exec_command_checked(f"kubectl get node {shlex.quote(node)} -o json"))
+            uid = data["metadata"]["uid"]
+            suffix = hashlib.sha256(uid.encode()).hexdigest()[:20]
+            self._device_names[node] = f"{DM_FLAKEY_DEVICE_NAME}_{suffix}"
+        return self._device_names[node]
+
+    def _environment(self, node: str) -> str:
+        name = self.device_name(node)
+        return (
+            f"DM_NAME={shlex.quote(name)}\n"
+            f"BACKING_FILE={shlex.quote('/var/tmp/' + name + '.img')}\n"
+            f"MOUNT_PATH={shlex.quote(OPENEBS_LOCAL_PATH)}\n"
+        )
 
     def setup_openebs_dm_flakey_infrastructure(self, nodes: list[str] | None = None) -> None:
-        """
-        Set up dm-flakey to intercept all OpenEBS local storage on the specified nodes.
-        Creates a dm-flakey device that will be used for all PVs created in /var/openebs/local/.
-
-        Args:
-            nodes: List of node names to set up. If None, sets up on worker nodes only
-                   (control-plane nodes are skipped to avoid destabilising the K8s API server).
-        """
         if nodes is None:
-            nodes_response = self.kubectl.list_nodes()
             nodes = [
                 node.metadata.name
-                for node in nodes_response.items
-                if not any(
-                    label.startswith("node-role.kubernetes.io/control-plane") for label in (node.metadata.labels or {})
+                for node in self.kubectl.list_nodes().items
+                if not {"node-role.kubernetes.io/control-plane", "node-role.kubernetes.io/master"}.intersection(
+                    node.metadata.labels or {}
                 )
             ]
-
         if not nodes:
             raise RuntimeError("No worker nodes available for dm-flakey setup")
-
-        for node in nodes:
-            try:
+        attempted = []
+        try:
+            for node in nodes:
+                attempted.append(node)
                 self._setup_dm_flakey_on_node(node)
-                print(f"[dm-flakey] ✅ Set up dm-flakey infrastructure on {node}")
-            except Exception as e:
-                print(f"[dm-flakey] ❌ Failed to set up dm-flakey on {node}: {e}")
-                raise
+                print(f"[dm-flakey] Set up infrastructure on {node}")
+            self._ensure_storage_class()
+        except Exception as exc:
+            # Include the failing node: it may already own a loop or dm device.
+            try:
+                self.teardown_openebs_dm_flakey_infrastructure(list(reversed(attempted)))
+            except Exception as cleanup_exc:
+                exc.add_note(f"Rollback also failed: {cleanup_exc}")
+            raise
+
+    def _ensure_storage_class(self) -> None:
+        # Keep observability PVCs on the regular hostpath. Only the faulted
+        # application's PVCs opt into this separate storage class.
+        storage_class = {
+            "apiVersion": "storage.k8s.io/v1",
+            "kind": "StorageClass",
+            "metadata": {
+                "name": DM_FLAKEY_STORAGE_CLASS,
+                "annotations": {
+                    "openebs.io/cas-type": "local",
+                    "cas.openebs.io/config": (
+                        f'- name: StorageType\n  value: "hostpath"\n- name: BasePath\n  value: "{OPENEBS_LOCAL_PATH}"\n'
+                    ),
+                },
+            },
+            "provisioner": "openebs.io/local",
+            "reclaimPolicy": "Delete",
+            "volumeBindingMode": "WaitForFirstConsumer",
+        }
+        self.kubectl.exec_command_checked("kubectl apply -f -", input_data=json.dumps(storage_class))
 
     def _setup_dm_flakey_on_node(self, node: str) -> None:
-        """Set up dm-flakey device to intercept OpenEBS storage on a single node."""
-        print(f"[dm-flakey] Setting up dm-flakey on {node}...")
-
-        # Build the complete setup script from logical sections
-        script_parts = [
-            self._build_module_check_script(),
-            self._build_cleanup_script(),
-            self._build_backing_file_script(),
-            self._build_dm_flakey_create_script(),
-            self._build_mount_script(),
-        ]
-
-        full_script = "set -e\n" + "\n".join(script_parts)
-
-        # Execute using nsenter to access host namespace
-        pod = self._get_khaos_pod_on_node(node)
-        cmd = [
-            "kubectl",
-            "-n",
-            self.khaos_ns,
-            "exec",
-            pod,
-            "--",
-            "nsenter",
-            "-t",
-            "1",
-            "-m",
-            "-u",
-            "-i",
-            "-n",
-            "-p",
-            "sh",
-            "-c",
-            full_script,
-        ]
-
-        try:
-            rc = subprocess.run(cmd, timeout=SETUP_TIMEOUT_SECONDS, capture_output=True, text=True)
-            if rc.returncode != 0:
-                error_msg = f"Failed to setup dm-flakey on {node}: return code {rc.returncode}"
-                if rc.stderr:
-                    error_msg += f"\nStderr: {rc.stderr}"
-                if rc.stdout:
-                    error_msg += f"\nStdout: {rc.stdout}"
-                raise RuntimeError(error_msg)
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError(f"Timeout setting up dm-flakey on {node} after {SETUP_TIMEOUT_SECONDS} seconds") from e
-
-    def _build_module_check_script(self) -> str:
-        """Build script to check and load dm_flakey module."""
-        return """
-echo 'Setting up dm-flakey for OpenEBS local storage...'
-echo 'Checking dm_flakey module...'
-modprobe dm_flakey || { echo 'Failed to load dm_flakey module'; exit 1; }
-lsmod | grep dm_flakey || { echo 'dm_flakey module not found in lsmod'; exit 1; }
-echo 'Checking device-mapper targets...'
-dmsetup targets | grep flakey || { echo 'flakey target not available in dmsetup'; exit 1; }
-"""
-
-    def _build_cleanup_script(self) -> str:
-        """Build script to clean up existing dm-flakey infrastructure."""
-        openebs_path = OPENEBS_LOCAL_PATH
-        return f"""
-DM_NAME={DM_FLAKEY_DEVICE_NAME}
-BACKING_FILE={shlex.quote(DM_FLAKEY_BACKING_FILE)}
-
-echo 'Cleaning up any existing dm-flakey infrastructure...'
-
-# Unmount if mounted
-if mountpoint -q {shlex.quote(openebs_path)} 2>/dev/null; then
-    echo 'Unmounting {openebs_path}...'
-    umount {shlex.quote(openebs_path)} 2>/dev/null || umount -f {shlex.quote(openebs_path)} 2>/dev/null || true
-    sleep 1
-fi
-
-# Remove existing dm device
-if dmsetup info $DM_NAME >/dev/null 2>&1; then
-    echo 'Found existing device $DM_NAME, attempting removal...'
-    mount | grep "/dev/mapper/$DM_NAME" | awk '{{print $3}}' | xargs -r -I {{}} umount -l {{}} 2>/dev/null || true
-    sleep 1
-    if dmsetup remove $DM_NAME 2>/dev/null; then
-        echo 'Device removed successfully'
-    elif dmsetup remove --force $DM_NAME 2>/dev/null; then
-        echo 'Device removed with --force'
-    else
-        echo 'Device is busy, renaming and marking for deferred removal...'
-        timestamp=$(date +%s)
-        dmsetup rename $DM_NAME ${{DM_NAME}}_old_${{timestamp}} 2>/dev/null || true
-        dmsetup remove --deferred ${{DM_NAME}}_old_${{timestamp}} 2>/dev/null || true
-        echo 'Old device will be cleaned up automatically when kernel releases it'
-    fi
-fi
-
-# Clean up backing file and loop devices
-if [ -f $BACKING_FILE ]; then
-    echo 'Cleaning up old backing file and loop devices...'
-    losetup -j $BACKING_FILE 2>/dev/null | awk -F: '{{print $1}}' | xargs -r losetup -d 2>/dev/null || true
-    rm -f $BACKING_FILE
-fi
-"""
-
-    def _build_backing_file_script(self) -> str:
-        """Build script to create backing file and loop device."""
-        openebs_path = OPENEBS_LOCAL_PATH
-        return f"""
-BACKING_FILE={shlex.quote(DM_FLAKEY_BACKING_FILE)}
-
-echo 'Preparing OpenEBS directory at {openebs_path}...'
-rm -rf {shlex.quote(openebs_path)}/* 2>/dev/null || true
-mkdir -p {shlex.quote(openebs_path)}
-
-echo 'Creating {DM_FLAKEY_BACKING_FILE_SIZE_GB}GB backing file for OpenEBS dm-flakey...'
-dd if=/dev/zero of=$BACKING_FILE bs=1M count={DM_FLAKEY_BACKING_FILE_SIZE_GB * 1024}
-
-echo 'Setting up loop device...'
-LOOP_DEV=$(losetup -f --show $BACKING_FILE)
-echo "Loop device: $LOOP_DEV"
-"""
-
-    def _build_dm_flakey_create_script(self) -> str:
-        """Build script to create and format dm-flakey device."""
-        return f"""
-DM_NAME={DM_FLAKEY_DEVICE_NAME}
-SECTORS=$(blockdev --getsz $LOOP_DEV)
-echo "Sectors: $SECTORS"
-
-echo 'Creating healthy dm-flakey device for OpenEBS...'
-echo 'Running dmsetup create command...'
-# up=1, down=0 means always up (pass-through)
-dmsetup create $DM_NAME --table "0 $SECTORS flakey $LOOP_DEV 0 1 0" || {{
-    echo 'dmsetup create failed'
-    dmsetup targets
+        self._teardown_dm_flakey_on_node(node)
+        script = (
+            self._environment(node)
+            + f"""
+modprobe dm_flakey
+mkdir -p "$MOUNT_PATH"
+# Never format over a running workload or unrelated mount.
+if mountpoint -q "$MOUNT_PATH" || [ -n "$(ls -A "$MOUNT_PATH")" ]; then
+    echo "Refusing to replace nonempty or mounted storage at $MOUNT_PATH" >&2
     exit 1
-}}
-
-echo 'dmsetup create completed successfully'
-echo 'Verifying dm device was created...'
-ls -la /dev/mapper/$DM_NAME || {{ echo 'dm device not found'; exit 1; }}
-
-echo 'Formatting dm-flakey device with ext4...'
-mkfs.ext4 -F /dev/mapper/$DM_NAME || {{ echo 'mkfs.ext4 failed'; exit 1; }}
+fi
+truncate -s {DM_FLAKEY_BACKING_FILE_SIZE_GB}G "$BACKING_FILE"
+LOOP_DEV=$(losetup --find --show "$BACKING_FILE")
+SECTORS=$(blockdev --getsz "$LOOP_DEV")
+dmsetup create --noudevsync "$DM_NAME" --table "0 $SECTORS flakey $LOOP_DEV 0 1 0"
+dmsetup mknodes "$DM_NAME"
+mkfs.ext4 -q -F "/dev/mapper/$DM_NAME"
+mount "/dev/mapper/$DM_NAME" "$MOUNT_PATH"
+chmod 755 "$MOUNT_PATH"
 """
-
-    def _build_mount_script(self) -> str:
-        """Build script to mount dm-flakey device and set permissions."""
-        openebs_path = OPENEBS_LOCAL_PATH
-        return f"""
-DM_NAME={DM_FLAKEY_DEVICE_NAME}
-echo 'Mounting dm-flakey device at {openebs_path}...'
-mount /dev/mapper/$DM_NAME {shlex.quote(openebs_path)}
-
-echo 'Setting proper permissions...'
-chmod 755 {shlex.quote(openebs_path)}
-
-echo 'OpenEBS dm-flakey infrastructure ready - all PVs will use dm-flakey'
-"""
+        )
+        self._run_on_node(node, script)
 
     def teardown_openebs_dm_flakey_infrastructure(self, nodes: list[str] | None = None) -> None:
-        """
-        Remove dm-flakey from OpenEBS storage on nodes, restoring direct host storage.
-
-        This is needed before deploying apps that require fast I/O (e.g., TiDB),
-        since the loop-backed dm-flakey device is too slow for some bootstrap operations.
-        """
         if nodes is None:
-            nodes_response = self.kubectl.list_nodes()
-            nodes = [node.metadata.name for node in nodes_response.items]
-
+            nodes = [node.metadata.name for node in self.kubectl.list_nodes().items]
+        errors = []
         for node in nodes:
             try:
                 self._teardown_dm_flakey_on_node(node)
-                print(f"[dm-flakey] ✅ Removed dm-flakey infrastructure on {node}")
-            except Exception as e:
-                print(f"[dm-flakey] ⚠️ Could not remove dm-flakey on {node} (may not exist): {e}")
+                print(f"[dm-flakey] Removed infrastructure on {node}")
+            except Exception as exc:
+                errors.append(f"{node}: {exc}")
+        if errors:
+            raise RuntimeError("Failed to remove dm-flakey infrastructure: " + "; ".join(errors))
 
     def _teardown_dm_flakey_on_node(self, node: str) -> None:
-        """Remove dm-flakey device and restore direct host storage on a single node."""
-        openebs_path = OPENEBS_LOCAL_PATH
-        script = f"""set -e
-# Check if dm-flakey is active
-if ! dmsetup info {DM_FLAKEY_DEVICE_NAME} >/dev/null 2>&1; then
-    echo 'No dm-flakey device found, nothing to do'
-    exit 0
+        script = (
+            self._environment(node)
+            + """
+if dmsetup info "$DM_NAME" >/dev/null 2>&1; then
+    if mountpoint -q "$MOUNT_PATH"; then
+        # Only unmount the device owned by this node. A busy device is an error,
+        # not permission to force-remove storage still used by an application.
+        expected=$(dmsetup info -c --noheadings -o major,minor --separator : "$DM_NAME" | tr -d '[:space:]')
+        actual=$(findmnt -n -o MAJ:MIN --target "$MOUNT_PATH" | tr -d '[:space:]')
+        if [ "$actual" != "$expected" ]; then
+            echo "Refusing to unmount unrelated storage at $MOUNT_PATH" >&2
+            exit 1
+        fi
+        umount "$MOUNT_PATH"
+    fi
+    dmsetup remove --noudevsync "$DM_NAME"
 fi
-
-echo 'Removing dm-flakey infrastructure...'
-
-# Unmount
-if mountpoint -q {shlex.quote(openebs_path)} 2>/dev/null; then
-    umount {shlex.quote(openebs_path)} 2>/dev/null || umount -l {shlex.quote(openebs_path)} 2>/dev/null || true
+if [ -f "$BACKING_FILE" ]; then
+    for loop in $(losetup -j "$BACKING_FILE" | cut -d: -f1); do
+        losetup -d "$loop"
+    done
+    rm -f "$BACKING_FILE"
 fi
-
-# Remove dm device
-dmsetup remove {DM_FLAKEY_DEVICE_NAME} 2>/dev/null || dmsetup remove --force {DM_FLAKEY_DEVICE_NAME} 2>/dev/null || true
-
-# Detach loop device
-LOOP=$(losetup -j {shlex.quote(DM_FLAKEY_BACKING_FILE)} 2>/dev/null | cut -d: -f1)
-[ -n "$LOOP" ] && losetup -d "$LOOP" 2>/dev/null || true
-
-# Ensure directory exists as regular hostpath
-mkdir -p {shlex.quote(openebs_path)}
-chmod 755 {shlex.quote(openebs_path)}
-echo 'dm-flakey removed, using direct host storage'
+mkdir -p "$MOUNT_PATH"
 """
+        )
+        self._run_on_node(node, script)
+
+    def _run_on_node(self, node: str, script: str) -> None:
         pod = self._get_khaos_pod_on_node(node)
         cmd = [
             "kubectl",
@@ -291,29 +211,27 @@ echo 'dm-flakey removed, using direct host storage'
             "-i",
             "-n",
             "-p",
+            # Bound execution on the node too: a kubectl timeout alone leaves
+            # the remote process alive, possibly modifying storage after cleanup.
+            "timeout",
+            "--kill-after=5",
+            str(SETUP_TIMEOUT_SECONDS),
             "sh",
-            "-c",
+            "-ec",
             script,
         ]
-        rc = subprocess.run(cmd, timeout=SETUP_TIMEOUT_SECONDS, capture_output=True, text=True)
-        if rc.returncode != 0:
-            raise RuntimeError(f"Failed on {node}: {rc.stderr}")
+        result = subprocess.run(cmd, timeout=SETUP_TIMEOUT_SECONDS + 15, capture_output=True, text=True)
+        if result.returncode:
+            raise RuntimeError(
+                f"dm-flakey operation failed on {node} (exit {result.returncode}):\n{result.stdout}\n{result.stderr}"
+            )
 
     def _get_khaos_pod_on_node(self, node: str) -> str:
-        """Find a running Khaos pod on the specified node, with caching."""
-        if node in self._pod_cache:
-            return self._pod_cache[node]
-
-        cmd = f"kubectl -n {shlex.quote(self.khaos_ns)} get pods -l {shlex.quote(self.khaos_label)} -o json"
-        out = self.kubectl.exec_command(cmd)
-        if not out:
-            raise RuntimeError("Failed to get pods: empty response")
-
-        data = json.loads(out)
-        for item in data.get("items", []):
+        # Re-query so a rollout cannot leave a deleted pod cached for recovery.
+        out = self.kubectl.exec_command_checked(
+            f"kubectl -n {shlex.quote(self.khaos_ns)} get pods -l {shlex.quote(self.khaos_label)} -o json"
+        )
+        for item in json.loads(out)["items"]:
             if item.get("spec", {}).get("nodeName") == node and item.get("status", {}).get("phase") == "Running":
-                pod_name = item["metadata"]["name"]
-                self._pod_cache[node] = pod_name
-                return pod_name
-
+                return item["metadata"]["name"]
         raise RuntimeError(f"No running Khaos pod found on node {node}")

--- a/sregym/service/khaos.py
+++ b/sregym/service/khaos.py
@@ -1,9 +1,14 @@
 import json
+import os
 import shlex
+import subprocess
 import time
 from collections.abc import Iterable
 
+import yaml
+
 from sregym.paths import KHAOS_DS
+from sregym.service.dm_flakey_manager import dm_flakey_preflight_script
 from sregym.service.khaos_capabilities import KhaosCapability
 from sregym.service.kubectl import KubeCtl
 
@@ -15,13 +20,31 @@ class KhaosUnsupportedError(RuntimeError):
     """Raised when a node kernel cannot provide a problem's Khaos capability."""
 
 
+class KhaosImageError(RuntimeError):
+    """The deployed Khaos binary does not implement the required interface."""
+
+
 class KhaosController:
     def __init__(self, kubectl: KubeCtl):
         self.kubectl = kubectl
 
     def ensure_deployed(self, required_capabilities: Iterable[KhaosCapability] = ()):
+        image = os.environ.get("KHAOS_IMAGE")
+        pull_policy = os.environ.get("KHAOS_IMAGE_PULL_POLICY")
+        if pull_policy and pull_policy not in {"Always", "IfNotPresent", "Never"}:
+            raise ValueError("KHAOS_IMAGE_PULL_POLICY must be Always, IfNotPresent, or Never")
         self.kubectl.exec_command_checked(f"kubectl get ns {KHAOS_NS} >/dev/null 2>&1 || kubectl create ns {KHAOS_NS}")
-        self.kubectl.exec_command_checked(f"kubectl apply -f {KHAOS_DS}")
+        if image or pull_policy:
+            manifests = list(yaml.safe_load_all(KHAOS_DS.read_text()))
+            for manifest in manifests:
+                container = manifest["spec"]["template"]["spec"]["containers"][0]
+                if image:
+                    container["image"] = image
+                if pull_policy:
+                    container["imagePullPolicy"] = pull_policy
+            self.kubectl.exec_command_checked("kubectl apply -f -", input_data=yaml.safe_dump_all(manifests))
+        else:
+            self.kubectl.exec_command_checked(f"kubectl apply -f {KHAOS_DS}")
 
         # Wait for both DaemonSets to be ready (control-plane and worker)
         # The YAML file contains two DaemonSets: khaos-control-plane and khaos-worker
@@ -38,40 +61,72 @@ class KhaosController:
         return [item for item in data.get("items", []) if item.get("status", {}).get("phase") == "Running"]
 
     def _check_capabilities(self, required_capabilities: frozenset[KhaosCapability]) -> None:
+        if not required_capabilities:
+            return
+        nodes = json.loads(self.kubectl.exec_command_checked("kubectl get nodes -o json"))["items"]
         for capability in sorted(required_capabilities, key=str):
-            profile = "worker" if capability == KhaosCapability.DM_FLAKEY else None
+            profile = (
+                "worker"
+                if capability in {KhaosCapability.DM_FLAKEY, KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION}
+                else None
+            )
+            expected_nodes = {
+                node["metadata"]["name"]
+                for node in nodes
+                if not profile
+                or not {"node-role.kubernetes.io/control-plane", "node-role.kubernetes.io/master"}.intersection(
+                    node["metadata"].get("labels", {})
+                )
+            }
             pods = self._running_pods(profile=profile)
             if not pods:
                 target = "worker nodes" if profile else "cluster nodes"
                 raise KhaosUnsupportedError(f"Khaos capability {capability.value!r} has no running pod on {target}")
+
+            missing = expected_nodes - {pod.get("spec", {}).get("nodeName") for pod in pods}
+            if missing:
+                raise RuntimeError(
+                    f"Khaos deployment is incomplete for {capability.value!r}: no running pod on {', '.join(sorted(missing))}"
+                )
 
             for pod in pods:
                 pod_name = pod["metadata"]["name"]
                 node_name = pod.get("spec", {}).get("nodeName", "unknown")
                 try:
                     self._check_pod_capability(pod_name, capability)
+                except KhaosImageError:
+                    raise
                 except RuntimeError as exc:
+                    detail = str(exc)
+                    if isinstance(exc.__cause__, subprocess.CalledProcessError) and exc.__cause__.stderr:
+                        stderr = exc.__cause__.stderr
+                        detail = stderr.decode("utf-8", errors="replace") if isinstance(stderr, bytes) else stderr
                     raise KhaosUnsupportedError(
-                        f"Node {node_name!r} does not support Khaos capability {capability.value!r}: {exc}"
+                        f"Node {node_name!r} does not support Khaos capability {capability.value!r}: {detail.strip()}"
                     ) from exc
 
     def _check_pod_capability(self, pod_name: str, capability: KhaosCapability) -> None:
         pod = shlex.quote(pod_name)
         if capability == KhaosCapability.EBPF_SYSCALL:
-            self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} exec {pod} -- /khaos/khaos --check")
+            try:
+                self.kubectl.exec_command_checked(f"kubectl -n {KHAOS_NS} exec {pod} -- /khaos/khaos --check")
+            except RuntimeError as exc:
+                if "Usage:" in str(exc):
+                    raise KhaosImageError(
+                        "The deployed Khaos image does not support --check. "
+                        "Build or publish the image containing Khaos PR #37, then select it with KHAOS_IMAGE."
+                    ) from exc
+                raise
             return
 
-        if capability == KhaosCapability.DM_FLAKEY:
-            script = """
-set -e
-command -v dmsetup >/dev/null
-command -v losetup >/dev/null
-command -v mkfs.ext4 >/dev/null
-modprobe dm_flakey
-dmsetup targets | grep -qw flakey
-""".strip()
+        if capability in {KhaosCapability.DM_FLAKEY, KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION}:
+            script = dm_flakey_preflight_script(
+                random_corruption=capability == KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION
+            )
             self.kubectl.exec_command_checked(
-                f"kubectl -n {KHAOS_NS} exec {pod} -- nsenter -t 1 -m -u -i -n -p sh -ec {shlex.quote(script)}"
+                f"kubectl -n {KHAOS_NS} exec {pod} -- nsenter -t 1 -m -u -i -n -p "
+                f"timeout --kill-after=5 30 sh -ec {shlex.quote(script)}",
+                timeout=45,
             )
             return
 

--- a/sregym/service/khaos.yaml
+++ b/sregym/service/khaos.yaml
@@ -93,10 +93,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node-role.kubernetes.io/worker
-                    operator: Exists
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""   # explicit worker targeting
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
       containers:
         - name: khaos
           image: ghcr.io/xlab-uiuc/khaos:latest
@@ -130,5 +130,5 @@ spec:
         - { name: btf,         hostPath: { path: /sys/kernel/btf, type: DirectoryOrCreate } }
         - { name: run-dir,     hostPath: { path: /run, type: Directory } }
         - { name: var-run,     hostPath: { path: /var/run, type: Directory } }
-        - { name: openebs,     hostPath: { path: /var/openebs, type: Directory } }
+        - { name: openebs,     hostPath: { path: /var/openebs, type: DirectoryOrCreate } }
         - { name: host-dev,    hostPath: { path: /dev, type: Directory } }

--- a/sregym/service/khaos_capabilities.py
+++ b/sregym/service/khaos_capabilities.py
@@ -6,3 +6,4 @@ class KhaosCapability(StrEnum):
 
     EBPF_SYSCALL = "ebpf-syscall"
     DM_FLAKEY = "dm-flakey"
+    DM_FLAKEY_RANDOM_CORRUPTION = "dm-flakey-random-corruption"

--- a/tests/service/test_dm_flakey_manager.py
+++ b/tests/service/test_dm_flakey_manager.py
@@ -1,0 +1,73 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from sregym.generators.fault.inject_kernel import KernelInjector
+from sregym.service.apps.hotel_reservation import HotelReservation
+from sregym.service.dm_flakey_manager import DmFlakeyManager
+
+
+def test_device_identity_is_stable_and_isolates_clusters():
+    def manager(uid):
+        return DmFlakeyManager(
+            SimpleNamespace(exec_command_checked=lambda command: json.dumps({"metadata": {"uid": uid}}))
+        )
+
+    assert manager("uid-a").device_name("kind-worker") == manager("uid-a").device_name("kind-worker")
+    assert manager("uid-a").device_name("kind-worker") != manager("uid-b").device_name("kind-worker")
+
+
+def test_partial_setup_rolls_back_failed_node_and_previous_nodes(monkeypatch):
+    manager = DmFlakeyManager(None)
+    setup = Mock(side_effect=[None, RuntimeError("create failed")])
+    rollback = Mock()
+    monkeypatch.setattr(manager, "_setup_dm_flakey_on_node", setup)
+    monkeypatch.setattr(manager, "teardown_openebs_dm_flakey_infrastructure", rollback)
+    with pytest.raises(RuntimeError, match="create failed"):
+        manager.setup_openebs_dm_flakey_infrastructure(["worker-a", "worker-b", "worker-c"])
+    rollback.assert_called_once_with(["worker-b", "worker-a"])
+    assert setup.call_count == 2
+
+
+def test_teardown_errors_are_not_silently_successful(monkeypatch):
+    manager = DmFlakeyManager(None)
+    teardown = Mock(side_effect=[RuntimeError("device busy"), None])
+    monkeypatch.setattr(manager, "_teardown_dm_flakey_on_node", teardown)
+    with pytest.raises(RuntimeError, match="worker-a: device busy"):
+        manager.teardown_openebs_dm_flakey_infrastructure(["worker-a", "worker-b"])
+    assert teardown.call_count == 2
+
+
+def test_remote_operation_has_timeout_and_propagates_failure(monkeypatch):
+    manager = DmFlakeyManager(None)
+    monkeypatch.setattr(manager, "_get_khaos_pod_on_node", lambda node: "khaos-test")
+    run = Mock(return_value=SimpleNamespace(returncode=124, stdout="", stderr="timed out"))
+    monkeypatch.setattr("sregym.service.dm_flakey_manager.subprocess.run", run)
+    with pytest.raises(RuntimeError, match="exit 124"):
+        manager._run_on_node("worker", "echo test")
+    command = run.call_args.args[0]
+    assert command[command.index("timeout") + 1 :][:2] == ["--kill-after=5", "120"]
+    assert run.call_args.kwargs["timeout"] > 125
+
+
+def test_fault_storage_override_does_not_change_source_manifests(tmp_path):
+    source = tmp_path / "resources.yaml"
+    source.write_text("kind: PersistentVolumeClaim\nmetadata:\n  name: database\nspec:\n  storageClassName: original\n")
+    app = object.__new__(HotelReservation)
+    app.k8s_deploy_path = tmp_path
+    app.deployment_env_overrides = {}
+    app.storage_class_name = "sregym-dm-flakey"
+    with app._rendered_deployment_configs() as rendered:
+        assert yaml.safe_load((rendered / source.name).read_text())["spec"]["storageClassName"] == "sregym-dm-flakey"
+    assert yaml.safe_load(source.read_text())["spec"]["storageClassName"] == "original"
+
+
+def test_kernel_reload_failure_is_not_reported_as_success(monkeypatch):
+    kubectl = SimpleNamespace(exec_command_checked=Mock(side_effect=RuntimeError("Invalid argument")))
+    injector = KernelInjector(kubectl)
+    monkeypatch.setattr(injector, "_get_khaos_pod_on_node", lambda node: "khaos-test")
+    with pytest.raises(RuntimeError, match="Invalid argument"):
+        injector.dm_flakey_reload("worker", "test-device", 0, 1, "random_read_corrupt 1000000000")

--- a/tests/service/test_khaos.py
+++ b/tests/service/test_khaos.py
@@ -1,11 +1,12 @@
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
 from sregym.conductor.problems.silent_data_corruption import SilentDataCorruption
-from sregym.service.khaos import KhaosController, KhaosUnsupportedError
+from sregym.service.khaos import KhaosController, KhaosImageError, KhaosUnsupportedError
 from sregym.service.khaos_capabilities import KhaosCapability
 
 
@@ -13,9 +14,26 @@ class FakeKubectl:
     def __init__(self, *, fail_ebpf_check: bool = False):
         self.commands: list[str] = []
         self.fail_ebpf_check = fail_ebpf_check
+        self.applied_manifest = None
 
     def exec_command_checked(self, command: str, input_data=None, timeout=None):
         self.commands.append(command)
+        if command == "kubectl apply -f -":
+            self.applied_manifest = input_data
+        if command == "kubectl get nodes -o json":
+            return json.dumps(
+                {
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "kind-control-plane",
+                                "labels": {"node-role.kubernetes.io/control-plane": ""},
+                            }
+                        },
+                        {"metadata": {"name": "kind-worker", "labels": {}}},
+                    ]
+                }
+            )
         if "get pods" in command:
             pods = [
                 {
@@ -89,4 +107,88 @@ def test_daemonsets_bootstrap_bpffs_with_privileged_xlab_image():
 
 
 def test_silent_data_corruption_requests_dm_flakey_instead_of_ebpf():
-    assert SilentDataCorruption.khaos_capabilities(object()) == frozenset({KhaosCapability.DM_FLAKEY})
+    assert SilentDataCorruption.khaos_capabilities(object()) == frozenset({KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION})
+
+
+def test_missing_worker_cannot_pass_ebpf_preflight():
+    class MissingWorker(FakeKubectl):
+        def exec_command_checked(self, command, **kwargs):
+            out = super().exec_command_checked(command, **kwargs)
+            if "get pods" in command:
+                return json.dumps({"items": json.loads(out)["items"][:1]})
+            return out
+
+    with pytest.raises(RuntimeError, match="deployment is incomplete.*kind-worker"):
+        KhaosController(MissingWorker()).ensure_deployed({KhaosCapability.EBPF_SYSCALL})
+
+
+def test_old_image_is_not_reported_as_unsupported_kernel():
+    class OldImage(FakeKubectl):
+        def exec_command_checked(self, command, **kwargs):
+            if "/khaos/khaos --check" in command:
+                raise RuntimeError("Usage: /khaos/khaos <fault_name> <pid>")
+            return super().exec_command_checked(command, **kwargs)
+
+    with pytest.raises(KhaosImageError, match="does not support --check"):
+        KhaosController(OldImage()).ensure_deployed({KhaosCapability.EBPF_SYSCALL})
+
+
+def test_random_corruption_preflight_loads_required_features():
+    kubectl = FakeKubectl()
+    KhaosController(kubectl).ensure_deployed({KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION})
+    probe = next(c for c in kubectl.commands if "modprobe dm_flakey" in c)
+    assert "random_read_corrupt" in probe and "random_write_corrupt" in probe
+    assert "dmsetup reload --noudevsync" in probe
+    assert "timeout --kill-after=5 30" in probe
+
+
+def test_worker_manifest_supports_unlabelled_kind_nodes_and_fresh_storage():
+    _, worker = yaml.safe_load_all(Path("sregym/service/khaos.yaml").read_text())
+    spec = worker["spec"]["template"]["spec"]
+    assert not spec.get("nodeSelector")
+    expressions = spec["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"][
+        "nodeSelectorTerms"
+    ][0]["matchExpressions"]
+    assert {e["key"] for e in expressions} == {
+        "node-role.kubernetes.io/control-plane",
+        "node-role.kubernetes.io/master",
+    }
+    assert all(e["operator"] == "DoesNotExist" for e in expressions)
+    volume = next(v for v in spec["volumes"] if v["name"] == "openebs")
+    assert volume["hostPath"]["type"] == "DirectoryOrCreate"
+
+
+def test_local_pr_image_override_applies_to_both_daemonsets(monkeypatch):
+    monkeypatch.setenv("KHAOS_IMAGE", "khaos:pr37-test")
+    monkeypatch.setenv("KHAOS_IMAGE_PULL_POLICY", "Never")
+    kubectl = FakeKubectl()
+    KhaosController(kubectl).ensure_deployed()
+    manifests = list(yaml.safe_load_all(kubectl.applied_manifest))
+    assert len(manifests) == 2
+    for manifest in manifests:
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["image"] == "khaos:pr37-test"
+        assert container["imagePullPolicy"] == "Never"
+
+
+def test_invalid_pull_policy_fails_before_cluster_changes(monkeypatch):
+    monkeypatch.setenv("KHAOS_IMAGE_PULL_POLICY", "Sometimes")
+    kubectl = FakeKubectl()
+    with pytest.raises(ValueError, match="KHAOS_IMAGE_PULL_POLICY"):
+        KhaosController(kubectl).ensure_deployed()
+    assert not kubectl.commands
+
+
+def test_preflight_error_reports_stderr_without_embedding_the_probe_script():
+    class FailedFeature(FakeKubectl):
+        def exec_command_checked(self, command, **kwargs):
+            if "modprobe dm_flakey" in command:
+                cause = subprocess.CalledProcessError(1, command, stderr=b"random corruption is unsupported")
+                raise RuntimeError(f"failed command: {command}") from cause
+            return super().exec_command_checked(command, **kwargs)
+
+    with pytest.raises(KhaosUnsupportedError) as error:
+        KhaosController(FailedFeature()).ensure_deployed({KhaosCapability.DM_FLAKEY_RANDOM_CORRUPTION})
+    assert "kind-worker" in str(error.value)
+    assert "random corruption is unsupported" in str(error.value)
+    assert "modprobe" not in str(error.value)


### PR DESCRIPTION
Khaos deployment on a default kind cluster could miss unlabeled workers, and silent data corruption reused device names shared by the kind nodes and replaced storage used by observability. These fixes let both registered Khaos-backed problems complete deployment, injection, mitigation-oracle failure, recovery, and mitigation-oracle success while keeping fault storage separate from other PVCs.

This PR targets `feat/khaos-kind-support` and is stacked on #984. It contains the fixes found during coordinated validation with xlab-uiuc/khaos#37.

## Changes

- Select workers by excluding control-plane/master roles, create the OpenEBS mount directory when absent, and require Khaos pod coverage on every required node.
- Support `KHAOS_IMAGE` and `KHAOS_IMAGE_PULL_POLICY` overrides and distinguish an incompatible image from an unsupported kernel.
- Probe disposable dm-flakey devices for formatting, mounting, and the actual random-corruption features before deploying the problem.
- Use node-UID-specific device names and backing files, explicit device-node creation, bounded commands, setup rollback, and checked cleanup.
- Place only the faulted application's PVCs on the non-default `sregym-dm-flakey` class under `/var/openebs/khaos`. Restore normal storage during recovery.
- Add regression coverage and document the prerequisites and local-image workflow.

## Validation

Tested on four kind nodes running Kubernetes 1.32.0 on x86_64 Linux 6.8.0-138-generic. The Khaos image was built from unmodified PR #37 commit `3b0634c18706e311f0ba71896d141e6bc17b478c` and loaded locally.

- 367 targeted regression tests passed; all pre-commit hooks passed.
- Khaos `--check` passed on all four nodes; random-corruption preflight passed on all three workers.
- **latent_sector_error:** healthy baseline, default 30% injection, 120-second fault dwell, read EIO errors and application failures, mitigation oracle failure, recovery, and the normal 120-second alert-free window. All 26 sampled requests during the fault failed; 18/18 late-recovery samples succeeded.
- **silent_data_corruption:** healthy baseline, 120-second fault dwell, ext4 checksum failures and MongoDB `/data/db: Bad message`, alerts naming the damaged MongoDB, recovery, populated hotel-search results, and the normal 120-second alert-free window.
- All 47 individual fault types passed attachment and cleanup checks. Application-impact/oracle testing covered the two registered problems; the other 46 configurations and eight disabled compound problems were not validated as application benchmarks.
- Final cleanup left all nodes Ready, with no Khaos pins, dm-flakey/loop devices, fault storage class, or temporary application/test namespaces.

LLM diagnosis-oracle invocations returned no verdict because `JUDGE_MODEL_ID` is unset. These results validate the mitigation oracles, not LLM diagnosis scoring. The image was loaded locally; deployment through the default public image still depends on publishing the compatible Khaos build.
