### PR TITLE
Apply deployment profiles and validate infrastructure reuse

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.problem_sets import PROBLEM_SETS
 from sregym.phases import read_ledger as read_phase_ledger
 from sregym.phases import results_columns as phase_results_columns
-from sregym.profile import PROFILES, set_profile
+from sregym.profile import PROFILES, get_profile, set_profile
 from sregym.results.resume import complete_resume_rows
 from sregym.run_artifacts import ArtifactFinalizationError, RunArtifacts
 from sregym.service.container_runner import ContainerRunner, ExecInput, get_container_host_bind_address
@@ -428,6 +428,7 @@ def driver_loop(
                     snapshot = {
                         "problem_id": pid,
                         "attempt": attempt,
+                        "deployment_profile": get_profile(),
                         "deploy_failed": True,
                     }
                     for stage, outcome in conductor.results.items():
@@ -662,6 +663,7 @@ def driver_loop(
                 snapshot = {
                     "problem_id": pid,
                     "attempt": attempt,
+                    "deployment_profile": get_profile(),
                 }
                 snapshot.update(LAUNCHER.internet_policy_result(agent_proc))
                 for stage, outcome in conductor.results.items():
@@ -835,6 +837,7 @@ def main(args):
     logger.info(
         f"🔧 Config — agent: {args.agent}, agent_model: {agent_model}, judge_model: {judge_model}, "
         f"reasoning_effort: {getattr(args, 'reasoning_effort', None) or 'agent default'}, "
+        f"deployment_profile: {get_profile()}, "
         f"internet_access: {internet_policy.mode.value}, "
         f"container_hardening: {args.container_hardening}, "
         f"agent_api_base: {_env_status('AGENT_API_BASE')}, judge_api_base: {_env_status('JUDGE_API_BASE')}"

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1367,7 +1368,16 @@ class Conductor:
                 '{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-preferred-address-types=InternalIP"}'
                 "]'"
             )
+            # Apply retains selector keys added outside the original manifest.
+            # Replace the complete selector so the Service reaches metrics-server.
+            self.kubectl.core_v1_api.patch_namespaced_service(
+                "metrics-server",
+                "kube-system",
+                [{"op": "replace", "path": "/spec/selector", "value": {"k8s-app": "metrics-server"}}],
+                _request_timeout=10,
+            )
         self.kubectl.wait_for_ready("kube-system")
+        self._wait_for_infrastructure_ready("metrics-server", self._metrics_server_configured)
 
         # Only deploy Khaos if the problem requires it
         if problem.requires_khaos():
@@ -1390,11 +1400,21 @@ class Conductor:
                 "kubectl patch storageclass openebs-hostpath "
                 '-p \'{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}\''
             )
+            if not svelte:
+                # The operator manifest has no NDM node selector. An extra
+                # selector can survive apply and prevent every NDM pod scheduling.
+                self.kubectl.apps_v1_api.patch_namespaced_daemon_set(
+                    "openebs-ndm",
+                    "openebs",
+                    [{"op": "add", "path": "/spec/template/spec/nodeSelector", "value": {}}],
+                    _request_timeout=10,
+                )
         # Idempotent and cheap; also covers an `openebs` left over from an
         # earlier full-profile run on the same cluster.
         if svelte:
             self._trim_openebs_ndm()
         self.kubectl.wait_for_ready("openebs")
+        self._wait_for_infrastructure_ready("OpenEBS", lambda: self._openebs_ready(svelte))
         if not svelte:
             self._ensure_openebs_device_storageclass()
 
@@ -1452,6 +1472,15 @@ class Conductor:
         if self.problem:
             self.problem.app.cleanup()
 
+    def _wait_for_infrastructure_ready(self, name: str, is_ready: Callable[[], bool], timeout: float = 180) -> None:
+        """Require functional infrastructure, not just Ready surviving pods."""
+        deadline = time.monotonic() + timeout
+        while not is_ready():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"{name} did not become healthy within {timeout:g}s; stopping application setup")
+            time.sleep(min(2, remaining))
+
     def _preflight_openebs_udev_mount(self) -> None:
         if shutil.which("docker") is None:
             self.logger.info("[DEPLOY] Docker is unavailable; skipping kind /run/udev preflight")
@@ -1501,7 +1530,7 @@ class Conductor:
         """
         args = self.kubectl.exec_command(
             "kubectl -n kube-system get deployment metrics-server "
-            "-o jsonpath='{.spec.template.spec.containers[0].args}' --ignore-not-found"
+            "-o jsonpath='{.spec.template.spec.containers[0].args}' --ignore-not-found --request-timeout=10s"
         )
         if not args or not args.strip():
             return False
@@ -1509,7 +1538,8 @@ class Conductor:
             return False
 
         binding = self.kubectl.exec_command(
-            f"kubectl get clusterrolebinding {self._METRICS_SERVER_BINDING} -o name --ignore-not-found"
+            f"kubectl get clusterrolebinding {self._METRICS_SERVER_BINDING} -o name "
+            "--ignore-not-found --request-timeout=10s"
         )
         if not binding or not binding.strip():
             self.logger.info("[DEPLOY] metrics-server RBAC missing; re-applying components.yaml")
@@ -1537,7 +1567,7 @@ class Conductor:
         """
         out = self.kubectl.exec_command(
             "kubectl -n openebs get deployment openebs-localpv-provisioner "
-            "-o jsonpath='{.status.readyReplicas}' --ignore-not-found"
+            "-o jsonpath='{.status.readyReplicas}' --ignore-not-found --request-timeout=10s"
         )
         try:
             if int(out.strip()) < 1:

--- a/sregym/conductor/conductor.py
+++ b/sregym/conductor/conductor.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
+from kubernetes.client.rest import ApiException
 
 from sregym.conductor.constants import StartProblemResult
 from sregym.conductor.oracles.base import Oracle
@@ -1489,7 +1490,7 @@ class Conductor:
     _METRICS_SERVER_BINDING = "metrics-server:system:auth-delegator"
 
     def _metrics_server_configured(self) -> bool:
-        """True if metrics-server is deployed, patched, *and* still has its RBAC.
+        """True if metrics-server has its configuration, RBAC, and usable metrics.
 
         Checking more than existence matters because the Deployment and its
         cluster-scoped RBAC have different lifetimes: the Deployment sits in the
@@ -1513,7 +1514,16 @@ class Conductor:
         if not binding or not binding.strip():
             self.logger.info("[DEPLOY] metrics-server RBAC missing; re-applying components.yaml")
             return False
-        return True
+        # A Ready Deployment does not prove that its Service and aggregated API
+        # still work. Exercise the same API path used by kubectl top.
+        raw_metrics = self.kubectl.exec_command(
+            "kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes --request-timeout=10s"
+        )
+        try:
+            metrics = json.loads(raw_metrics)
+            return metrics.get("kind") == "NodeMetricsList" and bool(metrics.get("items"))
+        except (ValueError, TypeError, AttributeError):
+            return False
 
     def _openebs_ready(self, svelte: bool) -> bool:
         """True if the OpenEBS tier already matches what this profile wants.
@@ -1538,11 +1548,23 @@ class Conductor:
         if svelte:
             return True
 
-        ndm = self.kubectl.exec_command("kubectl -n openebs get daemonset openebs-ndm -o name --ignore-not-found")
-        if not ndm or not ndm.strip():
-            self.logger.info("[DEPLOY] OpenEBS node-disk-manager missing; re-applying operator manifest")
+        try:
+            ndm = self.kubectl.apps_v1_api.read_namespaced_daemon_set("openebs-ndm", "openebs", _request_timeout=10)
+        except ApiException:
             return False
-        return True
+        status = ndm.status
+        if status is None:
+            return False
+        desired = status.desired_number_scheduled or 0
+        return (
+            desired > 0
+            and (status.observed_generation or 0) >= (ndm.metadata.generation or 0)
+            and status.current_number_scheduled == desired
+            and status.updated_number_scheduled == desired
+            and status.number_ready == desired
+            and status.number_available == desired
+            and (status.number_misscheduled or 0) == 0
+        )
 
     # openebs-operator.yaml bundles the node-disk-manager alongside the LocalPV
     # provisioner. NDM exists to discover block devices and back the
@@ -1558,12 +1580,24 @@ class Conductor:
     )
 
     def _trim_openebs_ndm(self) -> None:
-        """Remove the node-disk-manager workloads left by openebs-operator.yaml.
+        """Remove unused device storage and node-disk-manager workloads.
 
         Deleting rather than scaling: the operator manifest is a plain apply with
         no controller to recreate them, and re-applying it recreates them for this
         method to remove again.
         """
+        baseline = self.cluster_state.baseline
+        if baseline is None:
+            raise RuntimeError("Cannot trim OpenEBS before the cluster baseline is available")
+        # Keep user-provided StorageClasses. The shared cluster baseline is
+        # captured before SREGym installs OpenEBS and survives interrupted runs.
+        if "openebs-device" not in baseline.storage_classes:
+            try:
+                self.cluster_state.storage_v1.delete_storage_class("openebs-device")
+            except ApiException as exc:
+                if exc.status != 404:
+                    raise
+
         self.logger.info("[svelte] Removing OpenEBS node-disk-manager (openebs-hostpath does not use it)")
         for kind, name in self._OPENEBS_NDM_WORKLOADS:
             self.kubectl.exec_command(f"kubectl delete {kind} {name} -n openebs --ignore-not-found")

--- a/sregym/service/cluster_state.py
+++ b/sregym/service/cluster_state.py
@@ -59,34 +59,26 @@ def _is_chaos_mesh_resource(name: str) -> bool:
     )
 
 
-def _is_openebs_resource(name: str) -> bool:
-    """True if a cluster-scoped resource belongs to OpenEBS and must be preserved.
+# Exact cluster-scoped identities from openebs-operator.yaml and the
+# metrics-server components.yaml used by Conductor. Keep this list aligned with
+# those manifests when changing infrastructure versions. A matching substring
+# or a matching name on another resource kind does not establish ownership.
+_PRESERVED_INFRA_RESOURCES = {
+    "ClusterRole": frozenset({"openebs-maya-operator", "system:aggregated-metrics-reader", "system:metrics-server"}),
+    "ClusterRoleBinding": frozenset(
+        {
+            "openebs-maya-operator",
+            "metrics-server:system:auth-delegator",
+            "system:metrics-server",
+        }
+    ),
+    "CustomResourceDefinition": frozenset({"blockdevices.openebs.io", "blockdeviceclaims.openebs.io"}),
+    "StorageClass": frozenset({"openebs-hostpath", "openebs-device"}),
+}
 
-    Protecting the `openebs` namespace alone is not enough: openebs-operator.yaml
-    also creates cluster-scoped RBAC, CRDs (`*.openebs.io`) and StorageClasses.
-    Deleting those while keeping the namespace leaves the provisioner running but
-    unable to act — a broken half-state that is harder to diagnose than a clean
-    rebuild. Preserve the whole tier together.
-    """
-    if not name:
-        return False
-    return name.endswith(".openebs.io") or "openebs" in name
 
-
-def _is_metrics_server_resource(name: str) -> bool:
-    """True if a cluster-scoped resource belongs to metrics-server.
-
-    The Deployment lives in kube-system and is protected, but its cluster-scoped
-    RBAC is not in the baseline and was being deleted here every problem. That
-    went unnoticed only because the conductor re-applied components.yaml on each
-    problem and silently recreated it. The binding that matters is
-    `metrics-server:system:auth-delegator`, which does not start with "system:"
-    and so escapes the generic guard below; without it metrics-server cannot
-    create subjectaccessreviews and every `kubectl top` fails with a 500.
-    """
-    if not name:
-        return False
-    return "metrics-server" in name
+def _is_preserved_infra_resource(kind: str, name: str) -> bool:
+    return name in _PRESERVED_INFRA_RESOURCES.get(kind, ())
 
 
 @dataclass
@@ -267,7 +259,7 @@ class ClusterStateManager:
             # Skip system roles that may have been auto-created
             if role.startswith("system:") or role.startswith("kubeadm:"):
                 continue
-            if _is_chaos_mesh_resource(role) or _is_openebs_resource(role) or _is_metrics_server_resource(role):
+            if _is_chaos_mesh_resource(role) or _is_preserved_infra_resource("ClusterRole", role):
                 continue
             logger.info(f"Deleting unexpected ClusterRole: {role}")
             try:
@@ -283,11 +275,7 @@ class ClusterStateManager:
         for binding in unexpected_bindings:
             if binding.startswith("system:") or binding.startswith("kubeadm:"):
                 continue
-            if (
-                _is_chaos_mesh_resource(binding)
-                or _is_openebs_resource(binding)
-                or _is_metrics_server_resource(binding)
-            ):
+            if _is_chaos_mesh_resource(binding) or _is_preserved_infra_resource("ClusterRoleBinding", binding):
                 continue
             logger.info(f"Deleting unexpected ClusterRoleBinding: {binding}")
             try:
@@ -331,7 +319,7 @@ class ClusterStateManager:
         current_scs = self._get_storage_classes()
         unexpected_scs = current_scs - self.baseline.storage_classes
         for sc in unexpected_scs:
-            if _is_openebs_resource(sc):
+            if _is_preserved_infra_resource("StorageClass", sc):
                 continue
             logger.info(f"Deleting unexpected StorageClass: {sc}")
             try:
@@ -345,7 +333,7 @@ class ClusterStateManager:
         current_crds = self._get_crds()
         unexpected_crds = current_crds - self.baseline.crds
         for crd in unexpected_crds:
-            if _is_chaos_mesh_resource(crd) or _is_openebs_resource(crd):
+            if _is_chaos_mesh_resource(crd) or _is_preserved_infra_resource("CustomResourceDefinition", crd):
                 continue
             logger.info(f"Deleting unexpected CRD: {crd}")
             self._strip_cr_finalizers(crd)
@@ -360,7 +348,7 @@ class ClusterStateManager:
         current_vwc = self._get_validating_webhook_configs()
         unexpected_vwc = current_vwc - self.baseline.validating_webhook_configs
         for vwc in unexpected_vwc:
-            if _is_chaos_mesh_resource(vwc) or _is_openebs_resource(vwc):
+            if _is_chaos_mesh_resource(vwc) or _is_preserved_infra_resource("ValidatingWebhookConfiguration", vwc):
                 continue
             logger.info(f"Deleting unexpected ValidatingWebhookConfiguration: {vwc}")
             try:
@@ -374,7 +362,7 @@ class ClusterStateManager:
         current_mwc = self._get_mutating_webhook_configs()
         unexpected_mwc = current_mwc - self.baseline.mutating_webhook_configs
         for mwc in unexpected_mwc:
-            if _is_chaos_mesh_resource(mwc) or _is_openebs_resource(mwc):
+            if _is_chaos_mesh_resource(mwc) or _is_preserved_infra_resource("MutatingWebhookConfiguration", mwc):
                 continue
             logger.info(f"Deleting unexpected MutatingWebhookConfiguration: {mwc}")
             try:

--- a/sregym/service/helm.py
+++ b/sregym/service/helm.py
@@ -3,6 +3,9 @@
 import logging
 import subprocess
 import time
+from pathlib import Path
+
+import yaml
 
 from sregym.service.kubectl import KubeCtl
 
@@ -76,22 +79,35 @@ class Helm:
         "ok" per dependency when the pinned version is present in charts/. Only fall
         through to the update when something is missing or the wrong version.
         """
-        listing = subprocess.run(f"helm dependency list {chart_path}", shell=True, capture_output=True, text=True)
+        chart_dir = Path(chart_path).expanduser()
+        with (chart_dir / "Chart.yaml").open() as file:
+            chart = yaml.safe_load(file) or {}
+        # Helm v1 charts can declare dependencies in requirements.yaml.
+        requirements = chart_dir / "requirements.yaml"
+        if chart.get("apiVersion") == "v1" and requirements.exists():
+            with requirements.open() as file:
+                chart = yaml.safe_load(file) or {}
+        dependencies = chart.get("dependencies", [])
+        if not dependencies:
+            return
+
+        listing = subprocess.run(["helm", "dependency", "list", str(chart_dir)], capture_output=True, text=True)
         if listing.returncode == 0:
-            # Header row plus one row per dependency; trailing text (e.g. WARNING
-            # lines) has fewer than 4 columns and is ignored.
-            rows = [ln.split() for ln in listing.stdout.splitlines()[1:]]
-            statuses = [r[-1] for r in rows if len(r) >= 4]
-            if statuses and all(s == "ok" for s in statuses):
+            # Keep empty repository columns for local subcharts. Warnings are
+            # outside the tab-separated table, and must not count as dependencies.
+            rows = [[field.strip() for field in line.split("\t")] for line in listing.stdout.splitlines()[1:]]
+            statuses = [row[-1] for row in rows if len(row) in (3, 4)]
+            if len(statuses) == len(dependencies) and all(status in {"ok", "unpacked"} for status in statuses):
                 logger.debug(f"Chart dependencies already satisfied for {chart_path}; skipping update")
                 return
             logger.info(f"Chart dependencies not satisfied for {chart_path} ({statuses or 'none listed'}); updating")
 
-        result = subprocess.run(f"helm dependency update {chart_path}", shell=True, capture_output=True, text=True)
+        result = subprocess.run(["helm", "dependency", "update", str(chart_dir)], capture_output=True, text=True)
         if result.returncode != 0:
-            # Previously swallowed. A failure here surfaces later as a confusing
-            # "chart not found" from helm install, so say so now.
-            logger.error(f"helm dependency update failed for {chart_path}:\n{result.stderr.strip()}")
+            raise RuntimeError(
+                f"Helm dependency update failed for chart '{chart_path}'. "
+                f"Error output:\n{result.stderr.strip()}\nStdout:\n{result.stdout.strip()}"
+            )
 
     @staticmethod
     def uninstall(**args):

--- a/sregym/service/telemetry/prometheus.py
+++ b/sregym/service/telemetry/prometheus.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import subprocess
+from pathlib import Path
+
+import yaml
 
 from sregym.paths import BASE_DIR, PROMETHEUS_METADATA
 from sregym.profile import is_svelte
@@ -62,8 +65,8 @@ class Prometheus:
 
     def deploy(self):
         """Deploy the metric collector using Helm."""
-        if self._is_prometheus_running():
-            self.logger.warning("Prometheus is already running. Skipping redeployment.")
+        if self._is_prometheus_running() and self._matches_requested_profile():
+            self.logger.info("Prometheus already uses the requested profile. Skipping redeployment.")
             return
 
         # Wait for namespace to be fully terminated before attempting fresh install
@@ -79,6 +82,40 @@ class Prometheus:
 
         Helm.install(**helm_configs)
         Helm.assert_if_deployed(self.namespace)
+
+    def _matches_requested_profile(self) -> bool:
+        """Compare installed Helm values with the settings controlled by the profile."""
+        result = subprocess.run(
+            [
+                "helm",
+                "get",
+                "values",
+                self.helm_configs["release_name"],
+                "-n",
+                self.namespace,
+                "--all",
+                "-o",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        installed = json.loads(result.stdout)
+        with open(Path(self.helm_configs["chart_path"]) / "values.yaml") as file:
+            expected = yaml.safe_load(file)
+        # Compare actual values rather than a new marker, so releases installed
+        # before profile tracking also work. Other Helm values remain unrelated.
+        with open(BASE_DIR / "observer" / "prometheus" / "values-svelte.yaml") as file:
+            svelte_values = yaml.safe_load(file)
+        for component, settings in svelte_values.items():
+            for setting, svelte_value in settings.items():
+                wanted = svelte_value if is_svelte() else expected[component][setting]
+                if installed.get(component, {}).get(setting) != wanted:
+                    self.logger.info("Prometheus profile differs at %s.%s; redeploying", component, setting)
+                    return False
+        return True
 
     def teardown(self):
         """Teardown the metric collector deployment."""

--- a/tests/test_deployment_profiles.py
+++ b/tests/test_deployment_profiles.py
@@ -1,0 +1,198 @@
+import csv
+import importlib.util
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+from kubernetes.client.rest import ApiException
+
+from sregym import profile
+from sregym.conductor.conductor import Conductor
+from sregym.paths import BASE_DIR
+from sregym.service.cluster_state import ClusterBaseline
+from sregym.service.helm import Helm
+from sregym.service.telemetry import prometheus as prometheus_module
+from sregym.service.telemetry.prometheus import Prometheus
+
+
+@pytest.fixture(autouse=True)
+def reset_profile(monkeypatch):
+    monkeypatch.setattr(profile, "_profile", None)
+    monkeypatch.delenv("SREGYM_PROFILE", raising=False)
+
+
+def helm_values(prometheus, selected_profile):
+    values = yaml.safe_load((Path(prometheus.helm_configs["chart_path"]) / "values.yaml").read_text())
+    if selected_profile == "svelte":
+        overlay = yaml.safe_load((BASE_DIR / "observer/prometheus/values-svelte.yaml").read_text())
+        for component, settings in overlay.items():
+            values[component].update(settings)
+    return values
+
+
+@pytest.mark.parametrize("installed", ["full", "svelte"])
+@pytest.mark.parametrize("requested", ["full", "svelte"])
+def test_prometheus_reuses_only_the_requested_profile(monkeypatch, installed, requested):
+    prometheus = Prometheus()
+    profile.set_profile(requested)
+    values = helm_values(prometheus, installed)
+    # Settings outside the profile do not force an unnecessary reinstall.
+    values["unrelatedSetting"] = "preserved"
+    run = MagicMock(return_value=SimpleNamespace(stdout=json.dumps(values)))
+    monkeypatch.setattr(prometheus_module.subprocess, "run", run)
+    monkeypatch.setattr(prometheus, "_is_prometheus_running", lambda: True)
+    monkeypatch.setattr(prometheus, "_wait_for_namespace_termination", lambda: None)
+    helm = MagicMock(spec=Helm)
+    monkeypatch.setattr(prometheus_module, "Helm", helm)
+
+    prometheus.deploy()
+
+    assert run.call_args.args[0][-3:] == ["--all", "-o", "json"]
+    assert helm.install.call_count == (installed != requested)
+    assert helm.uninstall.call_count == (installed != requested)
+    assert helm.assert_if_deployed.call_count == (installed != requested)
+    if installed != requested:
+        extra_args = helm.install.call_args.kwargs.get("extra_args", [])
+        assert any("values-svelte.yaml" in arg for arg in extra_args) == (requested == "svelte")
+
+
+@pytest.mark.parametrize("requested", ["full", "svelte"])
+def test_prometheus_fresh_install_does_not_query_a_missing_release(monkeypatch, requested):
+    prometheus = Prometheus()
+    profile.set_profile(requested)
+    monkeypatch.setattr(prometheus, "_is_prometheus_running", lambda: False)
+    monkeypatch.setattr(prometheus, "_wait_for_namespace_termination", lambda: None)
+    query = MagicMock()
+    monkeypatch.setattr(prometheus, "_matches_requested_profile", query)
+    helm = MagicMock(spec=Helm)
+    monkeypatch.setattr(prometheus_module, "Helm", helm)
+    prometheus.deploy()
+    query.assert_not_called()
+    helm.install.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "component,setting,value",
+    [
+        ("alertmanager", "enabled", True),
+        ("prometheus-pushgateway", "enabled", True),
+        ("server", "retention", "15d"),
+        ("server", "resources", {}),
+    ],
+)
+def test_prometheus_checks_every_profile_setting(monkeypatch, component, setting, value):
+    prometheus = Prometheus()
+    profile.set_profile("svelte")
+    values = helm_values(prometheus, "svelte")
+    values[component][setting] = value
+    monkeypatch.setattr(
+        prometheus_module.subprocess, "run", MagicMock(return_value=SimpleNamespace(stdout=json.dumps(values)))
+    )
+    assert not prometheus._matches_requested_profile()
+
+
+@pytest.mark.parametrize("error", [subprocess.CalledProcessError(1, "helm"), subprocess.TimeoutExpired("helm", 30)])
+def test_prometheus_query_failure_does_not_remove_the_release(monkeypatch, error):
+    prometheus = Prometheus()
+    monkeypatch.setattr(prometheus, "_is_prometheus_running", lambda: True)
+    monkeypatch.setattr(prometheus_module.subprocess, "run", MagicMock(side_effect=error))
+    helm = MagicMock(spec=Helm)
+    monkeypatch.setattr(prometheus_module, "Helm", helm)
+    with pytest.raises(type(error)):
+        prometheus.deploy()
+    helm.uninstall.assert_not_called()
+    helm.install.assert_not_called()
+
+
+@pytest.mark.parametrize("preexisting", [False, True])
+def test_svelte_preserves_original_storage_classes(preexisting):
+    conductor = Conductor.__new__(Conductor)
+    conductor.logger = logging.getLogger("test.profile")
+    conductor.kubectl = MagicMock()
+    baseline = ClusterBaseline(storage_classes={"openebs-device"} if preexisting else set())
+    conductor.cluster_state = SimpleNamespace(baseline=baseline, storage_v1=MagicMock())
+    conductor._trim_openebs_ndm()
+    assert conductor.cluster_state.storage_v1.delete_storage_class.call_count == (not preexisting)
+    if not preexisting:
+        conductor.cluster_state.storage_v1.delete_storage_class.assert_called_once_with("openebs-device")
+    assert conductor.kubectl.exec_command.call_count == 4
+    assert all("openebs-hostpath" not in call.args[0] for call in conductor.kubectl.exec_command.call_args_list)
+
+
+@pytest.mark.parametrize("status", [404, 403])
+def test_storage_cleanup_ignores_only_missing_class(status):
+    conductor = Conductor.__new__(Conductor)
+    conductor.logger = logging.getLogger("test.profile")
+    conductor.kubectl = MagicMock()
+    storage = MagicMock()
+    storage.delete_storage_class.side_effect = ApiException(status=status)
+    conductor.cluster_state = SimpleNamespace(baseline=ClusterBaseline(), storage_v1=storage)
+    if status == 404:
+        conductor._trim_openebs_ndm()
+        assert conductor.kubectl.exec_command.call_count == 4
+    else:
+        with pytest.raises(ApiException):
+            conductor._trim_openebs_ndm()
+        conductor.kubectl.exec_command.assert_not_called()
+
+
+def test_missing_baseline_does_not_remove_storage_or_workloads():
+    conductor = Conductor.__new__(Conductor)
+    conductor.kubectl = MagicMock()
+    conductor.cluster_state = SimpleNamespace(baseline=None, storage_v1=MagicMock())
+    with pytest.raises(RuntimeError, match="baseline"):
+        conductor._trim_openebs_ndm()
+    conductor.cluster_state.storage_v1.delete_storage_class.assert_not_called()
+    conductor.kubectl.exec_command.assert_not_called()
+
+
+@pytest.mark.parametrize("selected_profile", ["full", "svelte"])
+@pytest.mark.parametrize("deploy_failed", [False, True])
+def test_driver_records_profile_in_result_rows(tmp_path, monkeypatch, selected_profile, deploy_failed):
+    spec = importlib.util.spec_from_file_location(
+        "profile_benchmark_test", Path(__file__).resolve().parents[1] / "main.py"
+    )
+    benchmark = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, benchmark)
+    spec.loader.exec_module(benchmark)
+    profile.set_profile(selected_profile)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(benchmark, "list_agents", lambda **kwargs: {"demo": {}})
+    monkeypatch.setattr(benchmark.asyncio, "sleep", AsyncMock())
+    launcher = MagicMock()
+    launcher._procs = {}
+    launcher._container_runner = None
+    launcher.internet_policy_result.return_value = {}
+    monkeypatch.setattr(benchmark, "LAUNCHER", launcher)
+    run = MagicMock()
+    run.finalize_and_publish.return_value = None
+    monkeypatch.setattr(benchmark.RunArtifacts, "create", lambda **kwargs: run)
+    conductor = MagicMock()
+    conductor.problems.get_problem_ids.return_value = ["example"]
+    conductor.start_problem = AsyncMock(side_effect=RuntimeError("deploy failed") if deploy_failed else None)
+    conductor.wait_for_submission_work = AsyncMock()
+    conductor.close_submissions.return_value = False
+    conductor.submission_stage = "done"
+    conductor.stage_sequence = []
+    conductor.phases = None
+    conductor.results = {"run_status": "complete", "Diagnosis": {"success": True}, "Mitigation": {"success": True}}
+    conductor.finalize_attempt_status.return_value = "complete"
+
+    results = benchmark.driver_loop(conductor, problem_selection=["example"], agent_to_run="demo")
+
+    row = results[0]["demo"][0]
+    assert row["deployment_profile"] == selected_profile
+    assert bool(row.get("deploy_failed")) == deploy_failed
+    csv_files = list(tmp_path.rglob("*.csv"))
+    assert csv_files
+    for path in csv_files:
+        with path.open() as file:
+            assert list(csv.DictReader(file))[0]["deployment_profile"] == selected_profile
+    if not deploy_failed:
+        assert run.finalize_and_publish.call_args.kwargs["snapshot"]["deployment_profile"] == selected_profile

--- a/tests/test_infrastructure_reuse.py
+++ b/tests/test_infrastructure_reuse.py
@@ -1,0 +1,223 @@
+import json
+import logging
+import shutil
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from kubernetes.client.rest import ApiException
+
+from sregym.conductor.conductor import Conductor
+from sregym.service import helm as helm_module
+from sregym.service.cluster_state import ClusterBaseline, ClusterStateManager
+from sregym.service.helm import Helm
+
+
+@pytest.fixture
+def conductor():
+    obj = Conductor.__new__(Conductor)
+    obj.logger = logging.getLogger("test.infra")
+    obj.kubectl = MagicMock()
+    return obj
+
+
+@pytest.mark.parametrize(
+    "response,healthy",
+    [
+        (json.dumps({"kind": "NodeMetricsList", "items": [{"metadata": {"name": "node"}}]}), True),
+        (json.dumps({"kind": "NodeMetricsList", "items": []}), False),
+        (json.dumps({"kind": "Status", "status": "Failure"}), False),
+        ("Error from server (ServiceUnavailable)", False),
+        ("null", False),
+    ],
+)
+def test_metrics_reuse_requires_the_functional_api(conductor, response, healthy):
+    conductor.kubectl.exec_command.side_effect = [" ".join(conductor._METRICS_SERVER_ARGS), "binding", response]
+    assert conductor._metrics_server_configured() is healthy
+    assert "--raw /apis/metrics.k8s.io/v1beta1/nodes" in conductor.kubectl.exec_command.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {},
+        {"desired_number_scheduled": 0, "current_number_scheduled": 0, "number_ready": 0},
+        {"number_ready": 2},
+        {"number_available": 2},
+        {"updated_number_scheduled": 2},
+        {"observed_generation": 1},
+        {"number_misscheduled": 1},
+    ],
+)
+def test_ndm_reuse_requires_a_nonempty_current_rollout(conductor, changed):
+    conductor.kubectl.exec_command.return_value = "1"
+    status = dict(
+        desired_number_scheduled=3,
+        current_number_scheduled=3,
+        updated_number_scheduled=3,
+        number_ready=3,
+        number_available=3,
+        observed_generation=2,
+        number_misscheduled=0,
+    )
+    status.update(changed)
+    conductor.kubectl.apps_v1_api.read_namespaced_daemon_set.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(generation=2), status=SimpleNamespace(**status)
+    )
+    assert conductor._openebs_ready(svelte=False) is (not changed)
+
+
+def test_svelte_does_not_require_ndm(conductor):
+    conductor.kubectl.exec_command.return_value = "1"
+    assert conductor._openebs_ready(svelte=True)
+    conductor.kubectl.apps_v1_api.read_namespaced_daemon_set.assert_not_called()
+
+
+def test_missing_ndm_is_not_reused(conductor):
+    conductor.kubectl.exec_command.return_value = "1"
+    conductor.kubectl.apps_v1_api.read_namespaced_daemon_set.side_effect = ApiException(status=404)
+    assert not conductor._openebs_ready(svelte=False)
+
+
+def test_new_ndm_without_status_is_not_reused(conductor):
+    conductor.kubectl.exec_command.return_value = "1"
+    conductor.kubectl.apps_v1_api.read_namespaced_daemon_set.return_value = SimpleNamespace(status=None)
+    assert not conductor._openebs_ready(svelte=False)
+
+
+def test_reconciliation_preserves_only_exact_infrastructure_identities():
+    manager = ClusterStateManager.__new__(ClusterStateManager)
+    manager.baseline = ClusterBaseline()
+    for attribute in ("kubectl", "core_v1", "rbac_v1", "storage_v1", "apiextensions_v1", "admission_v1"):
+        setattr(manager, attribute, MagicMock())
+    manager.kubectl.gc_orphan_localpv_dirs.return_value = {}
+    for method in (
+        "_get_namespaces",
+        "_get_persistent_volumes",
+        "_get_node_labels",
+        "_get_node_taints",
+        "_get_validating_webhook_configs",
+        "_get_mutating_webhook_configs",
+        "_get_cluster_roles",
+        "_get_cluster_role_bindings",
+        "_get_crds",
+        "_get_storage_classes",
+    ):
+        setattr(manager, method, MagicMock(return_value=set()))
+    manager._reconcile_node_labels = MagicMock(return_value={})
+    manager._reconcile_node_taints = MagicMock(return_value={})
+    manager._is_coredns_modified = MagicMock(return_value=False)
+    manager._strip_cr_finalizers = MagicMock()
+    decoys = {"debug-openebs-access", "unrelated-metrics-server-reader", "openebs-hostpath"}
+    manager._get_cluster_roles.return_value = decoys | {"openebs-maya-operator", "system:metrics-server"}
+    manager._get_cluster_role_bindings.return_value = decoys | {
+        "openebs-maya-operator",
+        "metrics-server:system:auth-delegator",
+        "system:metrics-server",
+    }
+    manager._get_storage_classes.return_value = {"openebs-hostpath", "openebs-device", "other-openebs-class"}
+    manager._get_crds.return_value = {"blockdevices.openebs.io", "blockdeviceclaims.openebs.io", "other.openebs.io"}
+    manager._get_validating_webhook_configs.return_value = {"openebs-maya-operator"}
+    manager._get_mutating_webhook_configs.return_value = {"openebs-maya-operator"}
+
+    changes = manager.reconcile_to_baseline()
+
+    assert set(changes["cluster_roles_deleted"]) == decoys
+    assert set(changes["cluster_role_bindings_deleted"]) == decoys
+    assert changes["storage_classes_deleted"] == ["other-openebs-class"]
+    assert changes["crds_deleted"] == ["other.openebs.io"]
+    assert changes["validating_webhook_configs_deleted"] == ["openebs-maya-operator"]
+    assert changes["mutating_webhook_configs_deleted"] == ["openebs-maya-operator"]
+
+
+@pytest.fixture
+def chart(tmp_path):
+    def create(dependencies, api_version="v2"):
+        metadata = {"apiVersion": api_version, "name": "test", "version": "1.0.0"}
+        if api_version == "v1":
+            (tmp_path / "requirements.yaml").write_text(yaml.safe_dump({"dependencies": dependencies}))
+        else:
+            metadata["dependencies"] = dependencies
+        (tmp_path / "Chart.yaml").write_text(yaml.safe_dump(metadata))
+        return str(tmp_path)
+
+    return create
+
+
+@pytest.mark.parametrize("repository_column", ["\t", ""])
+@pytest.mark.parametrize("api_version", ["v1", "v2"])
+def test_helm_accepts_local_dependencies_and_ignores_warnings(monkeypatch, chart, repository_column, api_version):
+    path = chart([{"name": "local"}, {"name": "remote"}], api_version)
+    output = (
+        "NAME\tVERSION\tREPOSITORY\tSTATUS\n"
+        f"local\t1.0.0\t{repository_column}unpacked\n"
+        "remote\t1.0.0\thttps://charts.example\tok\n\n"
+        'WARNING: "charts/extra" is not in Chart.yaml.\n'
+    )
+    run = MagicMock(return_value=SimpleNamespace(returncode=0, stdout=output, stderr=""))
+    monkeypatch.setattr(helm_module.subprocess, "run", run)
+    Helm.ensure_dependencies(path)
+    run.assert_called_once_with(["helm", "dependency", "list", path], capture_output=True, text=True)
+
+
+def test_chart_without_dependencies_does_not_contact_repositories(monkeypatch, chart):
+    run = MagicMock()
+    monkeypatch.setattr(helm_module.subprocess, "run", run)
+    Helm.ensure_dependencies(chart([]))
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("local_status", ["missing", "wrong version", None])
+def test_helm_updates_when_any_local_dependency_is_missing_or_incompatible(monkeypatch, chart, local_status):
+    path = chart([{"name": "local"}, {"name": "remote"}])
+    output = "NAME\tVERSION\tREPOSITORY\tSTATUS\nremote\t1\thttps://charts.example\tok\n"
+    if local_status is not None:
+        output += f"local\t1\t\t{local_status}\n"
+    run = MagicMock(
+        side_effect=[
+            SimpleNamespace(returncode=0, stdout=output, stderr=""),
+            SimpleNamespace(returncode=0, stdout="updated", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(helm_module.subprocess, "run", run)
+    Helm.ensure_dependencies(path)
+    assert run.call_args.args[0] == ["helm", "dependency", "update", path]
+
+
+def test_failed_dependency_update_stops_before_install(monkeypatch, chart):
+    path = chart([{"name": "missing"}])
+    run = MagicMock(
+        side_effect=[
+            SimpleNamespace(returncode=1, stdout="", stderr="list failed"),
+            SimpleNamespace(returncode=1, stdout="partial update", stderr="repository failed"),
+        ]
+    )
+    monkeypatch.setattr(helm_module.subprocess, "run", run)
+    popen = MagicMock()
+    monkeypatch.setattr(helm_module.subprocess, "Popen", popen)
+    with pytest.raises(RuntimeError) as error:
+        Helm.install(release_name="test", namespace="test", chart_path=path)
+    assert path in str(error.value)
+    assert "partial update" in str(error.value)
+    assert "repository failed" in str(error.value)
+    popen.assert_not_called()
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="Helm CLI is not installed")
+def test_real_helm_missing_local_chart_stops_before_install(monkeypatch, chart):
+    path = chart([{"name": "missing-local", "version": "1.0.0"}])
+    popen = MagicMock()
+    # dependency list/update use subprocess.run, which needs the real Popen.
+    # Intercept only the eventual shell-based install command.
+    original = helm_module.subprocess.Popen
+
+    def no_install(command, *args, **kwargs):
+        if isinstance(command, str) and command.startswith("helm install "):
+            return popen(command, *args, **kwargs)
+        return original(command, *args, **kwargs)
+
+    monkeypatch.setattr(helm_module.subprocess, "Popen", no_install)
+    with pytest.raises(RuntimeError, match="dependency update failed"):
+        Helm.install(release_name="test", namespace="test", chart_path=path)
+    popen.assert_not_called()

--- a/tests/test_infrastructure_reuse.py
+++ b/tests/test_infrastructure_reuse.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 from kubernetes.client.rest import ApiException
 
+from sregym.conductor import conductor as conductor_module
 from sregym.conductor.conductor import Conductor
 from sregym.service import helm as helm_module
 from sregym.service.cluster_state import ClusterBaseline, ClusterStateManager
@@ -84,6 +85,96 @@ def test_new_ndm_without_status_is_not_reused(conductor):
     conductor.kubectl.exec_command.return_value = "1"
     conductor.kubectl.apps_v1_api.read_namespaced_daemon_set.return_value = SimpleNamespace(status=None)
     assert not conductor._openebs_ready(svelte=False)
+
+
+class ObserverSetupReached(Exception):
+    pass
+
+
+@pytest.fixture
+def startup(conductor, monkeypatch):
+    conductor._baseline_captured = True
+    conductor.problem = SimpleNamespace(requires_khaos=lambda: False)
+    conductor.prometheus = MagicMock()
+    conductor.prometheus.deploy.side_effect = ObserverSetupReached
+    conductor._metrics_server_configured = MagicMock(return_value=True)
+    conductor._openebs_ready = MagicMock(return_value=True)
+    conductor._preflight_openebs_udev_mount = MagicMock()
+    conductor._trim_openebs_ndm = MagicMock()
+    conductor._ensure_openebs_device_storageclass = MagicMock()
+    monkeypatch.setattr(conductor_module, "is_svelte", lambda: False)
+    monkeypatch.setattr(conductor_module.time, "sleep", MagicMock())
+    return conductor
+
+
+@pytest.mark.parametrize("svelte", [False, True])
+def test_startup_repairs_the_metrics_selector_then_waits_for_metrics(startup, monkeypatch, svelte):
+    monkeypatch.setattr(conductor_module, "is_svelte", lambda: svelte)
+    startup._metrics_server_configured.side_effect = [False, False, True]
+    with pytest.raises(ObserverSetupReached):
+        startup.deploy_app()
+    startup.kubectl.core_v1_api.patch_namespaced_service.assert_called_once_with(
+        "metrics-server",
+        "kube-system",
+        [{"op": "replace", "path": "/spec/selector", "value": {"k8s-app": "metrics-server"}}],
+        _request_timeout=10,
+    )
+    assert startup._metrics_server_configured.call_count == 3
+    conductor_module.time.sleep.assert_called_once_with(2)
+
+
+@pytest.mark.parametrize("svelte", [False, True])
+def test_startup_repairs_ndm_scheduling_only_in_full(startup, monkeypatch, svelte):
+    monkeypatch.setattr(conductor_module, "is_svelte", lambda: svelte)
+    startup._openebs_ready.side_effect = [False, False, True]
+    with pytest.raises(ObserverSetupReached):
+        startup.deploy_app()
+    patch = startup.kubectl.apps_v1_api.patch_namespaced_daemon_set
+    if svelte:
+        patch.assert_not_called()
+        startup._trim_openebs_ndm.assert_called_once()
+        startup._ensure_openebs_device_storageclass.assert_not_called()
+    else:
+        patch.assert_called_once_with(
+            "openebs-ndm",
+            "openebs",
+            [{"op": "add", "path": "/spec/template/spec/nodeSelector", "value": {}}],
+            _request_timeout=10,
+        )
+        startup._ensure_openebs_device_storageclass.assert_called_once()
+    assert startup._openebs_ready.call_count == 3
+
+
+def test_healthy_infrastructure_is_not_patched(startup):
+    with pytest.raises(ObserverSetupReached):
+        startup.deploy_app()
+    startup.kubectl.core_v1_api.patch_namespaced_service.assert_not_called()
+    startup.kubectl.apps_v1_api.patch_namespaced_daemon_set.assert_not_called()
+    assert startup._metrics_server_configured.call_count == 2
+    assert startup._openebs_ready.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "check,name", [("_metrics_server_configured", "metrics-server"), ("_openebs_ready", "OpenEBS")]
+)
+def test_failed_repair_stops_before_observers_and_application(startup, monkeypatch, check, name):
+    getattr(startup, check).return_value = False
+    monkeypatch.setattr(conductor_module.time, "monotonic", MagicMock(side_effect=[0, 180]))
+    # An earlier healthy component can complete its own wait immediately.
+    if name == "OpenEBS":
+        conductor_module.time.monotonic.side_effect = [0, 0, 180]
+    with pytest.raises(RuntimeError, match=f"{name} did not become healthy within 180s"):
+        startup.deploy_app()
+    startup.prometheus.deploy.assert_not_called()
+    startup._ensure_openebs_device_storageclass.assert_not_called()
+
+
+def test_repair_api_errors_stop_setup(startup):
+    startup._metrics_server_configured.return_value = False
+    startup.kubectl.core_v1_api.patch_namespaced_service.side_effect = ApiException(status=403)
+    with pytest.raises(ApiException):
+        startup.deploy_app()
+    startup.prometheus.deploy.assert_not_called()
 
 
 def test_reconciliation_preserves_only_exact_infrastructure_identities():


### PR DESCRIPTION
This PR fixes some issues in infrastructure setup, reuse, and cleanup.

Previously, switching between `full` and `svelte` could leave Prometheus on the previous profile. Prometheus now checks its installed configuration before reuse and redeploys when the profile differs. Svelte also removes `openebs-device` when it is absent from the original cluster baseline. Results and startup logs now record the selected profile.

Startup now checks the metrics API before reusing metrics-server. Full mode also requires a complete, nonempty OpenEBS NDM rollout. Cleanup preserves infrastructure by exact resource type and name instead of matching name fragments.

Helm now reads local dependency entries correctly and stops installation when a dependency update fails. Complete local charts avoid unnecessary dependency downloads.