### PR TITLE
Align token metrics across client results and ATIF exports

### DIFF
--- a/atif_converter/README.md
+++ b/atif_converter/README.md
@@ -36,6 +36,20 @@ Supported explicit agent names are `claudecode`, `codex`, `copilot`, `gemini`,
 Missing paths raise `FileNotFoundError`. Unknown formats and failed conversions
 raise subclasses of `AtifConverterError`.
 
+## Token metrics
+
+Prompt totals include cache reads and writes. Completion totals include
+reasoning. Cached tokens are a subset of prompt tokens, not additional tokens.
+Reasoning and cache-write counts remain in `extra` when the source reports them.
+Unknown counts remain unset; a reported zero remains zero.
+
+New conversions set `final_metrics.extra.token_metrics_version` to `2`.
+Earlier conversions did not use consistent token definitions. Existing files
+remain unchanged until the caller converts their source recordings again.
+
+Adapters normalize the source counts inside this package. They do not import
+SREGym clients or use SREGym result files to calculate token totals.
+
 ## Scope
 
 This is an importable source folder, not a separately published distribution.

--- a/atif_converter/README.md
+++ b/atif_converter/README.md
@@ -36,6 +36,18 @@ Supported explicit agent names are `claudecode`, `codex`, `copilot`, `gemini`,
 Missing paths raise `FileNotFoundError`. Unknown formats and failed conversions
 raise subclasses of `AtifConverterError`.
 
+Some Copilot versions omit input and cache counts from the CLI stream.
+The converter accepts optional native OpenTelemetry JSONL files from the same run:
+
+```python
+trajectory = convert("copilot-cli.jsonl", telemetry_files=["copilot-otel.jsonl"])
+```
+
+Telemetry supplies final token counts without adding them to the CLI totals.
+The converter ignores duplicate spans and aggregate parent spans.
+CLI counts remain available for fields that telemetry does not report.
+Without telemetry, conversion works as before. Other agents do not accept this argument.
+
 ## Token metrics
 
 Prompt totals include cache reads and writes. Completion totals include

--- a/atif_converter/adapters/_common.py
+++ b/atif_converter/adapters/_common.py
@@ -15,6 +15,13 @@ from typing import Any
 from ..atif import FinalMetrics, Step
 
 logger = logging.getLogger(__name__)
+TOKEN_METRICS_VERSION = 2
+
+
+def _sum_tokens(*values: int | None) -> int | None:
+    """Sum reported token counts; preserve zero and leave absent counts unknown."""
+    known = [v for v in values if isinstance(v, int) and not isinstance(v, bool) and v >= 0]
+    return sum(known) if known else None
 
 
 def _stringify(value: Any) -> str:
@@ -78,5 +85,5 @@ def _aggregate_final_metrics(
         total_cached_tokens=sum(cached_values) if cached_values else None,
         total_cost_usd=total_cost_usd,
         total_steps=len(steps),
-        extra=extra,
+        extra={"token_metrics_version": TOKEN_METRICS_VERSION, **(extra or {})},
     )

--- a/atif_converter/adapters/claudecode.py
+++ b/atif_converter/adapters/claudecode.py
@@ -46,6 +46,7 @@ from ._common import (
     _aggregate_final_metrics,
     _load_jsonl,
     _stringify,
+    _sum_tokens,
 )
 
 logger = logging.getLogger(__name__)
@@ -120,11 +121,10 @@ def _build_metrics(usage: Any) -> Metrics | None:
     if not isinstance(usage, dict):
         return None
 
-    cached_tokens = usage.get("cache_read_input_tokens") or 0
-    creation = usage.get("cache_creation_input_tokens") or 0
-    input_tokens = usage.get("input_tokens") or 0
-    prompt_tokens = input_tokens + cached_tokens + creation
-    completion_tokens = usage.get("output_tokens") or 0
+    cached_tokens = usage.get("cache_read_input_tokens")
+    creation = usage.get("cache_creation_input_tokens")
+    prompt_tokens = _sum_tokens(usage.get("input_tokens"), cached_tokens, creation)
+    completion_tokens = usage.get("output_tokens")
 
     extra: dict[str, Any] = {}
     for key, value in usage.items():

--- a/atif_converter/adapters/codex.py
+++ b/atif_converter/adapters/codex.py
@@ -42,7 +42,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
-from ._common import _load_jsonl
+from ._common import TOKEN_METRICS_VERSION, _load_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -106,9 +106,9 @@ def _metrics_from_token_count_payload(
     total_tokens = last_usage.get("total_tokens")
 
     return {
-        "prompt_tokens": prompt_tokens if prompt_tokens else None,
-        "completion_tokens": completion_tokens or None,
-        "cached_tokens": cached_tokens or None,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cached_tokens": cached_tokens,
         "extra": {
             "reasoning_output_tokens": reasoning_tokens,
             "total_tokens": total_tokens,
@@ -405,15 +405,16 @@ def _extract_final_metrics(raw_events: list[dict[str, Any]], total_steps: int) -
             total_cost_usd = info.get("cost_usd")
 
         final_extra: dict[str, Any] | None = {
+            "token_metrics_version": TOKEN_METRICS_VERSION,
             "reasoning_output_tokens": reasoning_tokens,
             "total_tokens": overall_tokens,
             "last_token_usage": info.get("last_token_usage"),
         }
 
         return FinalMetrics(
-            total_prompt_tokens=prompt_tokens if prompt_tokens else None,
-            total_completion_tokens=completion_tokens or None,
-            total_cached_tokens=cached_tokens or None,
+            total_prompt_tokens=prompt_tokens,
+            total_completion_tokens=completion_tokens,
+            total_cached_tokens=cached_tokens,
             total_cost_usd=total_cost_usd,
             total_steps=total_steps,
             extra=final_extra,

--- a/atif_converter/adapters/copilot.py
+++ b/atif_converter/adapters/copilot.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -50,7 +51,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
-from ._common import TOKEN_METRICS_VERSION, _sum_tokens
+from ._common import TOKEN_METRICS_VERSION, _load_jsonl, _sum_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -524,6 +525,54 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
 # --------------------------------------------------------------------------- #
 # Public entrypoint
 # --------------------------------------------------------------------------- #
-def convert_file(session_file: Path | str) -> Trajectory | None:
-    """Convert one Copilot CLI JSONL output file to ATIF."""
-    return _convert_events(_read_copilot_cli_jsonl(Path(session_file)))
+def _telemetry_totals(files: Sequence[Path | str]) -> dict[str, int | None]:
+    """Count native chat spans once, excluding aggregate parent spans."""
+    fields = {
+        "total_prompt_tokens": ("gen_ai.usage.input_tokens",),
+        "total_completion_tokens": ("gen_ai.usage.output_tokens",),
+        "total_cached_tokens": ("gen_ai.usage.cache_read.input_tokens", "gen_ai.usage.cache_read_input_tokens"),
+        "reasoning_tokens": ("gen_ai.usage.reasoning.output_tokens", "gen_ai.usage.reasoning_tokens"),
+        "cache_write_tokens": ("gen_ai.usage.cache_creation.input_tokens",),
+    }
+    counts: dict[str, list[int | None]] = {name: [] for name in fields}
+    seen = set()
+    for file in files:
+        for event in _load_jsonl(Path(file)):
+            if not isinstance(event, dict):
+                continue
+            attrs = event.get("attributes")
+            if not isinstance(attrs, dict) or attrs.get("gen_ai.operation.name") not in {None, "chat"}:
+                continue
+            if not any(key in attrs for key in ("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens")):
+                continue
+            span_id = event.get("span_id") or event.get("spanId")
+            if span_id and span_id in seen:
+                continue
+            if span_id:
+                seen.add(span_id)
+            for name, keys in fields.items():
+                value = next((attrs[key] for key in keys if key in attrs), None)
+                counts[name].append(value)
+    return {name: _sum_tokens(*values) for name, values in counts.items()}
+
+
+def convert_file(session_file: Path | str, *, telemetry_files: Sequence[Path | str] = ()) -> Trajectory | None:
+    """Convert CLI events and optional same-run OTel files to ATIF.
+
+    Telemetry replaces the final token fields it reports; it is not added to
+    the CLI totals. Step metrics remain based on CLI events because span order
+    does not reliably identify the corresponding step.
+    """
+    trajectory = _convert_events(_read_copilot_cli_jsonl(Path(session_file)))
+    if trajectory is None or not telemetry_files:
+        return trajectory
+    final = trajectory.final_metrics
+    if final is not None:
+        for name, value in _telemetry_totals(telemetry_files).items():
+            if value is None:
+                continue
+            if name.startswith("total_"):
+                setattr(final, name, value)
+            else:
+                final.extra = {**(final.extra or {}), name: value}
+    return trajectory

--- a/atif_converter/adapters/copilot.py
+++ b/atif_converter/adapters/copilot.py
@@ -50,6 +50,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
+from ._common import TOKEN_METRICS_VERSION, _sum_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -255,7 +256,8 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
     if not raw_events:
         return None
 
-    state = {"step_id": 1, "in": 0, "out": 0, "result": None}
+    state = {"step_id": 1, "out": None, "result": None}
+    call_metrics: dict[str | int, Metrics] = {}
     steps: list[Step] = []
     call_id_map: dict[str, Step] = {}
     skipped_event_types: dict[str, int] = {}
@@ -320,15 +322,30 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
 
         # --- usage (flat schema) ---
         elif event_type == "usage":
-            input_tokens = event.get("input_tokens", 0)
-            output_tokens = event.get("output_tokens", 0)
-            state["in"] += input_tokens
-            state["out"] += output_tokens
+            metrics = Metrics(
+                prompt_tokens=event.get("input_tokens"),
+                completion_tokens=event.get("output_tokens"),
+                cached_tokens=event.get("cached_input_tokens"),
+            )
+            call_metrics[len(call_metrics)] = metrics
             if steps and steps[-1].source == "agent":
-                steps[-1].metrics = Metrics(
-                    prompt_tokens=input_tokens,
-                    completion_tokens=output_tokens,
-                )
+                steps[-1].metrics = metrics
+
+        elif event_type == "assistant.usage":
+            data = event["data"]
+            key = data.get("apiCallId") or event.get("id") or len(call_metrics)
+            metrics = Metrics(
+                prompt_tokens=data.get("inputTokens"),
+                completion_tokens=data.get("outputTokens"),
+                cached_tokens=data.get("cacheReadTokens"),
+                extra={
+                    "reasoning_tokens": data.get("reasoningTokens"),
+                    "cache_write_tokens": data.get("cacheWriteTokens"),
+                },
+            )
+            call_metrics[key] = metrics
+            if steps and steps[-1].source == "agent":
+                steps[-1].metrics = metrics
 
         # --- assistant.message (session-event schema) ---
         elif event_type == "assistant.message":
@@ -343,8 +360,8 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
                 )
                 for request in data.get("toolRequests") or []
             ]
-            output_tokens = data.get("outputTokens") or 0
-            state["out"] += output_tokens
+            output_tokens = data.get("outputTokens")
+            state["out"] = _sum_tokens(state["out"], output_tokens)
 
             # Copilot carries the turn's reasoning inline on ``reasoningText``
             # (grounded in real session output). Map it to ATIF's first-class
@@ -377,7 +394,7 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
                 model_name=data.get("model") or None,
                 reasoning_content=reasoning_text,
                 tool_calls=tool_calls or None,
-                metrics=(Metrics(completion_tokens=output_tokens) if output_tokens else None),
+                metrics=(Metrics(completion_tokens=output_tokens) if output_tokens is not None else None),
                 extra=extra,
             )
             steps.append(step)
@@ -484,10 +501,22 @@ def _convert_events(raw_events: list[dict[str, Any]]) -> Trajectory | None:
         ),
         steps=steps,
         final_metrics=FinalMetrics(
-            total_prompt_tokens=state["in"] or None,
-            total_completion_tokens=state["out"] or None,
+            total_prompt_tokens=_sum_tokens(*(m.prompt_tokens for m in call_metrics.values())),
+            total_completion_tokens=(
+                _sum_tokens(*(m.completion_tokens for m in call_metrics.values())) if call_metrics else state["out"]
+            ),
+            total_cached_tokens=_sum_tokens(*(m.cached_tokens for m in call_metrics.values())),
             total_steps=len(steps),
-            extra={"copilot_result": state["result"]} if state["result"] else None,
+            extra={
+                "token_metrics_version": TOKEN_METRICS_VERSION,
+                "reasoning_tokens": _sum_tokens(
+                    *(m.extra.get("reasoning_tokens") for m in call_metrics.values() if m.extra)
+                ),
+                "cache_write_tokens": _sum_tokens(
+                    *(m.extra.get("cache_write_tokens") for m in call_metrics.values() if m.extra)
+                ),
+                **({"copilot_result": state["result"]} if state["result"] else {}),
+            },
         ),
     )
 

--- a/atif_converter/adapters/gemini.py
+++ b/atif_converter/adapters/gemini.py
@@ -43,7 +43,6 @@ from typing import Any
 
 from ..atif import (
     Agent,
-    FinalMetrics,
     Metrics,
     Observation,
     ObservationResult,
@@ -51,7 +50,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
-from ._common import _stringify
+from ._common import _aggregate_final_metrics, _stringify, _sum_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -226,9 +225,6 @@ def _convert(gemini_trajectory: dict[str, Any]) -> Trajectory | None:
 
     steps: list[Step] = []
     step_id = 1
-    total_input = 0
-    total_output = 0
-    total_cached = 0
 
     for message in messages:
         msg_type = message.get("type")
@@ -277,17 +273,15 @@ def _convert(gemini_trajectory: dict[str, Any]) -> Trajectory | None:
 
             metrics: Metrics | None = None
             if tokens:
-                input_tokens = tokens.get("input", 0)
-                output_tokens = tokens.get("output", 0)
-                cached_tokens = tokens.get("cached", 0)
-                thoughts_tokens = tokens.get("thoughts", 0)
-                tool_tokens = tokens.get("tool", 0)
-                completion_tokens = output_tokens + thoughts_tokens + tool_tokens
-                total_input += input_tokens
-                total_output += completion_tokens
-                total_cached += cached_tokens
+                input_tokens = tokens.get("input")
+                output_tokens = tokens.get("output")
+                cached_tokens = tokens.get("cached")
+                thoughts_tokens = tokens.get("thoughts")
+                tool_tokens = tokens.get("tool")
+                # toolUsePromptTokenCount describes tool results used as input.
+                completion_tokens = _sum_tokens(output_tokens, thoughts_tokens)
                 metrics = Metrics(
-                    prompt_tokens=input_tokens,
+                    prompt_tokens=_sum_tokens(input_tokens, tool_tokens),
                     completion_tokens=completion_tokens,
                     cached_tokens=cached_tokens,
                     extra={"thoughts_tokens": thoughts_tokens, "tool_tokens": tool_tokens},
@@ -323,11 +317,13 @@ def _convert(gemini_trajectory: dict[str, Any]) -> Trajectory | None:
         session_id=session_id,
         agent=Agent(name=AGENT_NAME, version="unknown", model_name=default_model),
         steps=steps,
-        final_metrics=FinalMetrics(
-            total_prompt_tokens=total_input or None,
-            total_completion_tokens=total_output or None,
-            total_cached_tokens=total_cached or None,
-            total_steps=len(steps),
+        final_metrics=_aggregate_final_metrics(
+            steps,
+            extra={
+                "reasoning_tokens": _sum_tokens(
+                    *(s.metrics.extra.get("thoughts_tokens") for s in steps if s.metrics and s.metrics.extra)
+                )
+            },
         ),
     )
 

--- a/atif_converter/adapters/opencode.py
+++ b/atif_converter/adapters/opencode.py
@@ -30,6 +30,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
+from ._common import TOKEN_METRICS_VERSION, _aggregate_final_metrics, _sum_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -53,12 +54,12 @@ def _metrics_from_finish(finish: dict[str, Any]) -> tuple[Metrics | None, dict[s
     """Build per-step Metrics + a raw-tokens dict from a step-finish part."""
     tokens = finish.get("tokens", {})
     cost = finish.get("cost", 0) or 0
-    input_tok = tokens.get("input", 0) or 0
-    output_tok = tokens.get("output", 0) or 0
-    reasoning_tok = tokens.get("reasoning", 0) or 0
-    cache = tokens.get("cache", {})
-    cache_read = cache.get("read", 0) or 0
-    cache_write = cache.get("write", 0) or 0
+    input_tok = tokens.get("input")
+    output_tok = tokens.get("output")
+    reasoning_tok = tokens.get("reasoning")
+    cache = tokens.get("cache") or {}
+    cache_read = cache.get("read")
+    cache_write = cache.get("write")
 
     raw = {
         "input": input_tok,
@@ -70,11 +71,11 @@ def _metrics_from_finish(finish: dict[str, Any]) -> tuple[Metrics | None, dict[s
     }
 
     metrics: Metrics | None = None
-    if input_tok or output_tok or cache_read:
+    if tokens or cost:
         metrics = Metrics(
-            prompt_tokens=input_tok + cache_read,
-            completion_tokens=output_tok,
-            cached_tokens=cache_read if cache_read else None,
+            prompt_tokens=_sum_tokens(input_tok, cache_read, cache_write),
+            completion_tokens=_sum_tokens(output_tok, reasoning_tok),
+            cached_tokens=cache_read,
             cost_usd=cost if cost else None,
             extra={
                 k: v
@@ -82,7 +83,7 @@ def _metrics_from_finish(finish: dict[str, Any]) -> tuple[Metrics | None, dict[s
                     "reasoning_tokens": reasoning_tok,
                     "cache_write_tokens": cache_write,
                 }.items()
-                if v
+                if v is not None
             }
             or None,
         )
@@ -167,14 +168,11 @@ def _convert_from_session(session_path: Path) -> Trajectory | None:
     model_info = info.get("model", {}) if isinstance(info.get("model"), dict) else {}
     model_name = model_info.get("id") or model_info.get("modelID")
 
-    # Authoritative aggregate tokens (matches results JSON).
-    info_tokens = info.get("tokens", {}) if isinstance(info.get("tokens"), dict) else {}
-    agg_input = info_tokens.get("input", 0) or 0
-    agg_output = info_tokens.get("output", 0) or 0
-    agg_reasoning = info_tokens.get("reasoning", 0) or 0
-    agg_cache = info_tokens.get("cache", {}) if isinstance(info_tokens.get("cache"), dict) else {}
-    agg_cache_read = agg_cache.get("read", 0) or 0
-    agg_cache_write = agg_cache.get("write", 0) or 0
+    # Some exports include authoritative aggregates; others contain only
+    # per-message step-finish records.
+    info_tokens = info.get("tokens")
+    if not isinstance(info_tokens, dict):
+        info_tokens = {}
     agg_cost = info.get("cost", 0) or 0
 
     steps: list[Step] = []
@@ -211,23 +209,30 @@ def _convert_from_session(session_path: Path) -> Trajectory | None:
     if not steps:
         return None
 
-    final_metrics = FinalMetrics(
-        total_prompt_tokens=(agg_input + agg_cache_read) or None,
-        total_completion_tokens=agg_output or None,
-        total_cached_tokens=agg_cache_read or None,
-        total_cost_usd=agg_cost if agg_cost else None,
-        total_steps=len(steps),
-        extra={
-            k: v
-            for k, v in {
-                "input_tokens": agg_input or None,
-                "reasoning_tokens": agg_reasoning or None,
-                "cache_write_tokens": agg_cache_write or None,
-            }.items()
-            if v
-        }
-        or None,
-    )
+    final_metrics = _aggregate_final_metrics(steps, total_cost_usd=agg_cost or None)
+    metrics = None
+    if isinstance(info_tokens, dict) and info_tokens:
+        metrics, _raw = _metrics_from_finish({"tokens": info_tokens})
+    if metrics is not None:
+        final_metrics = FinalMetrics(
+            total_prompt_tokens=metrics.prompt_tokens,
+            total_completion_tokens=metrics.completion_tokens,
+            total_cached_tokens=metrics.cached_tokens,
+            total_cost_usd=agg_cost or None,
+            total_steps=len(steps),
+            extra={
+                "token_metrics_version": TOKEN_METRICS_VERSION,
+                "input_tokens": info_tokens.get("input"),
+                **(metrics.extra or {}),
+            },
+        )
+    else:
+        extra = dict(final_metrics.extra or {})
+        for key in ("reasoning_tokens", "cache_write_tokens"):
+            count = _sum_tokens(*(s.metrics.extra.get(key) for s in steps if s.metrics and s.metrics.extra))
+            if count is not None:
+                extra[key] = count
+        final_metrics.extra = extra
 
     return Trajectory(
         schema_version="ATIF-v1.7",

--- a/atif_converter/adapters/stratus.py
+++ b/atif_converter/adapters/stratus.py
@@ -51,7 +51,7 @@ from ..atif import (
     ToolCall,
     Trajectory,
 )
-from ._common import _load_jsonl, _stringify
+from ._common import TOKEN_METRICS_VERSION, _load_jsonl, _stringify, _sum_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,11 @@ def _metrics_from_usage(usage: dict[str, Any] | None, resp_meta: dict[str, Any] 
     if isinstance(details, dict):
         cached = details.get("cache_read")
     extra: dict[str, Any] = {}
+    if isinstance(details, dict) and details.get("cache_creation") is not None:
+        extra["cache_write_tokens"] = details["cache_creation"]
+    output_details = usage.get("output_token_details")
+    if isinstance(output_details, dict) and output_details.get("reasoning") is not None:
+        extra["reasoning_tokens"] = output_details["reasoning"]
     if resp_meta:
         # Keep model/cost breadcrumbs if the provider reported them.
         for key in ("model_name", "model", "finish_reason"):
@@ -265,6 +270,13 @@ def _aggregate_final_metrics(steps: list[Step]) -> FinalMetrics | None:
         total_cached_tokens=sum(cached) if cached else None,
         total_cost_usd=None,
         total_steps=len(steps),
+        extra={
+            "token_metrics_version": TOKEN_METRICS_VERSION,
+            **{
+                key: _sum_tokens(*(s.metrics.extra.get(key) for s in steps if s.metrics and s.metrics.extra))
+                for key in ("reasoning_tokens", "cache_write_tokens")
+            },
+        },
     )
 
 

--- a/atif_converter/converter.py
+++ b/atif_converter/converter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, cast
 
@@ -219,11 +220,19 @@ def detect_agent(session_file: Path | str) -> AgentName:
     raise UnsupportedFormatError(f"could not detect an agent format for {path}")
 
 
-def convert(session_file: Path | str, *, agent: AgentName | str | None = None) -> Trajectory:
+def convert(
+    session_file: Path | str,
+    *,
+    agent: AgentName | str | None = None,
+    telemetry_files: Sequence[Path | str] | None = None,
+) -> Trajectory:
     """Convert one native agent session file into a validated ATIF trajectory.
 
     The agent is detected from file contents unless ``agent`` explicitly selects
     one of :data:`SUPPORTED_AGENTS`.
+    Copilot callers can also supply native OTel JSONL files from the same run
+    for token counts absent from the CLI stream. Other agents do not accept
+    this option. The converter does not discover telemetry files itself.
     """
     path = _require_file(session_file)
     if agent is None:
@@ -234,8 +243,16 @@ def convert(session_file: Path | str, *, agent: AgentName | str | None = None) -
     else:
         selected = cast(AgentName, agent)
 
+    if telemetry_files is not None and selected != "copilot":
+        raise ValueError("telemetry_files is only supported for Copilot sessions")
+    telemetry = [_require_file(file) for file in telemetry_files] if telemetry_files is not None else []
+
     try:
-        trajectory = _CONVERTERS[selected](path)
+        trajectory = (
+            copilot.convert_file(path, telemetry_files=telemetry)
+            if telemetry_files is not None
+            else _CONVERTERS[selected](path)
+        )
     except AtifConverterError:
         raise
     except Exception as exc:

--- a/clients/claudecode/claudecode_agent.py
+++ b/clients/claudecode/claudecode_agent.py
@@ -3,12 +3,13 @@ Claude Code agent implementation for SREGym.
 Based on Harbor's Claude Code agent implementation for parity experiments.
 """
 
-import json
 import logging
 import os
 import shutil
 import subprocess
 from pathlib import Path
+
+from clients.harness.token_usage import aggregate_usage, read_jsonl, sum_counts, token_count, usage_metrics
 
 logger = logging.getLogger("all.claudecode.agent")
 
@@ -168,59 +169,36 @@ class ClaudeCodeAgent:
         logger.warning("Multiple Claude Code session directories found; could not identify the correct one")
         return None
 
-    def get_usage_metrics(self) -> dict[str, int]:
-        """
-        Extract usage metrics from Claude Code session files.
-
-        Returns:
-            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
-        """
-        metrics = {
-            "input_tokens": 0,
-            "cached_input_tokens": 0,
-            "output_tokens": 0,
-        }
-
+    def get_usage_metrics(self) -> dict[str, int | None]:
+        """Count each assistant message once, using its last usage update."""
         session_dir = self._get_session_dir()
         if not session_dir:
-            logger.debug("No Claude Code session directory found")
-            return metrics
+            return usage_metrics()
 
-        session_files = list(session_dir.glob("*.jsonl"))
-        if not session_files:
-            logger.debug(f"No session files found in {session_dir}")
-            return metrics
+        messages = {}
+        for session_file in sorted(session_dir.glob("*.jsonl")):
+            for index, event in enumerate(read_jsonl(session_file)):
+                if event.get("type") != "assistant":
+                    continue
+                message = event.get("message")
+                if not isinstance(message, dict) or not isinstance(message.get("usage"), dict):
+                    continue
+                key = message.get("id") or (str(session_file), index)
+                messages[key] = message["usage"]
 
-        total_input_tokens = 0
-        total_cached_tokens = 0
-        total_output_tokens = 0
-
-        for session_file in session_files:
-            with open(session_file) as handle:
-                for line in handle:
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        event = json.loads(stripped)
-                        message = event.get("message")
-                        if not isinstance(message, dict):
-                            continue
-
-                        usage = message.get("usage")
-                        if isinstance(usage, dict):
-                            total_input_tokens += usage.get("input_tokens", 0)
-                            total_cached_tokens += usage.get("cache_read_input_tokens", 0)
-                            total_output_tokens += usage.get("output_tokens", 0)
-                    except json.JSONDecodeError:
-                        continue
-
-        metrics["input_tokens"] = total_input_tokens
-        metrics["cached_input_tokens"] = total_cached_tokens
-        metrics["output_tokens"] = total_output_tokens
-
-        logger.info(f"Extracted usage metrics: {metrics}")
-        return metrics
+        records = []
+        for usage in messages.values():
+            cached = token_count(usage.get("cache_read_input_tokens"))
+            creation = token_count(usage.get("cache_creation_input_tokens"))
+            records.append(
+                usage_metrics(
+                    input_tokens=sum_counts([token_count(usage.get("input_tokens")), cached, creation]),
+                    output_tokens=token_count(usage.get("output_tokens")),
+                    cached_input_tokens=cached,
+                    cache_creation_input_tokens=creation,
+                )
+            )
+        return aggregate_usage(records)
 
     def _setup_sessions_structure(self) -> None:
         """Create required Claude Code session directory structure."""

--- a/clients/codex/codex_agent.py
+++ b/clients/codex/codex_agent.py
@@ -13,6 +13,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from clients.harness.token_usage import read_jsonl, token_count, usage_metrics
+
 logger = logging.getLogger("all.codex.agent")
 
 _CUSTOM_PROVIDER_ID = "sregym_custom"
@@ -186,47 +188,41 @@ class CodexAgent:
 
         return str(parsed), None
 
-    def get_usage_metrics(self) -> dict[str, int]:
-        """
-        Extract usage metrics from Codex output.
+    def get_usage_metrics(self) -> dict[str, int | None]:
+        """Read cumulative session usage, with CLI output as a fallback."""
+        output = list(read_jsonl(self.output_path)) if self.output_path.exists() else []
+        thread_id = next((event.get("thread_id") for event in output if event.get("type") == "thread.started"), None)
+        sessions = list((self.logs_dir / "sessions").rglob("*.jsonl"))
+        if thread_id:
+            sessions = [path for path in sessions if thread_id in path.name]
 
-        Returns:
-            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
-        """
-        metrics = {
-            "input_tokens": 0,
-            "cached_input_tokens": 0,
-            "output_tokens": 0,
-        }
+        usage = None
+        # An ambiguous directory can include other sessions. Do not count them.
+        if len(sessions) == 1:
+            for event in read_jsonl(sessions[0]):
+                payload = event.get("payload") or {}
+                if (
+                    event.get("type") != "event_msg"
+                    or not isinstance(payload, dict)
+                    or payload.get("type") != "token_count"
+                ):
+                    continue
+                info = payload.get("info")
+                if not isinstance(info, dict):
+                    continue
+                total = info.get("total_token_usage")
+                if isinstance(total, dict):
+                    usage = total
+        if usage is None:
+            usage = next((event["usage"] for event in reversed(output) if isinstance(event.get("usage"), dict)), {})
 
-        if not self.output_path.exists():
-            logger.debug(f"Codex output file {self.output_path} does not exist")
-            return metrics
-
-        with open(self.output_path) as f:
-            lines = f.readlines()
-
-        # Parse from the end to get the most recent usage info
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                parsed = json.loads(line)
-
-                if isinstance(parsed, dict) and "usage" in parsed:
-                    usage = parsed["usage"]
-                    metrics["input_tokens"] = usage.get("input_tokens", 0)
-                    metrics["cached_input_tokens"] = usage.get("cached_input_tokens", 0)
-                    metrics["output_tokens"] = usage.get("output_tokens", 0)
-                    logger.info(f"Extracted usage metrics: {metrics}")
-                    return metrics
-
-            except json.JSONDecodeError:
-                continue
-
-        return metrics
+        # Codex totals already contain cache hits and reasoning.
+        return usage_metrics(
+            input_tokens=token_count(usage.get("input_tokens")),
+            output_tokens=token_count(usage.get("output_tokens")),
+            cached_input_tokens=token_count(usage.get("cached_input_tokens")),
+            reasoning_output_tokens=token_count(usage.get("reasoning_output_tokens")),
+        )
 
     def _setup_auth(self) -> bool:
         """Set up authentication for Codex.

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -2,12 +2,13 @@
 GitHub Copilot CLI agent implementation for SREGym.
 """
 
-import json
 import logging
 import os
 import shutil
 import subprocess
 from pathlib import Path
+
+from clients.harness.token_usage import aggregate_usage, read_jsonl, token_count, usage_metrics
 
 logger = logging.getLogger("all.copilot.agent")
 
@@ -113,54 +114,69 @@ class CopilotCliAgent:
         """Path to session transcript markdown."""
         return self.logs_dir / "copilot-session.md"
 
-    def get_usage_metrics(self) -> dict[str, int]:
-        """
-        Extract usage metrics from Copilot CLI OTel JSONL files.
+    def get_usage_metrics(self) -> dict[str, int | None]:
+        """Count chat spans, not both chat spans and their parent totals."""
+        records = []
+        seen = set()
+        for path in sorted(self.otel_dir.glob("*.jsonl")):
+            for event in read_jsonl(path):
+                attrs = event.get("attributes") or {}
+                if not isinstance(attrs, dict):
+                    continue
+                # Older files lack the operation attribute. Their usage rows
+                # already describe individual requests.
+                if attrs.get("gen_ai.operation.name") not in {None, "chat"}:
+                    continue
+                span_id = event.get("span_id") or event.get("spanId")
+                if span_id and span_id in seen:
+                    continue
+                if span_id:
+                    seen.add(span_id)
+                if not any(key in attrs for key in ("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens")):
+                    continue
+                records.append(
+                    usage_metrics(
+                        input_tokens=token_count(attrs.get("gen_ai.usage.input_tokens")),
+                        output_tokens=token_count(attrs.get("gen_ai.usage.output_tokens")),
+                        cached_input_tokens=token_count(
+                            attrs.get(
+                                "gen_ai.usage.cache_read.input_tokens",
+                                attrs.get("gen_ai.usage.cache_read_input_tokens"),
+                            )
+                        ),
+                        cache_creation_input_tokens=token_count(attrs.get("gen_ai.usage.cache_creation.input_tokens")),
+                        reasoning_output_tokens=token_count(attrs.get("gen_ai.usage.reasoning_tokens")),
+                    )
+                )
+        if records:
+            return aggregate_usage(records)
 
-        Returns:
-            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
-        """
-        metrics = {
-            "input_tokens": 0,
-            "cached_input_tokens": 0,
-            "output_tokens": 0,
-        }
-
-        if not self.otel_dir.exists():
-            logger.debug("No OTel directory found for metrics")
-            return metrics
-
-        otel_files = list(self.otel_dir.glob("*.jsonl"))
-        if not otel_files:
-            logger.debug(f"No OTel JSONL files found in {self.otel_dir}")
-            return metrics
-
-        total_input = 0
-        total_output = 0
-        total_cached = 0
-
-        for otel_file in otel_files:
-            with open(otel_file) as handle:
-                for line in handle:
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        event = json.loads(stripped)
-                        attrs = event.get("attributes", {})
-                        # OTel semantic conventions for GenAI
-                        total_input += attrs.get("gen_ai.usage.input_tokens", 0)
-                        total_output += attrs.get("gen_ai.usage.output_tokens", 0)
-                        total_cached += attrs.get("gen_ai.usage.cache_read_input_tokens", 0)
-                    except json.JSONDecodeError:
-                        continue
-
-        metrics["input_tokens"] = total_input
-        metrics["output_tokens"] = total_output
-        metrics["cached_input_tokens"] = total_cached
-
-        logger.info(f"Extracted usage metrics: {metrics}")
-        return metrics
+        # Structured CLI output is also available when OTel is absent.
+        calls = {}
+        messages = []
+        if self.jsonl_path.exists():
+            for index, event in enumerate(read_jsonl(self.jsonl_path)):
+                data = event.get("data") or {}
+                if not isinstance(data, dict):
+                    continue
+                if event.get("type") == "assistant.usage":
+                    key = data.get("apiCallId") or event.get("id") or index
+                    calls[key] = usage_metrics(
+                        input_tokens=token_count(data.get("inputTokens")),
+                        output_tokens=token_count(data.get("outputTokens")),
+                        cached_input_tokens=token_count(data.get("cacheReadTokens")),
+                        cache_creation_input_tokens=token_count(data.get("cacheWriteTokens")),
+                        reasoning_output_tokens=token_count(data.get("reasoningTokens")),
+                    )
+                elif event.get("type") == "usage":
+                    calls[index] = usage_metrics(
+                        input_tokens=token_count(event.get("input_tokens")),
+                        output_tokens=token_count(event.get("output_tokens")),
+                        cached_input_tokens=token_count(event.get("cached_input_tokens")),
+                    )
+                elif event.get("type") == "assistant.message":
+                    messages.append(usage_metrics(output_tokens=token_count(data.get("outputTokens"))))
+        return aggregate_usage(calls.values() if calls else messages)
 
     def _build_command(self, instruction: str) -> list[str]:
         """Build the Copilot command, preserving the CLI's default effort when unset."""

--- a/clients/copilot/copilot_agent.py
+++ b/clients/copilot/copilot_agent.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from clients.harness.token_usage import aggregate_usage, read_jsonl, token_count, usage_metrics
+from clients.harness.token_usage import TOKEN_FIELDS, aggregate_usage, read_jsonl, token_count, usage_metrics
 
 logger = logging.getLogger("all.copilot.agent")
 
@@ -145,13 +145,17 @@ class CopilotCliAgent:
                             )
                         ),
                         cache_creation_input_tokens=token_count(attrs.get("gen_ai.usage.cache_creation.input_tokens")),
-                        reasoning_output_tokens=token_count(attrs.get("gen_ai.usage.reasoning_tokens")),
+                        reasoning_output_tokens=token_count(
+                            attrs.get(
+                                "gen_ai.usage.reasoning.output_tokens", attrs.get("gen_ai.usage.reasoning_tokens")
+                            )
+                        ),
                     )
                 )
-        if records:
-            return aggregate_usage(records)
+        telemetry_usage = aggregate_usage(records)
 
-        # Structured CLI output is also available when OTel is absent.
+        # Keep CLI fields that telemetry does not report. These are two views
+        # of the same calls, so never add their totals together.
         calls = {}
         messages = []
         if self.jsonl_path.exists():
@@ -176,7 +180,13 @@ class CopilotCliAgent:
                     )
                 elif event.get("type") == "assistant.message":
                     messages.append(usage_metrics(output_tokens=token_count(data.get("outputTokens"))))
-        return aggregate_usage(calls.values() if calls else messages)
+        stream_usage = aggregate_usage(calls.values() if calls else messages)
+        return usage_metrics(
+            **{
+                field: telemetry_usage[field] if telemetry_usage[field] is not None else stream_usage[field]
+                for field in TOKEN_FIELDS
+            }
+        )
 
     def _build_command(self, instruction: str) -> list[str]:
         """Build the Copilot command, preserving the CLI's default effort when unset."""

--- a/clients/cursor/cursor_agent.py
+++ b/clients/cursor/cursor_agent.py
@@ -17,6 +17,8 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from clients.harness.token_usage import usage_metrics
+
 logger = logging.getLogger("all.cursor.agent")
 
 _INSTALL_URL = "https://cursor.com/install"
@@ -113,13 +115,13 @@ class CursorAgent:
         """Path to the raw `agent` CLI JSON output."""
         return self.logs_dir / self._OUTPUT_FILENAME
 
-    def get_usage_metrics(self) -> dict[str, int]:
+    def get_usage_metrics(self) -> dict[str, int | None]:
         """
         Cursor's `--output-format json` result does not report token usage,
-        so this always returns zeros. Kept for interface parity with the
+        so this returns unknown counts. Kept for interface parity with the
         other agent clients, whose usage metrics feed the same report.
         """
-        return {"input_tokens": 0, "cached_input_tokens": 0, "output_tokens": 0}
+        return usage_metrics()
 
     def generate_trajectory(self, problem_id: str) -> Path | None:
         """Cursor CLI trajectories are not wired into the visualizer yet."""

--- a/clients/geminicli/geminicli_agent.py
+++ b/clients/geminicli/geminicli_agent.py
@@ -13,6 +13,8 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
+from clients.harness.token_usage import aggregate_usage, read_jsonl, sum_counts, token_count, usage_metrics
+
 logger = logging.getLogger("all.geminicli.agent")
 
 
@@ -157,49 +159,68 @@ class GeminiCliAgent:
             logger.warning(f"Could not copy session file: {e}")
             return None
 
-    def get_usage_metrics(self) -> dict[str, int]:
-        """
-        Extract usage metrics from Gemini CLI session file.
-
-        Returns:
-            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
-        """
-        metrics = {
-            "input_tokens": 0,
-            "cached_input_tokens": 0,
-            "output_tokens": 0,
-        }
-
-        # Read directly from the session file
+    def get_usage_metrics(self) -> dict[str, int | None]:
+        """Read inclusive totals from the native JSON or JSONL session."""
         session_file = self._find_session_file()
         if not session_file or not session_file.exists():
-            logger.debug("No session file found for metrics")
-            return metrics
+            return usage_metrics()
 
         try:
             trajectory = json.loads(session_file.read_text())
-        except Exception as e:
-            logger.warning(f"Error loading session: {e}")
-            return metrics
+            messages = trajectory.get("messages", []) if isinstance(trajectory, dict) else []
+        except json.JSONDecodeError:
+            messages = self._usage_messages(session_file)
+        except OSError as error:
+            logger.warning("Could not read Gemini usage: %s", error)
+            return usage_metrics()
 
-        total_input = 0
-        total_output = 0
-        total_cached = 0
+        records = []
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            tokens = message.get("tokens")
+            if message.get("type") != "gemini" or not isinstance(tokens, dict):
+                continue
+            reasoning = token_count(tokens.get("thoughts"))
+            # `tool` is toolUsePromptTokenCount: tool results sent as input.
+            records.append(
+                usage_metrics(
+                    input_tokens=sum_counts([token_count(tokens.get("input")), token_count(tokens.get("tool"))]),
+                    output_tokens=sum_counts([token_count(tokens.get("output")), reasoning]),
+                    cached_input_tokens=token_count(tokens.get("cached")),
+                    reasoning_output_tokens=reasoning,
+                )
+            )
+        return aggregate_usage(records)
 
-        for message in trajectory.get("messages", []):
-            if message.get("type") == "gemini":
-                tokens = message.get("tokens", {})
-                total_input += tokens.get("input", 0)
-                # output includes: output + thoughts + tool tokens
-                total_output += tokens.get("output", 0) + tokens.get("thoughts", 0) + tokens.get("tool", 0)
-                total_cached += tokens.get("cached", 0)
-
-        metrics["input_tokens"] = total_input
-        metrics["output_tokens"] = total_output
-        metrics["cached_input_tokens"] = total_cached
-
-        logger.info(f"Extracted usage metrics: {metrics}")
-        return metrics
+    @staticmethod
+    def _usage_messages(session_file: Path) -> list[dict]:
+        """Replay usage updates by message ID without importing the converter."""
+        messages = {}
+        pending = {}
+        for record in read_jsonl(session_file):
+            if "$rewindTo" in record:
+                ids = list(messages)
+                target = record["$rewindTo"]
+                removed = ids[ids.index(target) :] if target in messages else ids
+                for message_id in removed:
+                    messages.pop(message_id, None)
+                    pending.pop(message_id, None)
+                continue
+            message_id = record.get("id")
+            if not isinstance(message_id, str):
+                continue
+            if record.get("type") in {"gemini", "user"}:
+                message = messages.setdefault(message_id, {})
+                message.update(record)
+                if message_id in pending:
+                    message.setdefault("tokens", {}).update(pending.pop(message_id))
+            elif record.get("type") == "message_update" and isinstance(record.get("tokens"), dict):
+                if message_id in messages:
+                    messages[message_id].setdefault("tokens", {}).update(record["tokens"])
+                else:
+                    pending.setdefault(message_id, {}).update(record["tokens"])
+        return list(messages.values())
 
     def _build_command(self, instruction: str) -> str:
         model = self.model_name.split("/")[-1]

--- a/clients/harness/token_usage.py
+++ b/clients/harness/token_usage.py
@@ -1,0 +1,75 @@
+"""Token totals for client results. This module has no ATIF dependency.
+
+Input includes cache reads and writes. Output includes reasoning. The cache
+and reasoning fields are breakdowns, not additional tokens. Version 2 marks
+these definitions; older results did not use consistent definitions.
+"""
+
+import json
+import logging
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+TOKEN_METRICS_VERSION = 2
+TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cached_input_tokens",
+    "cache_creation_input_tokens",
+    "reasoning_output_tokens",
+)
+
+
+def token_count(value: object) -> int | None:
+    """Keep reported nonnegative integer counts, including explicit zero."""
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def sum_counts(values: Iterable[int | None]) -> int | None:
+    """Sum reported counts without turning an absent measurement into zero."""
+    known = [value for value in values if value is not None]
+    return sum(known) if known else None
+
+
+def usage_metrics(
+    *,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cached_input_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
+    reasoning_output_tokens: int | None = None,
+) -> dict[str, int | None]:
+    """Build results from inclusive totals. Do not add the breakdowns again."""
+    return {
+        "token_metrics_version": TOKEN_METRICS_VERSION,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cached_input_tokens": cached_input_tokens,
+        "cache_creation_input_tokens": cache_creation_input_tokens,
+        "reasoning_output_tokens": reasoning_output_tokens,
+        "total_tokens": input_tokens + output_tokens
+        if input_tokens is not None and output_tokens is not None
+        else None,
+    }
+
+
+def aggregate_usage(records: Iterable[Mapping[str, int | None]]) -> dict[str, int | None]:
+    """Sum distinct calls. Callers must resolve cumulative or repeated records."""
+    records = list(records)
+    return usage_metrics(**{field: sum_counts(record.get(field) for record in records) for field in TOKEN_FIELDS})
+
+
+def read_jsonl(path: Path) -> Iterable[dict]:
+    """Read complete records, including records from interrupted runs."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict):
+                    yield record
+    except OSError as error:
+        logger.warning("Could not read token usage from %s: %s", path, error)

--- a/clients/opencode/opencode_agent.py
+++ b/clients/opencode/opencode_agent.py
@@ -12,6 +12,8 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from clients.harness.token_usage import aggregate_usage, read_jsonl, sum_counts, token_count, usage_metrics
+
 logger = logging.getLogger("all.opencode.agent")
 
 
@@ -291,66 +293,69 @@ class OpenCodeAgent:
 
         return None
 
-    def get_usage_metrics(self) -> dict[str, int]:
-        """
-        Extract usage metrics from OpenCode output.
+    @staticmethod
+    def _token_usage(tokens: dict) -> dict[str, int | None]:
+        """OpenCode reports uncached input and non-reasoning output separately."""
+        cache = tokens.get("cache") or {}
+        if not isinstance(cache, dict):
+            cache = {}
+        cached = token_count(cache.get("read"))
+        creation = token_count(cache.get("write"))
+        reasoning = token_count(tokens.get("reasoning"))
+        return usage_metrics(
+            input_tokens=sum_counts([token_count(tokens.get("input")), cached, creation]),
+            output_tokens=sum_counts([token_count(tokens.get("output")), reasoning]),
+            cached_input_tokens=cached,
+            cache_creation_input_tokens=creation,
+            reasoning_output_tokens=reasoning,
+        )
 
-        Returns:
-            Dictionary with keys: input_tokens, cached_input_tokens, output_tokens
-        """
-        metrics = {
-            "input_tokens": 0,
-            "cached_input_tokens": 0,
-            "output_tokens": 0,
-        }
+    def get_usage_metrics(self) -> dict[str, int | None]:
+        """Prefer the exported session; fall back to completed stream records."""
+        session_id = self._get_session_id()
+        sessions = list(self.sessions_dir.rglob(f"session-{session_id}.json" if session_id else "session-*.json"))
+        if len(sessions) == 1:
+            try:
+                session = json.loads(sessions[0].read_text())
+                tokens = (session.get("info") or {}).get("tokens")
+                if isinstance(tokens, dict) and tokens:
+                    return self._token_usage(tokens)
+                return aggregate_usage(
+                    self._token_usage(part["tokens"])
+                    for message in session.get("messages", [])
+                    if (message.get("info") or {}).get("role") == "assistant"
+                    for part in message.get("parts", [])
+                    if part.get("type") == "step-finish" and isinstance(part.get("tokens"), dict)
+                )
+            except (OSError, ValueError, TypeError, AttributeError) as error:
+                logger.warning("Could not read OpenCode session usage: %s", error)
 
-        if not self.output_path.exists():
-            logger.debug(f"OpenCode output file {self.output_path} does not exist")
-            return metrics
-
-        total_input = 0
-        total_output = 0
-        total_cached = 0
-
-        try:
-            with open(self.output_path) as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
+        records = []
+        legacy_records = []
+        seen_parts = set()
+        if self.output_path.exists():
+            for event in read_jsonl(self.output_path):
+                part = event.get("part") or {}
+                if not isinstance(part, dict):
+                    continue
+                if event.get("type") == "step_finish" and isinstance(part.get("tokens"), dict):
+                    part_id = part.get("id")
+                    if part_id and part_id in seen_parts:
                         continue
-                    try:
-                        data = json.loads(line)
-                        if not isinstance(data, dict):
-                            continue
-
-                        # OpenCode format: step_finish events have tokens
-                        if data.get("type") == "step_finish":
-                            part = data.get("part", {})
-                            tokens = part.get("tokens", {})
-                            if tokens:
-                                total_input += tokens.get("input", 0)
-                                total_output += tokens.get("output", 0) + tokens.get("reasoning", 0)
-                                cache = tokens.get("cache", {})
-                                total_cached += cache.get("read", 0)
-
-                        # Also check for standard usage format
-                        if "usage" in data:
-                            usage = data["usage"]
-                            total_input += usage.get("input_tokens", 0)
-                            total_output += usage.get("output_tokens", 0)
-                            total_cached += usage.get("cached_input_tokens", 0)
-
-                    except json.JSONDecodeError:
-                        continue
-        except Exception as e:
-            logger.warning(f"Error parsing OpenCode output for metrics: {e}")
-
-        metrics["input_tokens"] = total_input
-        metrics["output_tokens"] = total_output
-        metrics["cached_input_tokens"] = total_cached
-
-        logger.info(f"Extracted usage metrics: {metrics}")
-        return metrics
+                    if part_id:
+                        seen_parts.add(part_id)
+                    records.append(self._token_usage(part["tokens"]))
+                elif isinstance(event.get("usage"), dict):
+                    usage = event["usage"]
+                    legacy_records.append(
+                        usage_metrics(
+                            input_tokens=token_count(usage.get("input_tokens")),
+                            output_tokens=token_count(usage.get("output_tokens")),
+                            cached_input_tokens=token_count(usage.get("cached_input_tokens")),
+                            reasoning_output_tokens=token_count(usage.get("reasoning_output_tokens")),
+                        )
+                    )
+        return aggregate_usage(records or legacy_records)
 
     def _build_env(self) -> dict[str, str]:
         """Build environment variables for OpenCode execution."""

--- a/clients/stratus/stratus_agent/driver/driver.py
+++ b/clients/stratus/stratus_agent/driver/driver.py
@@ -30,6 +30,7 @@ init_logger()
 import logging  # noqa: E402
 
 from clients.harness.problem_id import resolve_problem_id  # noqa: E402
+from clients.harness.token_usage import TOKEN_METRICS_VERSION  # noqa: E402
 from clients.stratus.configs.langgraph_tool_configs import LanggraphToolConfig  # noqa: E402
 from clients.stratus.stratus_agent.diagnosis_agent import (  # noqa: E402
     single_run_with_predefined_prompts as diagnosis_single_run,
@@ -858,6 +859,7 @@ async def main():
         )
 
     agent_output_df["agent_name"] = agent_names
+    # LangChain usage totals already include cache hits and reasoning.
     agent_output_df["input_tokens"] = agent_in_tokens
     agent_output_df["output_tokens"] = agent_out_tokens
     agent_output_df["total_tokens"] = agent_total_tokens
@@ -891,6 +893,7 @@ async def main():
         agent_output_df = pd.concat([agent_output_df, summary_row], ignore_index=True)
 
     csv_path = problem_dir / f"{current_problem}_stratus_output.csv"
+    agent_output_df["token_metrics_version"] = TOKEN_METRICS_VERSION
     agent_output_df.to_csv(csv_path, index=False, header=True)
     save_combined_trajectory(all_trajectories, current_problem, output_dir=problem_dir)
 

--- a/sregym/traces/convert.py
+++ b/sregym/traces/convert.py
@@ -155,6 +155,8 @@ def _convert_native_run(run_dir: Path, tool: str) -> Trajectory | None:
         session_file = _find_session_file(run_dir, tool)
         if session_file is None:
             return None
+        if tool == "copilot":
+            return convert_session(session_file, agent=tool, telemetry_files=sorted((run_dir / "otel").glob("*.jsonl")))
         return convert_session(session_file, agent=tool)
     except AtifConverterError as exc:
         logger.debug("Could not convert %s run %s: %s", tool, run_dir, exc)

--- a/tests/clients/test_token_metrics.py
+++ b/tests/clients/test_token_metrics.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from atif_converter import convert
 from atif_converter.adapters import claudecode, codex, copilot, gemini, opencode, stratus
 from clients.claudecode.claudecode_agent import ClaudeCodeAgent
 from clients.codex.codex_agent import CodexAgent
@@ -158,7 +159,8 @@ def test_recorded_copilot_stream_matches_atif(fixture, tmp_path):
     assert_totals_match(agent.get_usage_metrics(), copilot.convert_file(agent.jsonl_path))
 
 
-def test_copilot_does_not_add_parent_totals_or_repeated_spans(tmp_path):
+@pytest.mark.parametrize("reasoning_key", ["gen_ai.usage.reasoning.output_tokens", "gen_ai.usage.reasoning_tokens"])
+def test_copilot_does_not_add_parent_totals_or_repeated_spans(tmp_path, reasoning_key):
     agent = CopilotCliAgent(tmp_path, "example")
     agent.otel_dir.mkdir()
     attrs = {
@@ -167,7 +169,7 @@ def test_copilot_does_not_add_parent_totals_or_repeated_spans(tmp_path):
         "gen_ai.usage.output_tokens": 40,
         "gen_ai.usage.cache_read.input_tokens": 50,
         "gen_ai.usage.cache_creation.input_tokens": 20,
-        "gen_ai.usage.reasoning_tokens": 10,
+        reasoning_key: 10,
     }
     chat = {"span_id": "chat1", "attributes": attrs}
     parent = {"span_id": "parent", "attributes": {**attrs, "gen_ai.operation.name": "invoke_agent"}}
@@ -179,6 +181,66 @@ def test_copilot_does_not_add_parent_totals_or_repeated_spans(tmp_path):
     assert usage["cached_input_tokens"] == 50
     assert usage["cache_creation_input_tokens"] == 20
     assert usage["reasoning_output_tokens"] == 10
+    # Native CLI streams can omit input usage entirely. The independent
+    # converter must get those counts from the explicitly supplied telemetry.
+    agent.jsonl_path.write_text(
+        json.dumps({"type": "assistant.message", "data": {"content": "ok", "outputTokens": 40}}) + "\n"
+    )
+    trajectory = convert(agent.jsonl_path, telemetry_files=[agent.otel_dir / "spans.jsonl"])
+    assert_totals_match(usage, trajectory)
+    assert trajectory.final_metrics.extra["reasoning_tokens"] == 10
+    assert trajectory.final_metrics.extra["cache_write_tokens"] == 20
+
+
+@pytest.mark.parametrize("reported_input", [100, 0])
+def test_copilot_telemetry_replaces_stream_totals_without_losing_unreported_fields(tmp_path, reported_input):
+    from sregym.traces.convert import convert_run
+
+    run = tmp_path / "results/b/copilot/problem/run_1"
+    agent = CopilotCliAgent(run, "example")
+    agent.jsonl_path.write_text(
+        json.dumps({"type": "message", "role": "assistant", "content": "ok"})
+        + "\n"
+        + json.dumps({"type": "usage", "input_tokens": 90, "output_tokens": 40})
+        + "\n"
+    )
+    agent.otel_dir.mkdir()
+    span = {
+        "type": "span",
+        "spanId": "one",
+        "attributes": {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.usage.input_tokens": reported_input,
+        },
+    }
+    telemetry = agent.otel_dir / "one.jsonl"
+    telemetry.write_text(json.dumps(span) + '\n{"truncated":')
+    # The same span can occur in overlapping exported files.
+    (agent.otel_dir / "two.jsonl").write_text(json.dumps(span) + "\n[]\n")
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] == reported_input
+    assert usage["output_tokens"] == 40
+    trajectory = convert_run(run)
+    assert_totals_match(usage, trajectory)
+    assert trajectory.final_metrics.total_prompt_tokens == reported_input
+
+
+def test_copilot_irrelevant_telemetry_preserves_stream_usage(tmp_path):
+    agent = CopilotCliAgent(tmp_path, "example")
+    agent.jsonl_path.write_text(
+        json.dumps({"type": "message", "role": "assistant", "content": "ok"})
+        + "\n"
+        + json.dumps({"type": "usage", "input_tokens": 100, "output_tokens": 40})
+        + "\n"
+    )
+    agent.otel_dir.mkdir()
+    telemetry = agent.otel_dir / "spans.jsonl"
+    telemetry.write_text(
+        json.dumps({"attributes": {"gen_ai.operation.name": "invoke_agent", "gen_ai.usage.input_tokens": 999}})
+    )
+    trajectory = convert(agent.jsonl_path, telemetry_files=[telemetry])
+    assert_totals_match(agent.get_usage_metrics(), trajectory)
+    assert trajectory.final_metrics.total_prompt_tokens == 100
 
 
 def test_copilot_native_usage_replaces_message_estimate(tmp_path):

--- a/tests/clients/test_token_metrics.py
+++ b/tests/clients/test_token_metrics.py
@@ -1,0 +1,330 @@
+"""Client results and standalone ATIF exports must use the same token totals."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from atif_converter.adapters import claudecode, codex, copilot, gemini, opencode, stratus
+from clients.claudecode.claudecode_agent import ClaudeCodeAgent
+from clients.codex.codex_agent import CodexAgent
+from clients.copilot.copilot_agent import CopilotCliAgent
+from clients.cursor.cursor_agent import CursorAgent
+from clients.geminicli.geminicli_agent import GeminiCliAgent
+from clients.harness.token_usage import aggregate_usage, usage_metrics
+from clients.opencode.opencode_agent import OpenCodeAgent
+
+FIXTURES = Path(__file__).parents[1] / "traces" / "fixtures"
+
+
+def assert_totals_match(usage, trajectory):
+    final = trajectory.final_metrics
+    assert usage["input_tokens"] == final.total_prompt_tokens
+    assert usage["output_tokens"] == final.total_completion_tokens
+    assert usage["cached_input_tokens"] == final.total_cached_tokens
+    expected_total = (
+        usage["input_tokens"] + usage["output_tokens"]
+        if usage["input_tokens"] is not None and usage["output_tokens"] is not None
+        else None
+    )
+    assert usage["total_tokens"] == expected_total
+    assert usage["token_metrics_version"] == 2
+
+
+@pytest.mark.parametrize("agent_name", ["opencode", "claudecode", "codex", "gemini"])
+def test_recorded_run_matches_atif(agent_name, tmp_path):
+    shutil.copytree(FIXTURES / f"{agent_name}_run", tmp_path, dirs_exist_ok=True)
+    if agent_name == "opencode":
+        agent = OpenCodeAgent(tmp_path, "openai/example")
+        trajectory = opencode.convert_file(next((tmp_path / "sessions").rglob("session-*.json")))
+    elif agent_name == "claudecode":
+        agent = ClaudeCodeAgent(tmp_path, "example")
+        trajectory = claudecode.convert_files(list((tmp_path / "sessions/projects/-logs").glob("*.jsonl")))
+    elif agent_name == "codex":
+        agent = CodexAgent(tmp_path, "example")
+        trajectory = codex.convert_file(next((tmp_path / "sessions").rglob("*.jsonl")))
+    else:
+        agent = GeminiCliAgent(tmp_path, "example", gemini_home=tmp_path)
+        session = next((tmp_path / "sessions").rglob("session-*"))
+        home_sessions = tmp_path / "tmp/chats"
+        home_sessions.mkdir(parents=True)
+        shutil.copy(session, home_sessions / session.name)
+        trajectory = gemini.convert_file(session)
+    assert_totals_match(agent.get_usage_metrics(), trajectory)
+
+
+@pytest.mark.parametrize(
+    "agent_class", [OpenCodeAgent, ClaudeCodeAgent, CodexAgent, GeminiCliAgent, CopilotCliAgent, CursorAgent]
+)
+def test_missing_usage_is_unknown(agent_class, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent = agent_class(tmp_path, "openai/example")
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] is None
+    assert usage["output_tokens"] is None
+    assert usage["cached_input_tokens"] is None
+    assert usage["total_tokens"] is None
+    assert usage["token_metrics_version"] == 2
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        {"input": 100, "output": 40, "reasoning": 10, "cache": {"read": 50, "write": 20}},
+        {"input": 0, "output": 0, "reasoning": 10, "cache": {"read": 0, "write": 20}},
+        {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    ],
+)
+def test_opencode_split_tokens(tokens, tmp_path):
+    agent = OpenCodeAgent(tmp_path, "openai/example")
+    finish = {"type": "step-finish", "tokens": tokens}
+    agent.output_path.write_text(json.dumps({"type": "step_finish", "part": finish}) + "\n")
+    usage = agent.get_usage_metrics()
+    metrics, _ = opencode._metrics_from_finish(finish)
+    assert usage["input_tokens"] == tokens["input"] + sum(tokens["cache"].values())
+    assert usage["output_tokens"] == tokens["output"] + tokens["reasoning"]
+    assert usage["reasoning_output_tokens"] == tokens["reasoning"]
+    assert usage["cache_creation_input_tokens"] == tokens["cache"]["write"]
+    assert metrics.prompt_tokens == usage["input_tokens"]
+    assert metrics.completion_tokens == usage["output_tokens"]
+    assert metrics.cached_tokens == usage["cached_input_tokens"]
+
+
+def test_claude_streaming_usage_counted_once(tmp_path):
+    agent = ClaudeCodeAgent(tmp_path, "example")
+    project = agent.sessions_dir / "projects/test"
+    project.mkdir(parents=True)
+    events = [
+        {
+            "type": "assistant",
+            "message": {
+                "id": "same",
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_read_input_tokens": 50,
+                    "cache_creation_input_tokens": 20,
+                    "output_tokens": output,
+                },
+            },
+        }
+        for output in (1, 40, 40)
+    ]
+    (project / "session.jsonl").write_text("\n".join(map(json.dumps, events)))
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] == 170
+    assert usage["output_tokens"] == 40
+    assert usage["cached_input_tokens"] == 50
+    assert usage["cache_creation_input_tokens"] == 20
+    assert usage["reasoning_output_tokens"] is None
+
+
+def test_gemini_tool_prompt_tokens_are_input(tmp_path):
+    agent = GeminiCliAgent(tmp_path, "example", gemini_home=tmp_path)
+    chats = tmp_path / "tmp/chats"
+    chats.mkdir(parents=True)
+    session = chats / "session-test.json"
+    session.write_text(
+        json.dumps(
+            {
+                "sessionId": "test",
+                "messages": [
+                    {
+                        "type": "gemini",
+                        "content": "ok",
+                        "tokens": {
+                            "input": 100,
+                            "output": 40,
+                            "thoughts": 10,
+                            "tool": 20,
+                            "cached": 50,
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] == 120
+    assert usage["output_tokens"] == 50
+    assert usage["reasoning_output_tokens"] == 10
+    assert_totals_match(usage, gemini.convert_file(session))
+
+
+@pytest.mark.parametrize("fixture", ["copilot_run_flat", "copilot_run_real"])
+def test_recorded_copilot_stream_matches_atif(fixture, tmp_path):
+    shutil.copytree(FIXTURES / fixture, tmp_path, dirs_exist_ok=True)
+    agent = CopilotCliAgent(tmp_path, "example")
+    assert_totals_match(agent.get_usage_metrics(), copilot.convert_file(agent.jsonl_path))
+
+
+def test_copilot_does_not_add_parent_totals_or_repeated_spans(tmp_path):
+    agent = CopilotCliAgent(tmp_path, "example")
+    agent.otel_dir.mkdir()
+    attrs = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 40,
+        "gen_ai.usage.cache_read.input_tokens": 50,
+        "gen_ai.usage.cache_creation.input_tokens": 20,
+        "gen_ai.usage.reasoning_tokens": 10,
+    }
+    chat = {"span_id": "chat1", "attributes": attrs}
+    parent = {"span_id": "parent", "attributes": {**attrs, "gen_ai.operation.name": "invoke_agent"}}
+    (agent.otel_dir / "spans.jsonl").write_text("\n".join(map(json.dumps, [chat, parent, chat])))
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 40
+    assert usage["total_tokens"] == 140
+    assert usage["cached_input_tokens"] == 50
+    assert usage["cache_creation_input_tokens"] == 20
+    assert usage["reasoning_output_tokens"] == 10
+
+
+def test_copilot_native_usage_replaces_message_estimate(tmp_path):
+    agent = CopilotCliAgent(tmp_path, "example")
+    events = [
+        {"type": "assistant.message", "data": {"content": "ok", "outputTokens": 40}},
+        {
+            "type": "assistant.usage",
+            "data": {
+                "apiCallId": "one-call",
+                "inputTokens": 100,
+                "outputTokens": 40,
+                "cacheReadTokens": 50,
+                "cacheWriteTokens": 20,
+                "reasoningTokens": 10,
+            },
+        },
+    ]
+    agent.jsonl_path.write_text("\n".join(map(json.dumps, [*events, events[-1]])))
+    usage = agent.get_usage_metrics()
+    assert usage["total_tokens"] == 140
+    assert_totals_match(usage, copilot.convert_file(agent.jsonl_path))
+
+
+def test_opencode_without_session_aggregate_uses_steps(tmp_path):
+    agent = OpenCodeAgent(tmp_path, "openai/example")
+    agent.sessions_dir.mkdir()
+    session = agent.sessions_dir / "session-test.json"
+    messages = [
+        {
+            "info": {"role": "assistant"},
+            "parts": [
+                {
+                    "type": "step-finish",
+                    "tokens": {
+                        "input": 100,
+                        "output": 40,
+                        "reasoning": 10,
+                        "cache": {"read": 50, "write": 20},
+                    },
+                }
+            ],
+        }
+        for _ in range(2)
+    ]
+    session.write_text(json.dumps({"info": {"id": "test"}, "messages": messages}))
+    usage = agent.get_usage_metrics()
+    assert usage["input_tokens"] == 340
+    assert usage["output_tokens"] == 100
+    assert_totals_match(usage, opencode.convert_file(session))
+
+
+def test_opencode_stream_does_not_double_count_duplicate_or_legacy_usage(tmp_path):
+    agent = OpenCodeAgent(tmp_path, "openai/example")
+    finish = {
+        "type": "step_finish",
+        "part": {
+            "id": "one",
+            "tokens": {
+                "input": 100,
+                "output": 40,
+                "reasoning": 10,
+                "cache": {"read": 50, "write": 20},
+            },
+        },
+    }
+    lines = [finish, finish, {"usage": {"input_tokens": 170, "output_tokens": 50}}, {"part": "invalid"}, []]
+    agent.output_path.write_text("\n".join(map(json.dumps, lines)) + '\n{"interrupted":')
+    usage = agent.get_usage_metrics()
+    assert usage["total_tokens"] == 220
+
+
+@pytest.mark.parametrize("value", [0, 100])
+def test_codex_uses_latest_cumulative_usage_once(tmp_path, value):
+    agent = CodexAgent(tmp_path, "example")
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    session = sessions / "rollout-test.jsonl"
+    usage = {"input_tokens": value, "output_tokens": value, "cached_input_tokens": 0, "reasoning_output_tokens": 0}
+    events = [
+        {"type": "session_meta", "payload": {"id": "test"}},
+        {
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "ok"}]},
+        },
+        *[{"type": "event_msg", "payload": {"type": "token_count", "info": {"total_token_usage": usage}}}] * 3,
+    ]
+    session.write_text("\n".join(map(json.dumps, events)) + '\n{"unfinished":')
+    metrics = agent.get_usage_metrics()
+    assert metrics["total_tokens"] == value * 2
+    assert_totals_match(metrics, codex.convert_file(session))
+
+
+def test_codex_does_not_select_an_unrelated_session(tmp_path):
+    agent = CodexAgent(tmp_path, "example")
+    (tmp_path / "sessions").mkdir()
+    (tmp_path / "sessions/other.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"input_tokens": 999, "output_tokens": 999}},
+                },
+            }
+        )
+    )
+    agent.output_path.write_text(
+        "\n".join(
+            map(
+                json.dumps,
+                [
+                    {"type": "thread.started", "thread_id": "current"},
+                    {"type": "turn.completed", "usage": {"input_tokens": 100, "output_tokens": 40}},
+                ],
+            )
+        )
+    )
+    assert agent.get_usage_metrics()["total_tokens"] == 140
+
+
+def test_inclusive_totals_do_not_add_breakdowns_again():
+    metrics = usage_metrics(
+        input_tokens=100,
+        output_tokens=40,
+        cached_input_tokens=50,
+        cache_creation_input_tokens=20,
+        reasoning_output_tokens=10,
+    )
+    assert metrics["total_tokens"] == 140
+    assert aggregate_usage([metrics, metrics])["total_tokens"] == 280
+    assert aggregate_usage([])["total_tokens"] is None
+
+
+def test_stratus_keeps_langchain_totals_and_breakdowns():
+    metrics = stratus._metrics_from_usage(
+        {
+            "input_tokens": 100,
+            "output_tokens": 40,
+            "input_token_details": {"cache_read": 50, "cache_creation": 20},
+            "output_token_details": {"reasoning": 10},
+        },
+        None,
+    )
+    assert metrics.prompt_tokens == 100
+    assert metrics.completion_tokens == 40
+    assert metrics.cached_tokens == 50
+    assert metrics.extra["reasoning_tokens"] == 10
+    assert metrics.extra["cache_write_tokens"] == 20

--- a/tests/stratus/test_usage_reporting.py
+++ b/tests/stratus/test_usage_reporting.py
@@ -49,3 +49,4 @@ def test_completed_run_adds_summary_usage_to_csv(monkeypatch, tmp_path):
     output = pd.read_csv(tmp_path / f"{problem_id}_stratus_output.csv")
     assert output["agent_name"].tolist() == ["diagnosis_agent", "run_summary"]
     assert output["total_tokens"].tolist() == [6, 15]
+    assert output["token_metrics_version"].tolist() == [2, 2]

--- a/tests/traces/test_opencode_adapter.py
+++ b/tests/traces/test_opencode_adapter.py
@@ -89,11 +89,11 @@ def test_final_metrics_from_session_info():
     fm = traj.final_metrics
     assert fm is not None
     assert fm.total_prompt_tokens == 232529  # input + cache_read (ATIF convention)
-    assert fm.total_completion_tokens == 1963
+    assert fm.total_completion_tokens == 1963 + 2388  # output + reasoning
     assert fm.total_cached_tokens == 216704
     assert fm.total_cost_usd is None  # opencode reports cost 0
     assert fm.total_steps == EXPECTED_TOTAL_STEPS
-    # Raw input preserved in extra (matches results JSON usage_metrics).
+    # Raw uncached input remains available separately from the inclusive total.
     assert fm.extra["input_tokens"] == 15825
     assert fm.extra["reasoning_tokens"] == 2388
 

--- a/tests/traces/test_opencode_edge_cases.py
+++ b/tests/traces/test_opencode_edge_cases.py
@@ -236,8 +236,8 @@ def test_final_metrics_from_info_tokens(tmp_path):
     )
     traj = opencode.convert_file(_session_file(run_dir))
     fm = traj.final_metrics
-    assert fm.total_prompt_tokens == 700  # input + cache_read
-    assert fm.total_completion_tokens == 50
+    assert fm.total_prompt_tokens == 710  # input + cache_read + cache_write
+    assert fm.total_completion_tokens == 55  # output + reasoning
     assert fm.total_cached_tokens == 200
     assert fm.total_cost_usd == 0.02
     assert fm.extra["input_tokens"] == 500

--- a/tests/traces/test_standalone_converter.py
+++ b/tests/traces/test_standalone_converter.py
@@ -156,6 +156,13 @@ def test_deliberately_wrong_agent_raises_conversion_error():
         convert(claude_file, agent="codex")
 
 
+def test_telemetry_option_requires_copilot_and_existing_files(tmp_path):
+    with pytest.raises(ValueError, match="only supported for Copilot"):
+        convert(SESSION_CASES[1][1], telemetry_files=[])
+    with pytest.raises(FileNotFoundError):
+        convert(SESSION_CASES[2][1], telemetry_files=[tmp_path / "missing.jsonl"])
+
+
 def test_standalone_package_has_no_sregym_or_client_imports():
     package_root = Path(__file__).resolve().parents[2] / "atif_converter"
     offenders: list[str] = []
@@ -197,13 +204,36 @@ def test_copied_folder_imports_and_converts_without_importing_sregym(tmp_path: P
     shutil.copytree(source_root, tmp_path / "atif_converter")
     session_file = tmp_path / "session.jsonl"
     shutil.copy2(source_file, session_file)
+    # Explicit telemetry must still work after copying only this package.
+    if agent_name == "copilot":
+        (tmp_path / "telemetry.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "span",
+                    "spanId": "one",
+                    "attributes": {
+                        "gen_ai.operation.name": "chat",
+                        "gen_ai.usage.input_tokens": 100,
+                        "gen_ai.usage.output_tokens": 40,
+                        "gen_ai.usage.cache_read.input_tokens": 50,
+                        "gen_ai.usage.reasoning.output_tokens": 10,
+                    },
+                }
+            )
+        )
 
     script = """
 import sys
 from atif_converter import convert
 
-trajectory = convert("session.jsonl")
+kwargs = {"telemetry_files": ["telemetry.jsonl"]} if sys.argv[1] == "copilot" else {}
+trajectory = convert("session.jsonl", **kwargs)
 assert trajectory.agent.name == sys.argv[1]
+if kwargs:
+    assert trajectory.final_metrics.total_prompt_tokens == 100
+    assert trajectory.final_metrics.total_completion_tokens == 40
+    assert trajectory.final_metrics.total_cached_tokens == 50
+    assert trajectory.final_metrics.extra["reasoning_tokens"] == 10
 assert not any(name == "sregym" or name.startswith("sregym.") for name in sys.modules)
 assert not any(name == "clients" or name.startswith("clients.") for name in sys.modules)
 print(trajectory.schema_version)

--- a/tests/traces/test_standalone_converter.py
+++ b/tests/traces/test_standalone_converter.py
@@ -156,7 +156,7 @@ def test_deliberately_wrong_agent_raises_conversion_error():
         convert(claude_file, agent="codex")
 
 
-def test_standalone_package_has_no_sregym_imports():
+def test_standalone_package_has_no_sregym_or_client_imports():
     package_root = Path(__file__).resolve().parents[2] / "atif_converter"
     offenders: list[str] = []
     for source_file in package_root.rglob("*.py"):
@@ -165,9 +165,9 @@ def test_standalone_package_has_no_sregym_imports():
             if (
                 isinstance(node, ast.ImportFrom)
                 and node.module
-                and (node.module == "sregym" or node.module.startswith("sregym."))
+                and node.module.split(".")[0] in {"sregym", "clients", "llm_backend"}
                 or isinstance(node, ast.Import)
-                and any(alias.name == "sregym" or alias.name.startswith("sregym.") for alias in node.names)
+                and any(alias.name.split(".")[0] in {"sregym", "clients", "llm_backend"} for alias in node.names)
             ):
                 offenders.append(f"{source_file}:{node.lineno}")
     assert offenders == []
@@ -191,25 +191,27 @@ def test_standalone_package_uses_relative_internal_imports():
     assert offenders == []
 
 
-def test_copied_folder_imports_and_converts_without_importing_sregym(tmp_path: Path):
+@pytest.mark.parametrize("agent_name,source_file", SESSION_CASES)
+def test_copied_folder_imports_and_converts_without_importing_sregym(tmp_path: Path, agent_name, source_file):
     source_root = Path(__file__).resolve().parents[2] / "atif_converter"
     shutil.copytree(source_root, tmp_path / "atif_converter")
     session_file = tmp_path / "session.jsonl"
-    shutil.copy2(SESSION_CASES[1][1], session_file)
+    shutil.copy2(source_file, session_file)
 
     script = """
 import sys
 from atif_converter import convert
 
 trajectory = convert("session.jsonl")
-assert trajectory.agent.name == "codex"
+assert trajectory.agent.name == sys.argv[1]
 assert not any(name == "sregym" or name.startswith("sregym.") for name in sys.modules)
+assert not any(name == "clients" or name.startswith("clients.") for name in sys.modules)
 print(trajectory.schema_version)
 """
     env = dict(os.environ)
     env["PYTHONPATH"] = str(tmp_path)
     result = subprocess.run(
-        [sys.executable, "-c", script],
+        [sys.executable, "-c", script, agent_name],
         cwd=tmp_path,
         env=env,
         text=True,


### PR DESCRIPTION
The same run reported different token totals in its client results and ATIF export. The two implementations counted cached input and reasoning differently.

This PR gives both outputs consistent definitions. Input totals include cache reads and writes. Output totals include reasoning. Separate fields retain these breakdowns without counting them twice.

It also corrects duplicate usage records and reads usage from additional native session formats. Missing usage remains unknown instead of appearing as zero.